### PR TITLE
Fix UD-2198. cx metadata was not updated properly when calling

### DIFF
--- a/src/main/java/org/ndexbio/rest/services/NetworkServiceV2.java
+++ b/src/main/java/org/ndexbio/rest/services/NetworkServiceV2.java
@@ -1114,9 +1114,10 @@ public class NetworkServiceV2 extends NdexService {
 			MetaDataElement elmt = metadata.getMetaDataElement(NetworkAttributesElement.ASPECT_NAME);
 			if ( elmt == null) {
 				elmt = new MetaDataElement(NetworkAttributesElement.ASPECT_NAME, "1.0");
+				metadata.add(elmt);
 			}
 			elmt.setElementCount(Long.valueOf(attrs.size()));
-			
+						
 			if ( isSingleNetwork  && ! cx2metadata.stream().anyMatch(
 					(CxMetadata n) -> n.getName().equals(CxNetworkAttribute.ASPECT_NAME) )) {
 			


### PR DESCRIPTION
updateNetworkSummary on a network that has no network attributes.