### PR TITLE
Fix WWW-Authenticate header and createUser response for v2 API

### DIFF
--- a/src/main/java/org/ndexbio/rest/exceptions/mappers/NdexExceptionMapper.java
+++ b/src/main/java/org/ndexbio/rest/exceptions/mappers/NdexExceptionMapper.java
@@ -54,7 +54,7 @@ public class NdexExceptionMapper implements ExceptionMapper<NdexException>
         return Response
             .status(Status.INTERNAL_SERVER_ERROR)
             .entity(exception.getNdexExceptionInJason())
-            .header("WWW-Authenticate", "Basic")
+            //.header("WWW-Authenticate", "Basic")
             .type("application/json")
             .build();
     }

--- a/src/main/java/org/ndexbio/rest/exceptions/mappers/NotSupportedExceptionMapper.java
+++ b/src/main/java/org/ndexbio/rest/exceptions/mappers/NotSupportedExceptionMapper.java
@@ -57,7 +57,7 @@ public class NotSupportedExceptionMapper implements ExceptionMapper<NotSupported
         return Response
             .status(Status.UNSUPPORTED_MEDIA_TYPE)
             .entity(ne.getNdexExceptionInJason())
-            .header("WWW-Authenticate", "Basic")
+           // .header("WWW-Authenticate", "Basic")
             .type("application/json")
             .build();
     }

--- a/src/main/java/org/ndexbio/rest/exceptions/mappers/ObjectNotFoundExceptionMapper.java
+++ b/src/main/java/org/ndexbio/rest/exceptions/mappers/ObjectNotFoundExceptionMapper.java
@@ -54,7 +54,7 @@ public class ObjectNotFoundExceptionMapper implements ExceptionMapper<ObjectNotF
         return Response
             .status(Status.NOT_FOUND)
             .entity(exception.getNdexExceptionInJason())
-            .header("WWW-Authenticate", "Basic")
+            //.header("WWW-Authenticate", "Basic")
             .type("application/json")
             .build();
     }

--- a/src/main/java/org/ndexbio/rest/filters/BasicAuthenticationFilter.java
+++ b/src/main/java/org/ndexbio/rest/filters/BasicAuthenticationFilter.java
@@ -266,7 +266,7 @@ public class BasicAuthenticationFilter implements ContainerRequestFilter
         } catch (ObjectNotFoundException e0) {
             _logger.info("User: " + authInfo[0] +" not found in Ndex db." /*requestContext.getUriInfo().getPath()*/);
             String mName = method.getName();
-            if ( !mName.equals("createUser")) {
+            if ( !mName.equals("createUser") && !mName.equals("signInByIdToken")) {
             	// instantiate NdexException exception, transform it to JSON, and send it back to the client 
             	authorizationException = e0;
             }
@@ -300,8 +300,8 @@ public class BasicAuthenticationFilter implements ContainerRequestFilter
         ResponseBuilder rb = Response
                 .status(Status.UNAUTHORIZED)
                 .entity(authorizationException.getNdexExceptionInJason());
-        if (!setAuthHeaderIsFalse(requestContext))
-        	rb.header("WWW-Authenticate", "Basic");
+    /*    if (!setAuthHeaderIsFalse(requestContext) && "B".equals(authType))
+        	rb.header("WWW-Authenticate", "Basic"); */
         
         requestContext.abortWith(
            			rb.type("application/json")
@@ -312,11 +312,11 @@ public class BasicAuthenticationFilter implements ContainerRequestFilter
 		accessLogger.info("[start]\t" + buildLogString(authUser,requestContext,method, authType) + "\t[Unauthorized exception: "+ authorizationException.getMessage() + "]"  );
     }
     
-    public static boolean setAuthHeaderIsFalse(ContainerRequestContext arg0) {
+  /*  public static boolean setAuthHeaderIsFalse(ContainerRequestContext arg0) {
         UriInfo uriInfo = arg0.getUriInfo();
         MultivaluedMap<String,String> f = uriInfo.getQueryParameters();
         return f !=null && f.get("setAuthHeader") !=null && f.get("setAuthHeader").get(0).equals("false") ;
-    }
+    } */
     
     
     private String buildLogString(User authUser, ContainerRequestContext requestContext, Method method, String authorizationType ) {

--- a/src/main/java/org/ndexbio/rest/filters/NdexDefaultResponseFilter.java
+++ b/src/main/java/org/ndexbio/rest/filters/NdexDefaultResponseFilter.java
@@ -103,11 +103,12 @@ public class NdexDefaultResponseFilter implements ContainerResponseFilter //, Fi
 	    if ( methodInvoker != null) {
 	    	final Method method = methodInvoker.getMethod();
 	      
-	    	if (!method.isAnnotationPresent(AuthenticationNotRequired.class) && 
+	  /* Removing this logic because it is no a recommended header setup for REST server designed for web applications. 	
+	   * if (!method.isAnnotationPresent(AuthenticationNotRequired.class) && 
 	    		  !method.isAnnotationPresent(NdexOpenFunction.class) && 
 	    		  !BasicAuthenticationFilter.setAuthHeaderIsFalse(arg0)) {
 	           	   headers.putSingle("WWW-Authenticate", "Basic");
-	    	}
+	    	} */
 	    	
 	    	int responseCode = responseContext.getStatus();
 	    	

--- a/src/main/java/org/ndexbio/rest/services/UserServiceV2.java
+++ b/src/main/java/org/ndexbio/rest/services/UserServiceV2.java
@@ -204,6 +204,7 @@ public class UserServiceV2 extends NdexService {
 					Security.generateVerificationCode() : null;
 			
 			User user = userdao.createNewUser(newUser, verificationCode);
+			UUID newUserUUID = user.getExternalId();
 			
 			if ( verificationCode == null) {
 				try (UserIndexManager mgr = new UserIndexManager()) {
@@ -275,7 +276,10 @@ public class UserServiceV2 extends NdexService {
 			
 			String url = Configuration.getInstance().getHostURI()  + 
 		            Configuration.getInstance().getRestAPIPrefix()+"/user?username=" + URLEncoder.encode(newUser.getUserName().toLowerCase(), "UTF-8");
-			return Response.accepted().location(new URI (url)).header("Access-Control-Expose-Headers", "Location").build();
+			URI l = new URI (Configuration.getInstance().getHostURI()  + 
+			            Configuration.getInstance().getRestAPIPrefix()+"/user/"+ newUserUUID);
+
+			return Response.accepted(l).location(new URI (url)).header("Access-Control-Expose-Headers", "Location").build();
 		} 
 	}
 	


### PR DESCRIPTION
  - Remove WWW-Authenticate: Basic header from all exception mappers and response filters, as it is not appropriate for REST APIs serving web applications (causes unwanted browser login dialogs)
  - Return the new user's UUID in the createUser response body so callers
    can identify the created resource without a follow-up lookup
  - Allow signInByIdToken to proceed when user is not yet in the NDEx DB,
    consistent with existing createUser bypass logic