### PR TITLE
added user request transaction logger on mcp tool invocation request paths

### DIFF
--- a/src/main/java/org/ndexbio/rest/filters/BasicAuthenticationFilter.java
+++ b/src/main/java/org/ndexbio/rest/filters/BasicAuthenticationFilter.java
@@ -95,7 +95,7 @@ public class BasicAuthenticationFilter implements ContainerRequestFilter
 	public static final String accessLoggerName = "accesslog";
 	
     private static final Logger _logger = LoggerFactory.getLogger(BasicAuthenticationFilter.class);
-    private static final Logger accessLogger = LoggerFactory.getLogger(accessLoggerName);
+    protected static final Logger accessLogger = LoggerFactory.getLogger(accessLoggerName);
 
     //private static final ServerResponse ACCESS_DENIED = new ServerResponse("Invalid username or password.", 401, new Headers<>());
     //private static final ServerResponse ACCESS_DENIED_USER_NOT_FOUND = 

--- a/src/main/java/org/ndexbio/rest/filters/McpAuthFilter.java
+++ b/src/main/java/org/ndexbio/rest/filters/McpAuthFilter.java
@@ -1,6 +1,10 @@
 package org.ndexbio.rest.filters;
 
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Enumeration;
 
@@ -9,15 +13,21 @@ import org.ndexbio.model.object.User;
 import org.ndexbio.rest.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
+import jakarta.servlet.ReadListener;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 
@@ -36,7 +46,8 @@ import jakarta.ws.rs.core.MultivaluedHashMap;
  */
 public class McpAuthFilter extends BasicAuthenticationFilter implements Filter {
 
-    private static final Logger logger = LoggerFactory.getLogger(McpAuthFilter.class);
+    private static final Logger       logger = LoggerFactory.getLogger(McpAuthFilter.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     public McpAuthFilter() throws NdexException { super(); }
 
@@ -46,45 +57,116 @@ public class McpAuthFilter extends BasicAuthenticationFilter implements Filter {
         HttpServletRequest  httpReq  = (HttpServletRequest)  request;
         HttpServletResponse httpResp = (HttpServletResponse) response;
 
-        // Manifest is public documentation — no authentication required
-        String uri = httpReq.getRequestURI();
+        // Always upfront — same contract as BasicAuthenticationFilter.filter()
+        MDC.put("RequestsUniqueId", "tid:" + System.currentTimeMillis() + "-" + getCounter());
+
+        String uri         = httpReq.getRequestURI();
         String contextPath = httpReq.getContextPath();
-        String relPath = uri.startsWith(contextPath) ? uri.substring(contextPath.length()) : uri;
-        if ("/mcp/manifest".equals(relPath) || "/mcp/upload".equals(relPath) || "/mcp/download".equals(relPath)) {
+        String relPath     = uri.startsWith(contextPath) ? uri.substring(contextPath.length()) : uri;
+
+        // Manifest is public documentation — no authentication, no access log
+        if ("/mcp/manifest".equals(relPath)) {
             chain.doFilter(request, response);
+            return;
+        }
+
+        // Upload and download bypass — log with fixed label, but NEVER include query string
+        // (presigned upload_token / download_token are in the query and must not reach access logs)
+        if ("/mcp/upload".equals(relPath)) {
+            accessLogger.info("[start]\t" + buildMcpLogString(httpReq, relPath, null, "", "upload"));
+            chain.doFilter(request, response);
+            return;
+        }
+        if ("/mcp/download".equals(relPath)) {
+            accessLogger.info("[start]\t" + buildMcpLogString(httpReq, relPath, null, "", "download"));
+            chain.doFilter(request, response);
+            return;
+        }
+
+        // RPC paths — compute fullPath (with optional query string) for all log entries below
+        String query    = httpReq.getQueryString();
+        String fullPath = query != null ? relPath + "?" + query : relPath;
+
+        String authHeader = httpReq.getHeader("Authorization");
+        String authType   = authHeader == null ? "" : (authHeader.startsWith("Bearer ") ? "G" : "B");
+
+        if (authHeader != null) {
+            // Authenticate BEFORE buffering body so that auth failures never read the request body
+            // (avoids a DoS vector where unauthenticated callers exhaust heap with large bodies)
+            MultivaluedHashMap<String, String> headers = new MultivaluedHashMap<>();
+            Enumeration<String> names = httpReq.getHeaderNames();
+            while (names != null && names.hasMoreElements()) {
+                String name = names.nextElement();
+                // Normalize Authorization to canonical capitalization — Tomcat may lowercase header names
+                String canonicalName = "authorization".equalsIgnoreCase(name) ? "Authorization" : name;
+                headers.addAll(canonicalName, Collections.list(httpReq.getHeaders(name)));
+            }
+            User user = null;
+            try {
+                user = handleFilter(headers);
+            } catch (Exception e) {
+                String msg = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+                sendUnauthorizedResponse(httpResp, e, authHeader);
+                MDC.put("error", msg);
+                // Auth failed — body not read; tool label is empty
+                accessLogger.info("[start]\t" + buildMcpLogString(httpReq, fullPath, null, authType, "")
+                        + "\t[Unauthorized exception: " + msg + "]");
+                return;
+            }
+            // Auth succeeded — buffer body, extract tool label, pass wrapped request downstream
+            CachedBodyRequestWrapper wrapped = new CachedBodyRequestWrapper(httpReq);
+            if (user != null) wrapped.setAttribute("User", user);
+            String toolLabel = extractToolLabel(wrapped.getBody());
+            accessLogger.info("[start]\t" + buildMcpLogString(httpReq, fullPath, user, authType, toolLabel));
+            chain.doFilter(wrapped, response);
             return;
         }
 
         // Anonymous pass-through: skip handleFilter() entirely when no credentials are present.
-        // This prevents any edge-case exception from sending a spurious 401 to anonymous clients.
         // Tools enforce per-resource auth via their own user-null checks.
-        String authHeader = httpReq.getHeader("Authorization");
-        if (authHeader == null) {
-            chain.doFilter(request, response);
-            return;
-        }
+        CachedBodyRequestWrapper wrapped = new CachedBodyRequestWrapper(httpReq);
+        String toolLabel = extractToolLabel(wrapped.getBody());
+        accessLogger.info("[start]\t" + buildMcpLogString(httpReq, fullPath, null, "", toolLabel));
+        chain.doFilter(wrapped, response);
+    }
 
-        // Adapt HttpServletRequest headers to MultivaluedMap for handleFilter().
-        // parseCredentials() does case-sensitive map lookups (e.g. "Authorization"),
-        // but Tomcat may normalize header names. Use the case-insensitive Servlet API
-        // getHeader() to always populate the expected canonical key.
-        MultivaluedHashMap<String, String> headers = new MultivaluedHashMap<>();
-        Enumeration<String> names = httpReq.getHeaderNames();
-        while (names != null && names.hasMoreElements()) {
-            String name = names.nextElement();
-            // Normalize Authorization to canonical capitalization — Tomcat may lowercase header names
-            String canonicalName = "authorization".equalsIgnoreCase(name) ? "Authorization" : name;
-            headers.addAll(canonicalName, Collections.list(httpReq.getHeaders(name)));
-        }
-
+    /**
+     * Extracts a human-readable label for the JSON-RPC call from the buffered body.
+     * For {@code tools/call} requests returns {@code params.name} (e.g. {@code search_network}).
+     * For other methods returns the method name itself (e.g. {@code tools/list}).
+     * Returns {@code ""} on any parse failure or missing fields.
+     */
+    private static String extractToolLabel(byte[] body) {
+        if (body == null || body.length == 0) return "";
         try {
-            User user = handleFilter(headers);  // from BasicAuthenticationFilter; throws Exception broadly
-            if (user != null) httpReq.setAttribute("User", user);
+            JsonNode node   = MAPPER.readTree(body);
+            String   method = node.path("method").asText(null);
+            if ("tools/call".equals(method)) {
+                String name = node.path("params").path("name").asText(null);
+                return name != null ? name : "tools/call";
+            }
+            return method != null ? method : "";
         } catch (Exception e) {
-            sendUnauthorizedResponse(httpResp, e, authHeader);
-            return;
+            return "";
         }
-        chain.doFilter(request, response);
+    }
+
+    /**
+     * Builds the access-log line fragment (everything after "[start]\t").
+     * {@code fullPath} is pre-computed by the caller; upload/download callers pass {@code relPath}
+     * directly to avoid logging presigned query-string tokens.
+     */
+    private String buildMcpLogString(HttpServletRequest req, String fullPath,
+                                     User user, String authType, String toolLabel) {
+        String forwarded = req.getHeader("X-FORWARDED-FOR");
+        String clientIPs = forwarded != null ? forwarded : req.getRemoteAddr();
+        String userAgent = req.getHeader("User-Agent");
+        String ndexApp   = req.getHeader("NDEx-application");
+        if (userAgent == null) userAgent = "";
+        if (ndexApp != null)   userAgent += " " + ndexApp;
+        String userPart  = user == null ? "" : (authType + ":" + user.getUserName());
+        return "[" + req.getMethod() + "]\t[" + userPart + "]\t[" + clientIPs
+                + "]\t[" + userAgent + "]\t[" + toolLabel + "]\t[" + fullPath + "]\t{}";
     }
 
     private void sendUnauthorizedResponse(HttpServletResponse resp, Exception cause, String authHeader)
@@ -106,6 +188,40 @@ public class McpAuthFilter extends BasicAuthenticationFilter implements Filter {
         resp.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         resp.setContentType("application/json;charset=UTF-8");
         resp.getWriter().write("{\"error\":\"Unauthorized\",\"message\":\"" + cause.getMessage() + "\"}");
+    }
+
+    /**
+     * Wraps an {@link HttpServletRequest} and caches the body bytes so that
+     * {@link #getInputStream()} and {@link #getReader()} can be called multiple times.
+     * Required because the MCP SDK also reads the body via {@code getInputStream()} downstream.
+     */
+    private static final class CachedBodyRequestWrapper extends HttpServletRequestWrapper {
+        private final byte[] body;
+
+        CachedBodyRequestWrapper(HttpServletRequest req) throws IOException {
+            super(req);
+            this.body = req.getInputStream().readAllBytes();
+        }
+
+        @Override
+        public ServletInputStream getInputStream() {
+            ByteArrayInputStream bais = new ByteArrayInputStream(body);
+            return new ServletInputStream() {
+                public boolean isFinished()                           { return bais.available() == 0; }
+                public boolean isReady()                             { return true; }
+                // Body is already fully buffered; no-op is safe for non-blocking async reads
+                public void    setReadListener(ReadListener listener) { /* no-op */ }
+                public int     read()                                { return bais.read(); }
+            };
+        }
+
+        @Override
+        public BufferedReader getReader() {
+            return new BufferedReader(new InputStreamReader(
+                    new ByteArrayInputStream(body), StandardCharsets.UTF_8));
+        }
+
+        byte[] getBody() { return body; }
     }
 
 }

--- a/src/main/java/org/ndexbio/rest/filters/McpAuthFilter.java
+++ b/src/main/java/org/ndexbio/rest/filters/McpAuthFilter.java
@@ -117,7 +117,8 @@ public class McpAuthFilter extends BasicAuthenticationFilter implements Filter {
             CachedBodyRequestWrapper wrapped = new CachedBodyRequestWrapper(httpReq);
             if (user != null) wrapped.setAttribute("User", user);
             String toolLabel = extractToolLabel(wrapped.getBody());
-            accessLogger.info("[start]\t" + buildMcpLogString(httpReq, fullPath, user, authType, toolLabel));
+            if (!toolLabel.isEmpty())
+                accessLogger.info("[start]\t" + buildMcpLogString(httpReq, fullPath, user, authType, toolLabel));
             chain.doFilter(wrapped, response);
             return;
         }
@@ -126,7 +127,8 @@ public class McpAuthFilter extends BasicAuthenticationFilter implements Filter {
         // Tools enforce per-resource auth via their own user-null checks.
         CachedBodyRequestWrapper wrapped = new CachedBodyRequestWrapper(httpReq);
         String toolLabel = extractToolLabel(wrapped.getBody());
-        accessLogger.info("[start]\t" + buildMcpLogString(httpReq, fullPath, null, "", toolLabel));
+        if (!toolLabel.isEmpty())
+            accessLogger.info("[start]\t" + buildMcpLogString(httpReq, fullPath, null, "", toolLabel));
         chain.doFilter(wrapped, response);
     }
 

--- a/src/test/java/org/ndexbio/rest/filters/TestMcpAuthFilter.java
+++ b/src/test/java/org/ndexbio/rest/filters/TestMcpAuthFilter.java
@@ -101,6 +101,12 @@ class TestMcpAuthFilter {
             .andReturn(new MockServletInputStream(TOOL_CALL_BODY)).once();
     }
 
+    /** Covers the getInputStream() call when the filter buffers an empty body. */
+    private static void expectEmptyBodyRead(HttpServletRequest req) throws IOException {
+        expect(req.getInputStream())
+            .andReturn(new MockServletInputStream(new byte[0])).once();
+    }
+
     // ── tests ────────────────────────────────────────────────────────────────
 
     @Test
@@ -283,5 +289,53 @@ class TestMcpAuthFilter {
         replay(req, resp, chain, writer);
         filter.doFilter(req, resp, chain);
         verify(req, resp, chain, writer);
+    }
+
+    @Test
+    void doFilter_anonymous_emptyBody_suppressesLog() throws Exception {
+        TestableMcpFilter filter = new TestableMcpFilter(null, null);
+
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        FilterChain chain = mock(FilterChain.class);
+
+        expect(req.getRequestURI()).andReturn("/mcp/tool-call").once();
+        expect(req.getContextPath()).andReturn("").once();
+        expect(req.getHeader("Authorization")).andReturn(null).once();
+        expect(req.getQueryString()).andReturn(null).once();
+        expectEmptyBodyRead(req);
+        // toolLabel is "" — accessLogger must NOT be called; no expectLogCalls here
+        chain.doFilter(anyObject(), eq(resp));
+        expectLastCall().once();
+
+        replay(req, resp, chain);
+        filter.doFilter(req, resp, chain);
+        verify(req, resp, chain);
+    }
+
+    @Test
+    void doFilter_validUser_emptyBody_suppressesLog() throws Exception {
+        User mockUser = new User();
+        TestableMcpFilter filter = new TestableMcpFilter(mockUser, null);
+
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        FilterChain chain = mock(FilterChain.class);
+
+        expect(req.getRequestURI()).andReturn("/mcp/tool-call").once();
+        expect(req.getContextPath()).andReturn("").once();
+        expect(req.getHeader("Authorization")).andReturn("Basic dXNlcjpwYXNz").once();
+        expect(req.getHeaderNames()).andReturn(java.util.Collections.emptyEnumeration()).once();
+        expect(req.getQueryString()).andReturn(null).once();
+        req.setAttribute("User", mockUser);
+        expectLastCall().once();
+        expectEmptyBodyRead(req);
+        // toolLabel is "" — accessLogger must NOT be called; no expectLogCalls here
+        chain.doFilter(anyObject(), eq(resp));
+        expectLastCall().once();
+
+        replay(req, resp, chain);
+        filter.doFilter(req, resp, chain);
+        verify(req, resp, chain);
     }
 }

--- a/src/test/java/org/ndexbio/rest/filters/TestMcpAuthFilter.java
+++ b/src/test/java/org/ndexbio/rest/filters/TestMcpAuthFilter.java
@@ -1,9 +1,13 @@
 package org.ndexbio.rest.filters;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 
 import jakarta.servlet.FilterChain;
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.ws.rs.core.MultivaluedMap;
@@ -44,7 +48,7 @@ class TestMcpAuthFilter {
         Configuration.setInstance(savedInstance);
     }
 
-    // ── inner stub ──────────────────────────────────────────────────────────
+    // ── inner stubs ──────────────────────────────────────────────────────────
 
     private static class TestableMcpFilter extends McpAuthFilter {
         private final User userToReturn;
@@ -65,6 +69,38 @@ class TestMcpAuthFilter {
         }
     }
 
+    private static final byte[] TOOL_CALL_BODY =
+        "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"test_tool\"}}"
+            .getBytes(StandardCharsets.UTF_8);
+
+    private static class MockServletInputStream extends ServletInputStream {
+        private final ByteArrayInputStream stream;
+        MockServletInputStream(byte[] bytes) { this.stream = new ByteArrayInputStream(bytes); }
+        public boolean isFinished()                          { return stream.available() == 0; }
+        public boolean isReady()                             { return true; }
+        public void    setReadListener(ReadListener listener) { /* no-op */ }
+        public int     read() throws IOException             { return stream.read(); }
+    }
+
+    // ── helpers: mock the calls made inside doFilter / buildMcpLogString ─────
+
+    /** Covers the 5 calls made by buildMcpLogString. */
+    private static void expectLogCalls(HttpServletRequest req) {
+        expect(req.getHeader("X-FORWARDED-FOR")).andReturn(null).once();
+        expect(req.getRemoteAddr()).andReturn("127.0.0.1").once();
+        expect(req.getHeader("User-Agent")).andReturn("").once();
+        expect(req.getHeader("NDEx-application")).andReturn(null).once();
+        expect(req.getMethod()).andReturn("GET").once();
+        // getQueryString() is no longer called inside buildMcpLogString;
+        // RPC-path tests add it explicitly via expect(req.getQueryString())
+    }
+
+    /** Covers the getInputStream() call when the filter buffers the body. */
+    private static void expectBodyRead(HttpServletRequest req) throws IOException {
+        expect(req.getInputStream())
+            .andReturn(new MockServletInputStream(TOOL_CALL_BODY)).once();
+    }
+
     // ── tests ────────────────────────────────────────────────────────────────
 
     @Test
@@ -77,6 +113,8 @@ class TestMcpAuthFilter {
 
         expect(req.getRequestURI()).andReturn("/mcp/download").once();
         expect(req.getContextPath()).andReturn("").once();
+        expectLogCalls(req);
+        // original request passed — no body buffering for bypass paths
         chain.doFilter(req, resp);
         expectLastCall().once();
 
@@ -95,6 +133,8 @@ class TestMcpAuthFilter {
 
         expect(req.getRequestURI()).andReturn("/mcp/upload").once();
         expect(req.getContextPath()).andReturn("").once();
+        expectLogCalls(req);
+        // original request passed — no body buffering for bypass paths
         chain.doFilter(req, resp);
         expectLastCall().once();
         // response must NOT receive a 401 — auth is bypassed for /mcp/upload
@@ -115,7 +155,11 @@ class TestMcpAuthFilter {
         expect(req.getRequestURI()).andReturn("/mcp/tool-call").once();
         expect(req.getContextPath()).andReturn("").once();
         expect(req.getHeader("Authorization")).andReturn(null).once();
-        chain.doFilter(req, resp);
+        expect(req.getQueryString()).andReturn(null).once();
+        expectBodyRead(req);
+        expectLogCalls(req);
+        // wrapped request passed downstream — use anyObject() since wrapper is created internally
+        chain.doFilter(anyObject(), eq(resp));
         expectLastCall().once();
 
         replay(req, resp, chain);
@@ -136,9 +180,14 @@ class TestMcpAuthFilter {
         expect(req.getContextPath()).andReturn("").once();
         expect(req.getHeader("Authorization")).andReturn("Basic dXNlcjpwYXNz").once();
         expect(req.getHeaderNames()).andReturn(java.util.Collections.emptyEnumeration()).once();
+        expect(req.getQueryString()).andReturn(null).once();
+        // setAttribute delegates through the wrapper to the underlying request mock
         req.setAttribute("User", mockUser);
         expectLastCall().once();
-        chain.doFilter(req, resp);
+        expectBodyRead(req);
+        expectLogCalls(req);
+        // wrapped request passed downstream — use anyObject() since wrapper is created internally
+        chain.doFilter(anyObject(), eq(resp));
         expectLastCall().once();
 
         replay(req, resp, chain);
@@ -159,6 +208,8 @@ class TestMcpAuthFilter {
         expect(req.getContextPath()).andReturn("").once();
         expect(req.getHeaderNames()).andReturn(java.util.Collections.emptyEnumeration()).once();
         expect(req.getHeader("Authorization")).andReturn("Basic dXNlcjpwYXNz").once();
+        // auth-first: body is NOT buffered when auth fails — only getQueryString() is called
+        expect(req.getQueryString()).andReturn(null).once();
         resp.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         expectLastCall().once();
         resp.setContentType("application/json;charset=UTF-8");
@@ -166,6 +217,7 @@ class TestMcpAuthFilter {
         expect(resp.getWriter()).andReturn(writer).once();
         writer.write(anyString());
         expectLastCall().once();
+        expectLogCalls(req);
         // chain must NOT be called
 
         replay(req, resp, chain, writer);
@@ -185,10 +237,13 @@ class TestMcpAuthFilter {
         expect(req.getRequestURI()).andReturn("/mcp/tool-call").once();
         expect(req.getContextPath()).andReturn("").once();
         expect(req.getHeader("Authorization")).andReturn(null).once();
+        expect(req.getQueryString()).andReturn(null).once();
+        expectBodyRead(req);
+        expectLogCalls(req);
         // chain MUST be called — anonymous pass-through guaranteed
-        chain.doFilter(req, resp);
-        expectLastCall().once();
         // resp must NOT receive setStatus — no 401 generated for missing auth header
+        chain.doFilter(anyObject(), eq(resp));
+        expectLastCall().once();
 
         replay(req, resp, chain);
         filter.doFilter(req, resp, chain);
@@ -209,6 +264,8 @@ class TestMcpAuthFilter {
         expect(req.getContextPath()).andReturn("").once();
         expect(req.getHeaderNames()).andReturn(java.util.Collections.emptyEnumeration()).once();
         expect(req.getHeader("Authorization")).andReturn("Bearer old.token").once();
+        // auth-first: body is NOT buffered when auth fails — only getQueryString() is called
+        expect(req.getQueryString()).andReturn(null).once();
         resp.setHeader(eq("WWW-Authenticate"), and(
                 contains("Bearer resource_metadata="),
                 and(contains("/.well-known/oauth-protected-resource/mcp"),
@@ -221,6 +278,7 @@ class TestMcpAuthFilter {
         expect(resp.getWriter()).andReturn(writer).once();
         writer.write(anyString());
         expectLastCall().once();
+        expectLogCalls(req);
 
         replay(req, resp, chain, writer);
         filter.doFilter(req, resp, chain);


### PR DESCRIPTION
Added `accessLogger` transactional prints  of `[start]`  to mcp tool invocations to follow same pattern as API endpoint logging 

```
[2026-04-28 22:45:14,033]	[INFO]	[]	[tid:1777416314021-14]	[]	[start]	[POST]	[B:ndex-test]	[169.228.39.199]	[copilot/1.0.37 (darwin v24.11.1) term/Apple_Terminal]	[get_connection_status]	[/mcp]	{}	[McpAuthFilter.doFilter]
[2026-04-28 22:45:27,629]	[INFO]	[]	[tid:1777416327622-15]	[]	[start]	[POST]	[B:ndex-test]	[169.228.39.199]	[copilot/1.0.37 (darwin v24.11.1) term/Apple_Terminal]	[request_network_upload]	[/mcp]	{}	[McpAuthFilter.doFilter]
[2026-04-28 22:45:54,504]	[INFO]	[]	[tid:1777416354503-17]	[]	[start]	[POST]	[]	[169.228.39.199]	[curl/8.7.1]	[upload]	[/mcp/upload]	{}	[McpAuthFilter.doFilter]
[2026-04-28 22:46:19,720]	[INFO]	[]	[tid:1777416379704-19]	[]	[start]	[POST]	[B:ndex-test]	[169.228.39.199]	[copilot/1.0.37 (darwin v24.11.1) term/Apple_Terminal]	[get_user_networks]	[/mcp]	{}	[McpAuthFilter.doFilter]
```

Related to #NDEX-898