### PR TITLE
In order to resolve NDEX-405, we need to make sure that all projects use

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,31 @@
 			<version>2.3.1</version>
 		</dependency>
 -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.5.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.5.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.5.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <version>2.5.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-base</artifactId>
+            <version>2.5.2</version>
+        </dependency>
 
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>


### PR DESCRIPTION
the same version of Jackson library (2.5.2).  So we explicitly add to
the pom file the depenedency of ndexbio-rest from 2.5.2.  Before that,
ndexbio-rest used release 2.4.1.