### PR TITLE
allow reindex healing of existing networks stuck in err state

### DIFF
--- a/docker/test/integration-test.sh
+++ b/docker/test/integration-test.sh
@@ -31,7 +31,7 @@ TEST_USER2="ndextest2"
 TEST_PASS2="NDExTest2!"
 TEST_EMAIL2="ndextest2@ndex-integration.local"
 
-TOTAL_API_CALLS=28
+TOTAL_API_CALLS=30
 PASSED=0
 CALL_NUM=0
 STEP_NUM=0
@@ -533,6 +533,49 @@ while true; do
   echo "  Waiting for public-nfs Solr index... (${ELAPSED}s)"
 done
 api_pass "POST /v3/search/files → 200 OK, BindingDB UUID found in results (CX2 public-nfs confirmed)"
+
+# ── STEP: Reindex — trigger and verify clean completion ──────────────────────
+
+step "Triggering network reindex and verifying clean completion (no errorMessage)"
+
+REINDEX_UUID="${V3_UUIDS[0]}"
+CALL_NUM=$((CALL_NUM+1))
+echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: PUT /v2/network/${REINDEX_UUID}/systemproperty (index_level=ALL, expect 204)"
+
+REINDEX_HTTP=$(curl -s -o /dev/null -w "%{http_code}" -X PUT \
+  -u "${TEST_USER}:${TEST_PASS}" \
+  -H "Content-Type: application/json" \
+  -d '{"index_level":"ALL"}' \
+  "${BASE_URL}/v2/network/${REINDEX_UUID}/systemproperty")
+
+if [[ "${REINDEX_HTTP}" == "204" ]]; then
+  api_pass "PUT /v2/network/${REINDEX_UUID}/systemproperty → 204 No Content (reindex queued)"
+else
+  api_fail "PUT /v2/network/${REINDEX_UUID}/systemproperty → HTTP ${REINDEX_HTTP} (expected 204)"
+fi
+
+CALL_NUM=$((CALL_NUM+1))
+echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: GET /v3/networks/${REINDEX_UUID}/summary (poll until completed:true, expect no errorMessage)"
+
+ELAPSED=0
+SUMMARY_BODY=""
+while true; do
+  SUMMARY_BODY=$(curl -s -u "${TEST_USER}:${TEST_PASS}" "${BASE_URL}/v3/networks/${REINDEX_UUID}/summary")
+  if echo "${SUMMARY_BODY}" | grep -q '"completed":true'; then
+    break
+  fi
+  if [[ ${ELAPSED} -ge ${LOAD_TIMEOUT} ]]; then
+    api_fail "Network ${REINDEX_UUID} did not complete reindex within ${LOAD_TIMEOUT}s. Last: ${SUMMARY_BODY:0:300}"
+  fi
+  echo -e "  ${CYAN}Waiting for reindex to complete... (${ELAPSED}s)${NC}"
+  sleep 5; ELAPSED=$((ELAPSED + 5))
+done
+
+if echo "${SUMMARY_BODY}" | grep -qE '"errorMessage"[[:space:]]*:[[:space:]]*"'; then
+  api_fail "Network ${REINDEX_UUID} has errorMessage after reindex. Summary: ${SUMMARY_BODY:0:300}"
+else
+  api_pass "GET /v3/networks/${REINDEX_UUID}/summary → completed:true, no errorMessage (reindex succeeded cleanly)"
+fi
 
 # ── STEP: Neighborhood query — SSL context fix (local container only) ─────────
 

--- a/src/main/java/org/ndexbio/common/models/dao/postgresql/PostgresNetworkDAO.java
+++ b/src/main/java/org/ndexbio/common/models/dao/postgresql/PostgresNetworkDAO.java
@@ -2068,13 +2068,14 @@ public class PostgresNetworkDAO extends NdexDBDAO implements NetworkDAO {
     	String sql = "update network set error = ? where \"UUID\" = ? and is_deleted=false";
     	
     	String trimmedMsg = errorMessage;
-    	if ( trimmedMsg == null)
-    		trimmedMsg = "null";
-    	else if ( trimmedMsg.length() > 2000)
+    	if ( trimmedMsg != null && trimmedMsg.length() > 2000)
     		trimmedMsg = (errorMessage.substring(0, 1996) + "...");
-    	
+
     	try ( PreparedStatement pst = db.prepareStatement(sql)) {
-    		pst.setString(1, trimmedMsg);
+    		if (trimmedMsg == null)
+    			pst.setNull(1, java.sql.Types.VARCHAR);
+    		else
+    			pst.setString(1, trimmedMsg);
     		pst.setObject(2, networkId);
     		int i = pst.executeUpdate();
     		if ( i !=1)

--- a/src/main/java/org/ndexbio/common/models/dao/postgresql/PostgresNetworkDAO.java
+++ b/src/main/java/org/ndexbio/common/models/dao/postgresql/PostgresNetworkDAO.java
@@ -92,7 +92,9 @@ import org.ndexbio.common.models.dao.NetworkDAO;
 public class PostgresNetworkDAO extends NdexDBDAO implements NetworkDAO {
 
 	private static Logger logger = Logger.getLogger(PostgresNetworkDAO.class.getName());
-	
+
+	public static final String INDEXING_ERROR_PREFIX = "Failed to create Index on network.";
+
 //	public static final String RESET_MOD_TIME = "resetMTime";
 	
 	private  static List<String> emptyStringList = new ArrayList<>(1); 
@@ -2087,6 +2089,11 @@ public class PostgresNetworkDAO extends NdexDBDAO implements NetworkDAO {
     
     }
     
+    public void clearIndexingErrorIfPresent(UUID networkId, String currentError) {
+        if (currentError == null || currentError.startsWith(INDEXING_ERROR_PREFIX))
+            setErrorMessage(networkId, null);
+    }
+
     public void setWarning(UUID networkId, List<String> warnings) throws SQLException, NdexException {
     	String sqlStr = "update network set  warnings = ? where \"UUID\" = ? and is_deleted = false";
 		try (PreparedStatement pst = db.prepareStatement(sqlStr)) {

--- a/src/main/java/org/ndexbio/common/solr/SolrIndexBuilder.java
+++ b/src/main/java/org/ndexbio/common/solr/SolrIndexBuilder.java
@@ -138,7 +138,7 @@ public class SolrIndexBuilder implements AutoCloseable {
 
 				  logger.info("Solr index of network " + networkid + " created.");
 			  }
-			  dao.setErrorMessage(networkid, null);
+			  dao.clearIndexingErrorIfPresent(networkid, summary.getErrorMessage());
 		  } finally {
 			  dao.unlockNetwork(networkid);
 		  }
@@ -227,7 +227,7 @@ public class SolrIndexBuilder implements AutoCloseable {
 				 // dao.unlockNetwork(networkid);
 				  logger.info("Solr index of network " + networkid + " created.");
 			  }
-			  dao.setErrorMessage(networkid, null);
+			  dao.clearIndexingErrorIfPresent(networkid, summary.getErrorMessage());
 		}
 	}
 	
@@ -261,7 +261,7 @@ public class SolrIndexBuilder implements AutoCloseable {
 			
 		  }
 		  //dao.unlockNetwork(networkid);
-		  dao.setErrorMessage(networkid, null);
+		  dao.clearIndexingErrorIfPresent(networkid, summary.getErrorMessage());
 		}
 	}
 
@@ -271,7 +271,7 @@ public class SolrIndexBuilder implements AutoCloseable {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO ()) {
 			@SuppressWarnings("resource")
 			Connection db = dao.getDBConnection();
-			String sqlStr = "select \"UUID\" from network n where n.iscomplete and n.is_deleted=false and n.is_validated and n.islocked=false and (n.error is null or n.error like 'Failed to create Index%Connection refused%')";
+			String sqlStr = "select \"UUID\" from network n where n.iscomplete and n.is_deleted=false and n.is_validated and n.islocked=false and (n.error is null or n.error like '" + PostgresNetworkDAO.INDEXING_ERROR_PREFIX + "%')";
 
 			int i = 0;
 			try (PreparedStatement pst = db.prepareStatement(sqlStr)) {
@@ -303,7 +303,7 @@ public class SolrIndexBuilder implements AutoCloseable {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO ()) {
 			@SuppressWarnings("resource")
 			Connection db = dao.getDBConnection();
-			String sqlStr = "select \"UUID\" from network n where n.iscomplete and n.is_deleted=false and n.is_validated and n.islocked=false and (n.error is null or n.error like 'Failed to create Index%Connection refused%')";
+			String sqlStr = "select \"UUID\" from network n where n.iscomplete and n.is_deleted=false and n.is_validated and n.islocked=false and (n.error is null or n.error like '" + PostgresNetworkDAO.INDEXING_ERROR_PREFIX + "%')";
 
 			int i = 0;
 			try (PreparedStatement pst = db.prepareStatement(sqlStr)) {
@@ -335,7 +335,7 @@ public class SolrIndexBuilder implements AutoCloseable {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO ()) {
 			@SuppressWarnings("resource")
 			Connection db = dao.getDBConnection();
-			String sqlStr = "select \"UUID\" from network n where n.iscomplete and n.is_deleted=false and n.is_validated and n.islocked=false and (n.error is null or n.error like 'Failed to create Index%Connection refused%') and cx2_file_size is not null and nodecount >= "
+			String sqlStr = "select \"UUID\" from network n where n.iscomplete and n.is_deleted=false and n.is_validated and n.islocked=false and (n.error is null or n.error like '" + PostgresNetworkDAO.INDEXING_ERROR_PREFIX + "%') and cx2_file_size is not null and nodecount >= "
 					+ SingleNetworkSolrIdxManager.AUTOCREATE_THRESHHOLD ;
 			
 			int i = 0;
@@ -380,7 +380,7 @@ public class SolrIndexBuilder implements AutoCloseable {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO ()) {
 			@SuppressWarnings("resource")
 			Connection db = dao.getDBConnection();
-			String sqlStr = "select \"UUID\" from network n where n.iscomplete and n.is_deleted=false and n.is_validated and (n.error is null or n.error like 'Failed to create Index%Connection refused%')";
+			String sqlStr = "select \"UUID\" from network n where n.iscomplete and n.is_deleted=false and n.is_validated and (n.error is null or n.error like '" + PostgresNetworkDAO.INDEXING_ERROR_PREFIX + "%')";
 			
 			int i = 0;
 			try (PreparedStatement pst = db.prepareStatement(sqlStr)) {

--- a/src/main/java/org/ndexbio/common/solr/SolrIndexBuilder.java
+++ b/src/main/java/org/ndexbio/common/solr/SolrIndexBuilder.java
@@ -137,11 +137,12 @@ public class SolrIndexBuilder implements AutoCloseable {
 				  globalIdx.commit();
 
 				  logger.info("Solr index of network " + networkid + " created.");
-			  } 
+			  }
+			  dao.setErrorMessage(networkid, null);
 		  } finally {
 			  dao.unlockNetwork(networkid);
-		  }	 
-		}  
+		  }
+		}
 	}
 	
 	
@@ -222,12 +223,12 @@ public class SolrIndexBuilder implements AutoCloseable {
 						
 				  }	
 				  globalIdx.commit();
-			
+
 				 // dao.unlockNetwork(networkid);
 				  logger.info("Solr index of network " + networkid + " created.");
-			  } 
-		  	 
-		}  
+			  }
+			  dao.setErrorMessage(networkid, null);
+		}
 	}
 	
 	
@@ -258,10 +259,10 @@ public class SolrIndexBuilder implements AutoCloseable {
 				    logger.info("Solr index for query created.");
 			  }   			 	
 			
-		  }	 
+		  }
 		  //dao.unlockNetwork(networkid);
-
-		}  
+		  dao.setErrorMessage(networkid, null);
+		}
 	}
 
 	
@@ -270,8 +271,8 @@ public class SolrIndexBuilder implements AutoCloseable {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO ()) {
 			@SuppressWarnings("resource")
 			Connection db = dao.getDBConnection();
-			String sqlStr = "select \"UUID\" from network n where n.iscomplete and n.is_deleted=false and n.is_validated and n.islocked=false and n.error is null";
-			
+			String sqlStr = "select \"UUID\" from network n where n.iscomplete and n.is_deleted=false and n.is_validated and n.islocked=false and (n.error is null or n.error like 'Failed to create Index%Connection refused%')";
+
 			int i = 0;
 			try (PreparedStatement pst = db.prepareStatement(sqlStr)) {
 				try ( ResultSet rs = pst.executeQuery()) {
@@ -302,8 +303,8 @@ public class SolrIndexBuilder implements AutoCloseable {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO ()) {
 			@SuppressWarnings("resource")
 			Connection db = dao.getDBConnection();
-			String sqlStr = "select \"UUID\" from network n where n.iscomplete and n.is_deleted=false and n.is_validated and n.islocked=false and n.error is null";
-			
+			String sqlStr = "select \"UUID\" from network n where n.iscomplete and n.is_deleted=false and n.is_validated and n.islocked=false and (n.error is null or n.error like 'Failed to create Index%Connection refused%')";
+
 			int i = 0;
 			try (PreparedStatement pst = db.prepareStatement(sqlStr)) {
 				try ( ResultSet rs = pst.executeQuery()) {
@@ -334,7 +335,7 @@ public class SolrIndexBuilder implements AutoCloseable {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO ()) {
 			@SuppressWarnings("resource")
 			Connection db = dao.getDBConnection();
-			String sqlStr = "select \"UUID\" from network n where n.iscomplete and n.is_deleted=false and n.is_validated and n.islocked=false and n.error is null and cx2_file_size is not null and nodecount >= " 
+			String sqlStr = "select \"UUID\" from network n where n.iscomplete and n.is_deleted=false and n.is_validated and n.islocked=false and (n.error is null or n.error like 'Failed to create Index%Connection refused%') and cx2_file_size is not null and nodecount >= "
 					+ SingleNetworkSolrIdxManager.AUTOCREATE_THRESHHOLD ;
 			
 			int i = 0;
@@ -379,7 +380,7 @@ public class SolrIndexBuilder implements AutoCloseable {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO ()) {
 			@SuppressWarnings("resource")
 			Connection db = dao.getDBConnection();
-			String sqlStr = "select \"UUID\" from network n where n.iscomplete and n.is_deleted=false and n.is_validated and n.error is null";
+			String sqlStr = "select \"UUID\" from network n where n.iscomplete and n.is_deleted=false and n.is_validated and (n.error is null or n.error like 'Failed to create Index%Connection refused%')";
 			
 			int i = 0;
 			try (PreparedStatement pst = db.prepareStatement(sqlStr)) {

--- a/src/main/java/org/ndexbio/task/SolrTaskRebuildNetworkIdx.java
+++ b/src/main/java/org/ndexbio/task/SolrTaskRebuildNetworkIdx.java
@@ -206,7 +206,7 @@ public class SolrTaskRebuildNetworkIdx extends NdexSystemTask {
 			}
 
 			try {
-				dao.setErrorMessage(networkId, null);
+				dao.clearIndexingErrorIfPresent(networkId, summary.getErrorMessage());
 				dao.setFlag(this.networkId, "iscomplete", true);
 				dao.commit();
 			} catch (SQLException e) {
@@ -216,7 +216,7 @@ public class SolrTaskRebuildNetworkIdx extends NdexSystemTask {
 		} catch (SQLException | IOException | NdexException | SolrServerException e1) {
 			e1.printStackTrace();
 			try (PostgresNetworkDAO dao = new PostgresNetworkDAO()) {
-				dao.setErrorMessage(networkId, "Failed to create Index on network. Index type: " + this.idxScope
+				dao.setErrorMessage(networkId, PostgresNetworkDAO.INDEXING_ERROR_PREFIX + " Index type: " + this.idxScope
 						+ ". Cause: " + e1.getMessage());
 				dao.commit();
 			}

--- a/src/main/java/org/ndexbio/task/SolrTaskRebuildNetworkIdx.java
+++ b/src/main/java/org/ndexbio/task/SolrTaskRebuildNetworkIdx.java
@@ -206,6 +206,7 @@ public class SolrTaskRebuildNetworkIdx extends NdexSystemTask {
 			}
 
 			try {
+				dao.setErrorMessage(networkId, null);
 				dao.setFlag(this.networkId, "iscomplete", true);
 				dao.commit();
 			} catch (SQLException e) {


### PR DESCRIPTION
This was vibed with Claude:

# Root Cause: Networks Showing "This network has a data validation error"

## Root Cause

`SolrTaskRebuildNetworkIdx` stamps `network.error` when Solr is unreachable. The success path never clears that field, so the error persists after Solr recovers. `SolrIndexBuilder` batch queries filter `AND n.error IS NULL`, so batch runs can never heal stuck networks.

**DB-confirmed scale (dev3):** 142,432 networks carry `error = 'Failed to create Index on network. Cause: java.net.ConnectException: Connection refused'` from a past Solr outage. 141,798 are otherwise healthy (`iscomplete=true, is_validated=true`).

---

## Fix B — `setErrorMessage(null)` must write SQL NULL (prerequisite for A + C)

**File:** `src/main/java/org/ndexbio/common/models/dao/postgresql/PostgresNetworkDAO.java:2070-2073`

Current code writes the string `"null"` when `null` is passed, which is non-null in the DB:

```java
// current — wrong
if (trimmedMsg == null)
    trimmedMsg = "null";
```

Replace with a branch that calls `pst.setNull()`:

```java
if (trimmedMsg == null) {
    pst.setNull(1, java.sql.Types.VARCHAR);
} else {
    if (trimmedMsg.length() > 2000)
        trimmedMsg = trimmedMsg.substring(0, 1996) + "...";
    pst.setString(1, trimmedMsg);
}
```

Note: `setErrorMessage` already calls `db.commit()` internally. Callers that chain an additional `dao.commit()` after calling it will issue a redundant commit, which is harmless.

---

## Fix A — Clear `error` on successful reindex in `SolrTaskRebuildNetworkIdx`

**File:** `src/main/java/org/ndexbio/task/SolrTaskRebuildNetworkIdx.java:208-213`

Add `setErrorMessage(null)` before the `iscomplete` flag in the success path:

```java
dao.setErrorMessage(networkId, null);          // clear stale infra error
dao.setFlag(this.networkId, "iscomplete", true);
dao.commit();
```

No conflict with the catch block — if an exception is thrown, the catch path runs instead and the success path is never reached.

---

## Fix C — Relax `SolrIndexBuilder` batch filter + clear error on batch success

### Part 1 — Relax the batch query filter

**File:** `src/main/java/org/ndexbio/common/solr/SolrIndexBuilder.java:273, 305, 337, 382`

Change `AND n.error IS NULL` in all four batch query strings to:

```sql
AND (n.error IS NULL OR n.error LIKE 'Failed to create Index%Connection refused%')
```

Networks with real data errors (invalid type, missing CX2 file) remain excluded.

### Part 2 — Clear error on success inside `rebuildNetworkIndex` / `rebuildNetworkIndexInGlobalIdx` / `rebuildLocalNetworkIndex`

`SolrIndexBuilder` private methods make no DB writes today. After successful indexing (after `globalIdx.commit()` / `idx2.close()`, and **before** the `finally` block so it only runs on the non-exception path), add:

```java
dao.setErrorMessage(networkid, null);
```

**Placement note:** In `rebuildNetworkIndex`, the `finally` block calls `dao.unlockNetwork(networkid)`. Place `setErrorMessage` inside the inner `try` block after `globalIdx.commit()`, not inside `finally`, so it is skipped if an exception occurs. `rebuildNetworkIndexInGlobalIdx` and `rebuildLocalNetworkIndex` have their `lockNetwork` / `unlockNetwork` calls commented out — no finally-block concern there.

With all three fixes, the next admin `SolrIndexBuilder all-networks-online` run will pick up and reindex all 142,432 stuck networks, clearing their DB error fields and healing the UI automatically.


Closes [#CW-742](https://cytoscape.atlassian.net/browse/CW-742)