### PR TITLE
CW-708: fix neighborhood 500 error

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update \
        supervisor gosu \
        jq openssl unzip \
        apache2-utils \
+       python3 \
     && rm -rf /var/lib/apt/lists/*
 
 # ── Keycloak ──────────────────────────────────────────────────────────────────

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,13 +18,17 @@ RUN apt-get update \
         | gpg --dearmor -o /usr/share/keyrings/postgresql-keyring.gpg \
     && echo "deb [signed-by=/usr/share/keyrings/postgresql-keyring.gpg] https://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main" \
         > /etc/apt/sources.list.d/pgdg.list \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+        | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" \
+        > /etc/apt/sources.list.d/nodesource.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
        postgresql-${POSTGRES_VERSION} postgresql-client-${POSTGRES_VERSION} \
        supervisor gosu \
        jq openssl unzip \
        apache2-utils \
-       python3 \
+       nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # ── Keycloak ──────────────────────────────────────────────────────────────────

--- a/docker/README.md
+++ b/docker/README.md
@@ -268,7 +268,7 @@ For most deployments, you will not need to touch any of these files directly —
 The `--config /path/to/config.toml` flag is a convenience option that covers what most users will ever need. Pass it at container startup alongside the service flags. `start.sh` reads the file and applies its values to the appropriate low-level service configs automatically — no manual editing of `ndex.properties`, `keycloak.conf`, or any other service file required.
 
 ```bash
-docker run ... ndexbio/ndex-rest --ndex --config /etc/my-config.toml
+docker run ndexbio/ndex-rest --ndex --config /etc/my-config.toml
 ```
 
 Mount the file read-only into the container:
@@ -426,7 +426,7 @@ Remove and recreate the container. All state resets on the next boot:
 
 ```bash
 docker rm -f ndex
-docker run ... ndexbio/ndex-rest --ndex --postgres --keycloak --solr --mailhog
+docker run ndexbio/ndex-rest --ndex --postgres --keycloak --solr --mailhog
 ```
 
 ### Full reset of one service (persistent mode — bind mounts)
@@ -447,7 +447,7 @@ docker run -v /host/path/solr-config:/apps/solr/config -v /host/path/solr-data:/
 
 ```bash
 docker rm -f ndex
-docker run ... ndexbio/ndex-rest --ndex --postgres --keycloak --solr --mailhog
+docker run ndexbio/ndex-rest --ndex --postgres --keycloak --solr --mailhog
 ```
 
 **Persistent mode**: delete all bind-mounted host directories, then recreate:
@@ -459,5 +459,5 @@ rm -rf /host/path/ndex-config /host/path/ndex-data \
         /host/path/keycloak-config /host/path/keycloak-data \
         /host/path/solr-config /host/path/solr-data \
         /host/path/mailhog-config
-docker run -v /host/path/ndex-config:/apps/ndex/config ... ndexbio/ndex-rest --ndex --postgres --keycloak --solr --mailhog
+docker run -v /host/path/ndex-config:/apps/ndex/config ndexbio/ndex-rest --ndex --postgres --keycloak --solr --mailhog
 ```

--- a/docker/apps/keycloak/default/config/ndex-realm.json
+++ b/docker/apps/keycloak/default/config/ndex-realm.json
@@ -32,10 +32,12 @@
       "directAccessGrantsEnabled": true,
       "redirectUris": [
         "http://localhost:8080/*",
+        "http://localhost:3001/*",
         "http://localhost/*"
       ],
       "webOrigins": [
         "http://localhost:8080",
+        "http://localhost:3001",
         "http://localhost"
       ]
     }

--- a/docker/test/integration-test.sh
+++ b/docker/test/integration-test.sh
@@ -543,23 +543,17 @@ if [[ -z "${REMOTE_NDEX_URL}" ]]; then
   docker exec "${CONTAINER_NAME}" bash -c \
     "echo 'NeighborhoodQueryURL=http://localhost:8284/query/v1/network/' >> /apps/ndex/config/ndex.properties"
 
-  # Python stub: drains the request body before responding (avoids RST),
+  # Node.js stub: drains the request body before responding (avoids RST),
   # handles multiple connections without re-arming, no race between v2 and v3 calls.
-  docker exec -d "${CONTAINER_NAME}" python3 -c "
-import http.server, socketserver
-class H(http.server.BaseHTTPRequestHandler):
-    def do_POST(self):
-        length = int(self.headers.get('Content-Length', 0))
-        self.rfile.read(length)
-        self.send_response(200)
-        self.send_header('Content-Type', 'application/json')
-        self.send_header('Content-Length', '2')
-        self.end_headers()
-        self.wfile.write(b'[]')
-    def log_message(self, *a): pass
-socketserver.TCPServer.allow_reuse_address = True
-with socketserver.TCPServer(('', 8284), H) as s:
-    s.serve_forever()
+  docker exec -d "${CONTAINER_NAME}" node -e "
+const http = require('http');
+http.createServer((req, res) => {
+  req.resume();
+  req.on('end', () => {
+    res.writeHead(200, {'Content-Type': 'application/json', 'Content-Length': '2'});
+    res.end('[]');
+  });
+}).listen(8284);
 "
 
   docker exec "${CONTAINER_NAME}" supervisorctl -c /tmp/supervisord.conf restart ndex

--- a/docker/test/integration-test.sh
+++ b/docker/test/integration-test.sh
@@ -11,9 +11,9 @@
 #   user creation → v2 CX1 upload (2 public + 1 private) → v2 summary poll →
 #   v3 CX2 retrieve → v3 CX2 upload (2 public + 1 private) → v3 summary poll →
 #   v3 CX2 retrieve → private network access control → public anonymous access →
-#   v2 Solr search → v3 Solr search
+#   v2 Solr search → v3 Solr search → v2 neighborhood query (SSL context)
 #
-# Exits 0 if all 24 API calls pass, exits 1 on the first failure.
+# Exits 0 if all 28 API calls pass, exits 1 on the first failure.
 # Deps: docker, make, curl (no python, no jq, no uv)
 
 set -euo pipefail
@@ -31,7 +31,7 @@ TEST_USER2="ndextest2"
 TEST_PASS2="NDExTest2!"
 TEST_EMAIL2="ndextest2@ndex-integration.local"
 
-TOTAL_API_CALLS=26
+TOTAL_API_CALLS=28
 PASSED=0
 CALL_NUM=0
 STEP_NUM=0
@@ -533,6 +533,86 @@ while true; do
   echo "  Waiting for public-nfs Solr index... (${ELAPSED}s)"
 done
 api_pass "POST /v3/search/files → 200 OK, BindingDB UUID found in results (CX2 public-nfs confirmed)"
+
+# ── STEP: Neighborhood query — SSL context fix (local container only) ─────────
+
+if [[ -z "${REMOTE_NDEX_URL}" ]]; then
+  step "Verifying neighborhood query endpoint initializes SSL context correctly"
+
+  echo "  Injecting NeighborhoodQueryURL into ndex.properties and starting mock stub..."
+  docker exec "${CONTAINER_NAME}" bash -c \
+    "echo 'NeighborhoodQueryURL=http://localhost:8284/query/v1/network/' >> /apps/ndex/config/ndex.properties"
+
+  # Python stub: drains the request body before responding (avoids RST),
+  # handles multiple connections without re-arming, no race between v2 and v3 calls.
+  docker exec -d "${CONTAINER_NAME}" python3 -c "
+import http.server, socketserver
+class H(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get('Content-Length', 0))
+        self.rfile.read(length)
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', '2')
+        self.end_headers()
+        self.wfile.write(b'[]')
+    def log_message(self, *a): pass
+socketserver.TCPServer.allow_reuse_address = True
+with socketserver.TCPServer(('', 8284), H) as s:
+    s.serve_forever()
+"
+
+  docker exec "${CONTAINER_NAME}" supervisorctl -c /tmp/supervisord.conf restart ndex
+
+  echo "  Tomcat restart issued — waiting for NDEx to become responsive..."
+  MAX_WAIT=90
+  ELAPSED=0
+  until curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/v2/user" \
+        | grep -qE '^[2-9][0-9]{2}$|^401$|^400$'; do
+    if [[ ${ELAPSED} -ge ${MAX_WAIT} ]]; then
+      api_fail "NDEx did not respond within ${MAX_WAIT}s after Tomcat restart"
+    fi
+    echo -e "  ${CYAN}Waiting for Tomcat restart... (${ELAPSED}s)${NC}"
+    sleep 5; (( ELAPSED += 5 )) || true
+  done
+  echo "  Tomcat is ready."
+
+  CALL_NUM=$((CALL_NUM+1))
+  QUERY_UUID="${V2_UUIDS[0]}"
+  echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: POST /v2/search/network/${QUERY_UUID}/query (auth, expect 200)"
+
+  QUERY_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+    -u "${TEST_USER}:${TEST_PASS}" \
+    -H "Content-Type: application/json" \
+    -d '{"searchString":"EGFR","searchDepth":1}' \
+    "${BASE_URL}/v2/search/network/${QUERY_UUID}/query")
+  QUERY_HTTP=$(echo "${QUERY_RESPONSE}" | tail -1)
+  QUERY_BODY=$(echo "${QUERY_RESPONSE}" | head -1)
+
+  if [[ "${QUERY_HTTP}" == "200" ]]; then
+    api_pass "POST /v2/search/network/${QUERY_UUID}/query → 200 OK (SSL context initialized, stub proxied correctly)"
+  else
+    api_fail "POST /v2/search/network/${QUERY_UUID}/query → HTTP ${QUERY_HTTP}. Body: ${QUERY_BODY:0:400}"
+  fi
+
+  CALL_NUM=$((CALL_NUM+1))
+  QUERY_UUID_V3="${V3_UUIDS[0]}"
+  echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: POST /v3/search/networks/${QUERY_UUID_V3}/query (auth, expect 200)"
+
+  QUERY_V3_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+    -u "${TEST_USER}:${TEST_PASS}" \
+    -H "Content-Type: application/json" \
+    -d '{"searchString":"EGFR","searchDepth":1}' \
+    "${BASE_URL}/v3/search/networks/${QUERY_UUID_V3}/query")
+  QUERY_V3_HTTP=$(echo "${QUERY_V3_RESPONSE}" | tail -1)
+  QUERY_V3_BODY=$(echo "${QUERY_V3_RESPONSE}" | head -1)
+
+  if [[ "${QUERY_V3_HTTP}" == "200" ]]; then
+    api_pass "POST /v3/search/networks/${QUERY_UUID_V3}/query → 200 OK (SSL context initialized, stub proxied correctly)"
+  else
+    api_fail "POST /v3/search/networks/${QUERY_UUID_V3}/query → HTTP ${QUERY_V3_HTTP}. Body: ${QUERY_V3_BODY:0:400}"
+  fi
+fi
 
 # ── STEP: AUTHENTICATED_USER_ONLY blocks anonymous POST /v2/user ─────────────
 

--- a/src/main/java/org/ndexbio/rest/services/SearchServiceV2.java
+++ b/src/main/java/org/ndexbio/rest/services/SearchServiceV2.java
@@ -35,6 +35,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.net.ssl.SSLContext;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
@@ -328,8 +332,15 @@ public class SearchServiceV2 extends NdexService {
 		else
 			networkName = "Neighborhood query result on network - " + networkName;
 		
-		Client client = ClientBuilder.newBuilder().build();
-		
+		SSLContext sslContext;
+		try {
+			sslContext = SSLContext.getInstance("TLS");
+			sslContext.init(null, null, null);
+		} catch (NoSuchAlgorithmException | KeyManagementException e) {
+			throw new NdexException("Failed to initialize HTTP client: " + e.getMessage());
+		}
+		Client client = ClientBuilder.newBuilder().sslContext(sslContext).build();
+
 		String prefix = Configuration.getInstance().getProperty("NeighborhoodQueryURL");
         WebTarget target = client.target(prefix + networkId + "/query");
         Response response = target.request().post(Entity.entity(queryParameters, "application/json"));

--- a/src/main/java/org/ndexbio/rest/services/v3/SearchServiceV3.java
+++ b/src/main/java/org/ndexbio/rest/services/v3/SearchServiceV3.java
@@ -6,6 +6,10 @@ import java.io.InputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.net.URISyntaxException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.net.ssl.SSLContext;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -194,7 +198,14 @@ public class SearchServiceV3 extends NdexService  {
 		else
 			networkName = "Neighborhood query result on network - " + networkName;
 		
-		Client client = ClientBuilder.newBuilder().build();
+		SSLContext sslContext;
+		try {
+			sslContext = SSLContext.getInstance("TLS");
+			sslContext.init(null, null, null);
+		} catch (NoSuchAlgorithmException | KeyManagementException e) {
+			throw new NdexException("Failed to initialize HTTP client: " + e.getMessage());
+		}
+		Client client = ClientBuilder.newBuilder().sslContext(sslContext).build();
 		
 		String prefix = Configuration.getInstance().getProperty("NeighborhoodQueryURL");
 		String param = preserveNodeCoordinates ? "&perserveCoordinates=true" : "";
@@ -277,7 +288,14 @@ public class SearchServiceV3 extends NdexService  {
 		else
 			networkName = "Interconnect query result on network - " + networkName;
 				
-		Client client = ClientBuilder.newBuilder().build();
+		SSLContext sslContext;
+		try {
+			sslContext = SSLContext.getInstance("TLS");
+			sslContext.init(null, null, null);
+		} catch (NoSuchAlgorithmException | KeyManagementException e) {
+			throw new NdexException("Failed to initialize HTTP client: " + e.getMessage());
+		}
+		Client client = ClientBuilder.newBuilder().sslContext(sslContext).build();
 		
 		/*Map<String, Object> queryEntity = new TreeMap<>();
 		queryEntity.put("terms", queryParameters.getSearchString());
@@ -485,7 +503,14 @@ public class SearchServiceV3 extends NdexService  {
 			
 		}   
 	
-		Client client = ClientBuilder.newBuilder().build();
+		SSLContext sslContext;
+		try {
+			sslContext = SSLContext.getInstance("TLS");
+			sslContext.init(null, null, null);
+		} catch (NoSuchAlgorithmException | KeyManagementException e) {
+			throw new NdexException("Failed to initialize HTTP client: " + e.getMessage());
+		}
+		Client client = ClientBuilder.newBuilder().sslContext(sslContext).build();
 		
 		
 		String prefix = Configuration.getInstance().getProperty("NeighborhoodQueryURL");


### PR DESCRIPTION
eagerly default ssl context on http clients to avoid internal default `sun.security.ssl.SSLContextImpl` usage, this was getting triggered unnecessarily on neighborhood query url which is plain http, but the http client tries to default ssl context in any case.

```
org.ndexbio.model.exceptions.NdexException: Uncaught exception java.lang.NoClassDefFoundError: Could not initialize class sun.security.ssl.SSLContextImpl$DefaultSSLContext
	at org.ndexbio.rest.services.SearchServiceV2.queryNetworkAsCX(SearchServiceV2.java:339)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.jboss.resteasy.core.MethodInjectorImpl.invoke(MethodInjectorImpl.java:154)
	at org.jboss.resteasy.core.MethodInjectorImpl.invoke(MethodInjectorImpl.java:118)
	at org.jboss.resteasy.core.ResourceMethodInvoker.internalInvokeOnTarget(ResourceMethodInvoker.java:560)
	at org.jboss.resteasy.core.ResourceMethodInvoker.invokeOnTargetAfterFilter(ResourceMethodInvoker.java:452)
	at org.jboss.resteasy.core.ResourceMethodInvoker.lambda$invokeOnTarget$2(ResourceMethodInvoker.java:413)
	at org.jboss.resteasy.core.interception.jaxrs.PreMatchContainerRequestContext.filter(PreMatchContainerRequestContext.java:321)
	at org.jboss.resteasy.core.ResourceMethodInvoker.invokeOnTarget(ResourceMethodInvoker.java:415)
	at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:378)
	at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:356)
	at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:70)
	at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:429)
	at org.jboss.resteasy.core.SynchronousDispatcher.lambda$invoke$4(SynchronousDispatcher.java:240)
	at org.jboss.resteasy.core.SynchronousDispatcher.lambda$preprocess$0(SynchronousDispatcher.java:154)
	at org.jboss.resteasy.core.interception.jaxrs.PreMatchContainerRequestContext.filter(PreMatchContainerRequestContext.java:321)
	at org.jboss.resteasy.core.SynchronousDispatcher.preprocess(SynchronousDispatcher.java:157)
	at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:229)
	at org.jboss.resteasy.plugins.server.servlet.ServletContainerDispatcher.service(ServletContainerDispatcher.java:222)
	at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:55)
	at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:51)
	at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:658)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:196)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:51)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:165)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:167)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:90)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:482)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:115)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:93)
	at org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:673)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:344)
	at org.apache.coyote.ajp.AjpProcessor.service(AjpProcessor.java:431)
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63)
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:896)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1736)
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52)
	at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1191)
	at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:63)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

Fixes: [#CW-708](https://cytoscape.atlassian.net/browse/CW-708)