### PR TITLE
added multi-arch docker builds for amd and arm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,13 +78,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU (for arm64 cross-compilation)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: latest
+          name: ndex-builder
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Push latest image
+      - name: Build multi-platform image and push latest manifest
         env:
           DOCKER_REPO: ndexbio/ndex-rest
           DOCKER_TAG: latest
@@ -98,6 +109,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU (for arm64 cross-compilation)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: latest
+          name: ndex-builder
+
       - name: Extract Docker tag
         run: echo "DOCKER_TAG=${GITHUB_REF#refs/tags/docker}" >> $GITHUB_ENV
 
@@ -107,7 +129,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Push image
+      - name: Build multi-platform image and push manifest
         env:
           DOCKER_REPO: ndexbio/ndex-rest
         run: make push-docker

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean clean-test clean-pyc clean-build docs mcp-manifest help docker docker-dev push-docker integration-test integration-test-mcp build_claude_mcpb
+.PHONY: clean clean-test clean-pyc clean-build docs mcp-manifest help docker docker-dev docker-multi-platform buildx-setup push-docker integration-test integration-test-mcp build_claude_mcpb
 .DEFAULT_GOAL := help
 define BROWSER_PYSCRIPT
 import os, webbrowser, sys
@@ -79,21 +79,48 @@ DOCKER_BUILD_ARGS = \
 # Optional layer-cache flags — override from CI to enable e.g. --cache-from type=gha --cache-to type=gha,mode=max
 DOCKER_CACHE_ARGS ?=
 
+# Local build-cache dir for docker-multi-platform (persistent across rebuilds)
+MULTIPLATFORM_CACHE_DIR ?= /tmp/ndex-buildcache
+# Output path for the multi-platform OCI tar
+MULTIPLATFORM_OCI_TAR   ?= /tmp/ndex-multiarch.tar
+
 docker-base: ## build the shared runtime-base image (docker/Dockerfile)
-	docker buildx build --load --platform linux/amd64 -f docker/Dockerfile --target runtime-base $(DOCKER_BUILD_ARGS) $(DOCKER_CACHE_ARGS) -t ndex-runtime-base .
+	docker buildx build --load -f docker/Dockerfile --target runtime-base $(DOCKER_BUILD_ARGS) $(DOCKER_CACHE_ARGS) -t ndex-runtime-base .
 
 docker: docker-base ## build the deploy image (docker/Dockerfile)
-	docker buildx build --load --platform linux/amd64 -f docker/Dockerfile --target deploy \
+	docker buildx build --load -f docker/Dockerfile --target deploy \
 	    $(DOCKER_BUILD_ARGS) $(DOCKER_CACHE_ARGS) -t ndexbio/ndex-rest .
 
 docker-dev: docker-base ## build the devcontainer image (.devcontainer/Dockerfile)
-	docker build --platform linux/amd64 -f .devcontainer/Dockerfile -t ndexbio/ndex-rest-dev .
+	docker build -f .devcontainer/Dockerfile -t ndexbio/ndex-rest-dev .
 
-push-docker: docker ## push deploy image to registry (requires DOCKER_REPO and DOCKER_TAG)
+# ── Multi-platform build targets ─────────────────────────────────────────────
+# Prerequisite: QEMU must be installed once per host:
+#   docker run --privileged --rm tonistiigi/binfmt --install all
+
+buildx-setup: ## create the multi-platform builder (docker-container driver) — idempotent
+	docker buildx inspect ndex-builder > /dev/null 2>&1 || \
+	    docker buildx create --name ndex-builder --driver docker-container --bootstrap
+
+docker-multi-platform: buildx-setup ## build linux/amd64 + linux/arm64 OCI tar locally (no push) → $(MULTIPLATFORM_OCI_TAR)
+	docker buildx build --builder ndex-builder \
+	    --platform linux/amd64,linux/arm64 \
+	    --output type=oci,dest=$(MULTIPLATFORM_OCI_TAR) \
+	    --cache-to   type=local,dest=$(MULTIPLATFORM_CACHE_DIR),mode=max \
+	    --cache-from type=local,src=$(MULTIPLATFORM_CACHE_DIR) \
+	    -f docker/Dockerfile --target deploy \
+	    $(DOCKER_BUILD_ARGS) .
+
+push-docker: docker-multi-platform ## push multi-platform manifest to registry via cached rebuild (requires DOCKER_REPO and DOCKER_TAG)
 	@[ -n "$(DOCKER_REPO)" ] || { echo "ERROR: DOCKER_REPO is not set"; exit 1; }
 	@[ -n "$(DOCKER_TAG)" ]  || { echo "ERROR: DOCKER_TAG is not set"; exit 1; }
-	docker tag ndexbio/ndex-rest $(DOCKER_REPO):$(DOCKER_TAG)
-	docker push $(DOCKER_REPO):$(DOCKER_TAG)
+	docker buildx build --builder ndex-builder \
+	    --platform linux/amd64,linux/arm64 \
+	    --push \
+	    --cache-from type=local,src=$(MULTIPLATFORM_CACHE_DIR) \
+	    -f docker/Dockerfile --target deploy \
+	    $(DOCKER_BUILD_ARGS) \
+	    -t $(DOCKER_REPO):$(DOCKER_TAG) .
 
 integration-test: ## run integration tests
 	docker/test/integration-test.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,19 +69,20 @@ COPY src/main/resources/postgresql/ /opt/ndex-install/sql/
 COPY docker/scripts/init-postgres.sh /usr/local/bin/init-postgres.sh
 RUN chmod +x /usr/local/bin/init-postgres.sh
 
-# ── Build-time defaults (/apps/<svc>/default/config/) ────────────────────────
-# Operational /apps/<svc>/config/ and /apps/<svc>/data/ start empty.
-# start.sh copies from default/config → config on first run (sentinel-guarded).
-COPY docker/apps/ndex/default/config/      /apps/ndex/default/config/
-COPY docker/apps/postgres/default/config/  /apps/postgres/default/config/
-COPY docker/apps/keycloak/default/config/  /apps/keycloak/default/config/
-COPY docker/apps/solr/default/config/      /apps/solr/default/config/
-COPY docker/apps/mailhog/default/config/   /apps/mailhog/default/config/
+# ── Build-time defaults (/opt/defaults/<svc>/config/) ───────────────────────
+# Stored under /opt/defaults/ (not /apps/) so a volume mount to /apps/ does not
+# wipe out these baked-in defaults. Operational /apps/<svc>/config/ and
+# /apps/<svc>/data/ start empty; start.sh seeds them on first run.
+COPY docker/apps/ndex/default/config/      /opt/defaults/ndex/config/
+COPY docker/apps/postgres/default/config/  /opt/defaults/postgres/config/
+COPY docker/apps/keycloak/default/config/  /opt/defaults/keycloak/config/
+COPY docker/apps/solr/default/config/      /opt/defaults/solr/config/
+COPY docker/apps/mailhog/default/config/   /opt/defaults/mailhog/config/
 
 # ── Capture KC distribution keycloak.conf as the clean default ────────────────
 # Copied verbatim — no NDEx settings. start.sh appends NDEx deployment settings
 # at container runtime. Tied to the installed KC version; rebuild to pick up changes.
-RUN cp /opt/keycloak/conf/keycloak.conf /apps/keycloak/default/config/keycloak.conf
+RUN cp /opt/keycloak/conf/keycloak.conf /opt/defaults/keycloak/config/keycloak.conf
 
 # ── Operational config and data directories (empty; populated at runtime) ─────
 RUN mkdir -p \
@@ -95,7 +96,7 @@ RUN mkdir -p \
         /apps/solr/data \
         /apps/mailhog/config \
     && chown postgres:postgres /apps/postgres/data /apps/postgres/config \
-    && chown -R solr:solr /apps/solr/data /apps/solr/config /apps/solr/default
+    && chown -R solr:solr /apps/solr/data /apps/solr/config /opt/defaults/solr
 
 # ── Per-service supervisord snippets ─────────────────────────────────────────
 COPY docker/supervisord/ /opt/ndex-supervisord/

--- a/docker/README.md
+++ b/docker/README.md
@@ -53,42 +53,24 @@ make docker KEYCLOAK_VERSION=26.2.0 SOLR_VERSION=9.7.0
 
 Available version variables (with defaults):
 
-| Variable           | Default  |
+| Variable           | Default  | 
 |--------------------|----------|
 | `KEYCLOAK_VERSION` | `26.1.0` |
 | `SOLR_VERSION`     | `9.6.1`  |
 | `POSTGRES_VERSION` | `16`     |
 | `MAILHOG_VERSION`  | `1.0.1`  |
 
----
+### Platform support
 
-## Testing
+`make docker` builds a single-platform image for the **host's native architecture** (linux/amd64 on Intel/AMD, linux/arm64 on Apple Silicon). This image is loaded directly into the local Docker daemon.
 
-An integration test script lives at `docker/test/integration-test.sh`. It builds the image, starts an ephemeral container, and validates the full API lifecycle across both v2 and v3 endpoints. Or can skip the build and running a new container and instead point the script at an already running container with `--remote-ndex-url http://<ndex_api_host:port>`:
+`make docker-multi-platform` cross builds a multi-platform manifest supporting both **linux/amd64** and **linux/arm64**. `make push-docker` will push the multi platform manifest and images at `docker.io/ndexbio/ndex-rest` isDocker automatically pulls the correct variant for your host.
 
-- User creation and Basic Auth (v2)
-- CX1 network upload via v2, summary poll until `completed:true`, CX2 retrieval via v3
-- CX2 network upload via v3, summary poll until `completed:true`, CX2 retrieval via v3
-- Solr keyword search via v2 (step 15) and v3 (step 16)
-
-The test **fails fast** — on the first failure it stops, prints the reason, how many calls passed, and how many were left unrun, then exits 1.
-
-**Fixtures required** (pre-built, committed in `docker/test/fixtures/`):
-- 3 × `.cx` files (CX1) — uploaded via `POST /v2/network`
-- 3 × `.cx2` files (CX2) — uploaded via `POST /v3/networks`
-
-### Full run (build + test)
+### Integration test
 
 ```bash
 cd docker/test
 ./integration-test.sh
-```
-
-### Skip the image build (re-use existing image)
-
-```bash
-cd docker/test
-./integration-test.sh --skip-build
 ```
 
 ### What success looks like
@@ -444,7 +426,7 @@ Remove and recreate the container. All state resets on the next boot:
 
 ```bash
 docker rm -f ndex
-docker run --platform linux/amd64 ... ndexbio/ndex-rest --ndex --postgres --keycloak --solr --mailhog
+docker run ... ndexbio/ndex-rest --ndex --postgres --keycloak --solr --mailhog
 ```
 
 ### Full reset of one service (persistent mode — bind mounts)
@@ -454,7 +436,7 @@ Delete the host-side directory for the service(s) you want to reset, then restar
 ```bash
 docker rm -f ndex
 rm -rf /host/path/solr-config /host/path/solr-data
-docker run --platform linux/amd64 -v /host/path/solr-config:/apps/solr/config -v /host/path/solr-data:/apps/solr/data ... ndexbio/ndex-rest --ndex --postgres --keycloak --solr --mailhog
+docker run -v /host/path/solr-config:/apps/solr/config -v /host/path/solr-data:/apps/solr/data ... ndexbio/ndex-rest --ndex --postgres --keycloak --solr --mailhog
 ```
 
 `start.sh` detects the absent sentinel and re-initializes only the cleared service(s) on the next boot.
@@ -465,7 +447,7 @@ docker run --platform linux/amd64 -v /host/path/solr-config:/apps/solr/config -v
 
 ```bash
 docker rm -f ndex
-docker run --platform linux/amd64 ... ndexbio/ndex-rest --ndex --postgres --keycloak --solr --mailhog
+docker run ... ndexbio/ndex-rest --ndex --postgres --keycloak --solr --mailhog
 ```
 
 **Persistent mode**: delete all bind-mounted host directories, then recreate:
@@ -477,5 +459,5 @@ rm -rf /host/path/ndex-config /host/path/ndex-data \
         /host/path/keycloak-config /host/path/keycloak-data \
         /host/path/solr-config /host/path/solr-data \
         /host/path/mailhog-config
-docker run --platform linux/amd64 -v /host/path/ndex-config:/apps/ndex/config ... ndexbio/ndex-rest --ndex --postgres --keycloak --solr --mailhog
+docker run -v /host/path/ndex-config:/apps/ndex/config ... ndexbio/ndex-rest --ndex --postgres --keycloak --solr --mailhog
 ```

--- a/docker/RUNBOOK.md
+++ b/docker/RUNBOOK.md
@@ -1,9 +1,11 @@
 # NDEX Monolithic deployment (all services in one container)
 
+The `ndexbio/ndex-rest` image is a multi-platform manifest supporting **linux/amd64** and **linux/arm64** — Docker pulls the correct variant automatically. Images built locally with `make docker` are single-platform for the host's native architecture.
+
 ## Ephemeral (data lost on container removal)
 
 ```bash
-docker run --platform linux/amd64 -d \
+docker run -d \
   --name ndex \
   -p 8080:8080 \
   -p 8085:8085 \
@@ -16,14 +18,14 @@ docker run --platform linux/amd64 -d \
 
 > **Startup feedback**: while services initialize, the container prints `NDEx Container initializing...  (Xs)` to the console every 3 seconds. The `NDEx Deploy Container Ready!` banner (with service URLs) only appears once all enabled services have reached the `RUNNING` state. Wait for that banner before hitting API endpoints.
 
-All services state is ephemeral by default since the services store data on intenral container file system, which means all service level data is gone when container is deleted. Unless bind-mounts to host directories were used, then those paths are unaffected by container removal since they reside outside of container.
+All services state is ephemeral by default since the services store data on internal container file system, which means all service level data is gone when container is deleted. Unless bind-mounts to host directories were used, then those paths are unaffected by container removal since they reside outside of container.
 
 ## Persistent (data survives container removal)
 
 Bind-mount host directories at the paths you want to persist. Mount only what you need — each path is independent:
 
 ```bash
-docker run --platform linux/amd64 -d \
+docker run -d \
   --name ndex \
   -p 8080:8080 \
   -p 8085:8085 \

--- a/docker/k8s-ndex-deployment.yml
+++ b/docker/k8s-ndex-deployment.yml
@@ -8,6 +8,10 @@
 #
 # All service state is stored under the host path /data/ndex, which is
 # mounted into the container via a 512Gi PersistentVolumeClaim.
+#
+# PVC:
+# specify a different storageClassName no PVC if cluster default for storage class
+# does not support dynamic provisioning:
 
 ---
 apiVersion: v1
@@ -15,7 +19,6 @@ kind: PersistentVolumeClaim
 metadata:
   name: ndex-pvc
 spec:
-  storageClassName: default
   accessModes:
     - ReadWriteOnce
   resources:
@@ -41,7 +44,10 @@ spec:
     spec:
       initContainers:
         - name: ndex-init
-          image: busybox:latest
+          # Use the ndex image so that the postgres and solr system users exist
+          # and chown can reference them by name rather than fragile numeric UIDs.
+          image: docker.io/ndexbio/ndex-rest
+          imagePullPolicy: Always
           command:
             - sh
             - -c
@@ -56,13 +62,16 @@ spec:
                 /apps/solr/config \
                 /apps/solr/data \
                 /apps/mailhog/config
+              chown postgres:postgres /apps/postgres/config /apps/postgres/data
+              chown -R solr:solr /apps/solr/config /apps/solr/data
           volumeMounts:
             - name: ndex-storage
               mountPath: /apps
 
       containers:
         - name: ndex
-          image: ndexbio/ndex-rest
+          image: docker.io/ndexbio/ndex-rest
+          imagePullPolicy: Always
           args:
             - --ndex
             - --postgres
@@ -70,9 +79,12 @@ spec:
             - --solr
             - --mailhog
           ports:
-            - name: http
+            - name: ndex-rest
               containerPort: 8080
               protocol: TCP
+            - name: keycloak-http
+              containerPort: 8085
+              protocol: TCP  
           volumeMounts:
             - name: ndex-storage
               mountPath: /apps
@@ -97,4 +109,21 @@ spec:
     - name: http
       port: 8080
       targetPort: 8080
+      protocol: TCP
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+  labels:
+    app: ndex
+spec:
+  type: ClusterIP
+  selector:
+    app: ndex
+  ports:
+    - name: http
+      port: 8085
+      targetPort: 8085
       protocol: TCP

--- a/docker/k8s-ndex-deployment.yml
+++ b/docker/k8s-ndex-deployment.yml
@@ -84,7 +84,14 @@ spec:
               protocol: TCP
             - name: keycloak-http
               containerPort: 8085
-              protocol: TCP  
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /v3/admin/status
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
           volumeMounts:
             - name: ndex-storage
               mountPath: /apps

--- a/docker/scripts/start.sh
+++ b/docker/scripts/start.sh
@@ -148,7 +148,7 @@ KC_EOF
 _seed_config() {
   local svc="$1"
   local config_dir="/apps/${svc}/config"
-  local default_dir="/apps/${svc}/default/config"
+  local default_dir="/opt/defaults/${svc}/config"
   if [[ ! -f "${config_dir}/.initialized" ]]; then
     echo "==> Seeding /apps/${svc}/config/ from defaults..."
     cp -r "${default_dir}/." "${config_dir}/"
@@ -367,7 +367,7 @@ if [[ "${ENABLE_NDEX}" == "true" ]]; then
     echo "==> Initializing NDEx configuration..."
 
     mkdir -p /apps/ndex/config
-    cp -r /apps/ndex/default/config/. /apps/ndex/config/
+    cp -r /opt/defaults/ndex/config/. /apps/ndex/config/
 
     if [[ -n "${NDEX_CONFIG_FILE}" ]] && _toml_has_section "${NDEX_CONFIG_FILE}" ndexDb; then
       # External PG: role and DB must already exist; verify connectivity

--- a/docker/supervisord/ndex.conf
+++ b/docker/supervisord/ndex.conf
@@ -1,7 +1,7 @@
 # ── NDEx (Tomcat) ──────────────────────────────────────────────────────────────
 [program:ndex]
 command=/usr/local/tomcat/bin/catalina.sh run
-environment=ndexConfigurationPath="/apps/ndex/config/ndex.properties",CATALINA_OPTS="-Dlogback.configurationFile=/apps/ndex/default/config/logback.xml"
+environment=ndexConfigurationPath="/apps/ndex/config/ndex.properties",CATALINA_OPTS="-Dlogback.configurationFile=/apps/ndex/config/logback.xml"
 priority=30
 autostart=true
 autorestart=true

--- a/docker/test/integration-mcp-test.sh
+++ b/docker/test/integration-mcp-test.sh
@@ -193,8 +193,8 @@ else
 
   step "Starting ephemeral container"
   docker rm -fv "${CONTAINER_NAME}" 2>/dev/null || true
-  echo "  Running: docker run --platform linux/amd64 -d --name ${CONTAINER_NAME} -p 8080:8080 ..."
-  docker run --platform linux/amd64 -d \
+  echo "  Running: docker run -d --name ${CONTAINER_NAME} -p 8080:8080 ..."
+  docker run -d \
     --name "${CONTAINER_NAME}" \
     -p 8080:8080 \
     ndexbio/ndex-rest \

--- a/docker/test/integration-test.sh
+++ b/docker/test/integration-test.sh
@@ -136,8 +136,8 @@ else
 
   step "Starting ephemeral container"
   docker rm -fv "${CONTAINER_NAME}" 2>/dev/null || true
-  echo "  Running: docker run --platform linux/amd64 -d --name ${CONTAINER_NAME} -p 8080:8080 ..."
-  docker run --platform linux/amd64 -d \
+  echo "  Running: docker run -d --name ${CONTAINER_NAME} -p 8080:8080 ..."
+  docker run -d \
     --name "${CONTAINER_NAME}" \
     -p 8080:8080 \
     ndexbio/ndex-rest \


### PR DESCRIPTION
support building a multi-arch manifest for amd64 and arm64 that is then pushed to `ndexbio/ndex-rest` on dockerhub, this way any apple silicon hosts which are arm64 will get platform correct image instead of needing to qemu to run amd64 image. 