### PR TITLE
Fix UD-3073. Remove ObjectNotFoundException from UserDAO.updateUser

### DIFF
--- a/src/main/java/org/ndexbio/common/models/dao/postgresql/UserDAO.java
+++ b/src/main/java/org/ndexbio/common/models/dao/postgresql/UserDAO.java
@@ -545,7 +545,7 @@ public class UserDAO extends NdexDBDAO {
 	 **************************************************************************/
 	public User updateUser(User updatedUser, UUID id)
 			throws IllegalArgumentException, NdexException,
-			ObjectNotFoundException, SQLException, JsonProcessingException {
+			 SQLException, JsonProcessingException {
 
 		Preconditions.checkArgument(id != null, "A user id is required");
 		Preconditions.checkArgument(updatedUser != null,

--- a/src/main/java/org/ndexbio/rest/services/UserServiceV2.java
+++ b/src/main/java/org/ndexbio/rest/services/UserServiceV2.java
@@ -563,9 +563,13 @@ public class UserServiceV2 extends NdexService {
 						throw new NdexException("User with email address " + newEmail + " already exists.");
 					}
 					//check if there are any account using the new email address
-					u = dao.getUserByAccountName(newEmail, false, false);
-					if (u != null && !u.getExternalId().equals(user.getExternalId())) {
-						throw new NdexException("User with account name " + newEmail + " already exists.");
+					try { 
+						u = dao.getUserByAccountName(newEmail, false, false);					
+					    if (u != null && !u.getExternalId().equals(user.getExternalId())) {
+						   throw new NdexException("User with account name " + newEmail + " already exists.");
+					     }
+					} catch (ObjectNotFoundException e) {   
+						// do nothing. It is expected that the account name is not found.
 					}
 				}					
 				mgr.updateUser(userId, user.getUserName(), user.getFirstName(), user.getLastName(), user.getDisplayName(), user.getDescription());


### PR DESCRIPTION
function because it is not thrown. Modified updateUser function in UserServiceV2 to catch the ObjectNotFound when check if the new email is used as a user name by other users.