### PR TITLE
Modified the pom file to generate ndexbio-rest libraries, pack them into

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,43 @@
                 <artifactId>jetty-maven-plugin</artifactId>
                 <version>9.2.5.v20141112</version>
             </plugin>
-    
+              
+            <!-- the "maven-war-plugin" below generates the "ndexbio-rest-{project.artifactId}-${project.version}.jar" 
+                 in the ~/git/ndex-rest/target/ndexbio-rest/WEB-INF/lib direcotry.  This jar will be used by 
+                 JUnit tests in ndex-java-client project.
+              -->  
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-war-plugin</artifactId>
+               <version>2.6</version>
+               <configuration>
+                      <archiveClasses>true</archiveClasses>
+               </configuration>
+           </plugin>
+           
+              <!-- the "maven-install-plugin" copies the  "ndexbio-rest-{project.artifactId}-${project.version}.jar" file from
+                   ~/git/ndex-rest/target/ndexbio-rest/WEB-INF/lib to ~/.m2/repository/org/ndexbio/ndexbio-rest/{project.artifactId}-${project.version}. 
+                -->          
+           <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-install-plugin</artifactId>
+               <executions>
+                   <execution>
+                       <phase>install</phase>
+                       <goals>
+                           <goal>install-file</goal>
+                       </goals>
+                       <configuration>
+                           <packaging>jar</packaging>
+                           <artifactId>${project.artifactId}</artifactId>
+                           <groupId>${project.groupId}</groupId>
+                           <version>${project.version}</version>
+                           <file>${project.build.directory}/ndexbio-rest/WEB-INF/lib/${project.artifactId}-${project.version}.jar</file>
+                       </configuration>
+                   </execution>
+               </executions>
+           </plugin>
+
 		</plugins>
 	</build>
 	<properties>


### PR DESCRIPTION
jar file (ndexbio-rest-<version number>-<SNAPSHOT>.jar), and install it
to the local maven repository.  This jar file will be used by JUnit
tests found in ndex-java-client.  In other words, this is how we will
test ndexbio-rest APIs.
Thus, the pom file of ndexbio-rest now generates both WAR and JAR files.