### PR TITLE
Fix NFSReIndexer: rebuild per-network solr index, drop folder-based

### DIFF
--- a/src/main/java/org/ndexbio/server/migration/v3/NFSReIndexer.java
+++ b/src/main/java/org/ndexbio/server/migration/v3/NFSReIndexer.java
@@ -330,8 +330,8 @@ public class NFSReIndexer implements Runnable,AutoCloseable {
 				try (SingleNetworkSolrIdxManager idx2 = new SingleNetworkSolrIdxManager(fileId.toString())) {
 						idx2.createIndexFromCx2(null);
 				}
-				long t = Calendar.getInstance().getTimeInMillis() -t1;
-				System.out.println("Takes " + t/1000 +" secs to create index for network " + fileId.toString());
+				long t = Calendar.getInstance().getTimeInMillis() - t1;
+				logger.info("Takes {} secs to create index for network {}", t / 1000, fileId);
 			}
             
             

--- a/src/main/java/org/ndexbio/server/migration/v3/NFSReIndexer.java
+++ b/src/main/java/org/ndexbio/server/migration/v3/NFSReIndexer.java
@@ -188,15 +188,9 @@ public class NFSReIndexer implements Runnable,AutoCloseable {
                     String ownerName = getUsernameById(ownerId, dao);
                     shortcut.setOwner(ownerName);
 
-                    // Shortcuts inherit permissions from parent folder
-                    List<String> userReads = null;
-                    if (shortcut.getParent() != null) {
-                        Map<String, List<String>> perms = loadFolderPermissions(shortcut.getParent(), dao);
-                        userReads = perms.get("READ");
-                    }
-
-                    sim.createIndex(shortcut, vis, userReads, null);
-
+                    // Shortcuts have no shareable permissions — only owner + visibility govern access (see PostgresShortcutDAO.isReadable)
+                    sim.createIndex(shortcut, vis, null, null);
+                    
                     shortcutsProcessed++;
                     if (shortcutsProcessed % 500 == 0) {
                         logger.info("[Shortcuts] {}/{} ({}%)",
@@ -294,10 +288,7 @@ public class NFSReIndexer implements Runnable,AutoCloseable {
      */
     private void reindexNetwork(UUID networkId, UUID ownerId, String ownerName,
                                 String visibility, V3Migrator.DaoSet dao, GlobalNetworkIndexManager globalNetworkIndexManager) throws Exception {
-        NetworkSummary ns = dao.networkDAO.getNetworkSummaryById(networkId);
-        if (ns == null) return;
-
-        VisibilityType vis = VisibilityType.valueOf(visibility);
+        
         rebuildNetworkIndex(networkId, false, false, globalNetworkIndexManager,
                 dao.networkDAO);
 
@@ -326,8 +317,24 @@ public class NFSReIndexer implements Runnable,AutoCloseable {
             // drop the old ones.
             if (!createOnly) {
                 globalNetworkIndexManager.delete(id, visibilityType);
-
+                
+                if ( idxScope == SolrIndexScope.both)
+					try (SingleNetworkSolrIdxManager idx2 = new SingleNetworkSolrIdxManager(fileId.toString())) {
+						idx2.dropIndex();
+					}
             }
+            
+            //build the individual index for queries
+			if (idxScope == SolrIndexScope.both) {
+				long t1 = Calendar.getInstance().getTimeInMillis();
+				try (SingleNetworkSolrIdxManager idx2 = new SingleNetworkSolrIdxManager(fileId.toString())) {
+						idx2.createIndexFromCx2(null);
+				}
+				long t = Calendar.getInstance().getTimeInMillis() -t1;
+				System.out.println("Takes " + t/1000 +" secs to create index for network " + fileId.toString());
+			}
+            
+            
 
             // build the solr document obj
             List<Map<Permissions, Collection<String>>> permissionTable = dao


### PR DESCRIPTION
shortcut perms

  - Recreate the SingleNetworkSolrIdxManager core for networks above AUTOCREATE_THRESHHOLD, matching the original SolrTaskRebuildNetworkIdx
    behavior. Without this, per-network query indexes were never built during reindexing.
  - Stop inheriting parent-folder READ users onto shortcut solr docs. Shortcuts are not shareable and PostgresShortcutDAO.isReadable only honors owner + visibility, so the inherited permissions made shortcuts
    discoverable in search but inaccessible on GET.
  - Remove dead NetworkSummary/VisibilityType lookups in reindexNetwork (rebuildNetworkIndex re-fetches them from the DAO).