### PR TITLE
Refactor: Unlist networks that are public with solr_idx_level='NONE'

### DIFF
--- a/SolrIndexBuilder-CLI.md
+++ b/SolrIndexBuilder-CLI.md
@@ -1,0 +1,210 @@
+# SolrIndexBuilder CLI Reference
+
+Command-line tool for rebuilding and repairing NDEx Solr indexes from the
+PostgreSQL source of truth. Lives in `org.ndexbio.common.solr.SolrIndexBuilder`
+and is run directly from the deployed `ndexbio-rest` jar plus its `WEB-INF/lib`
+dependencies.
+
+## Running the tool
+
+The tool needs the app jar, all dependency jars in `WEB-INF/lib`, and the
+exploded `WEB-INF/classes` (for `logback.xml` and other resources) on the
+classpath. The app jar alone is not enough — it omits SolrJ and friends, which
+fails with `NoClassDefFoundError: org/apache/solr/client/solrj/SolrServerException`.
+
+```bash
+java -cp "/home/ndex/ndexbio-rest.jar:/home/ndex/ndexbio-rest/WEB-INF/lib/*:/home/ndex/ndexbio-rest/WEB-INF/classes" \
+  org.ndexbio.common.solr.SolrIndexBuilder <command>
+```
+
+Keep the entire `-cp` value inside quotes so the JVM expands the `/*` glob
+rather than the shell. The tool takes exactly one argument; with zero or more
+than one it prints the usage line and exits.
+
+### Configuration
+
+On startup the tool calls `Configuration.createInstance()`, which reads
+`/opt/ndex/conf/ndex.properties` for DB URL/credentials and Solr URL. No DB or
+Solr connection details are passed on the command line. Make sure the config
+file is in place and points at the intended server before running.
+
+```bash
+# optional: be explicit about the config path
+export ndexConfigurationPath=/opt/ndex/conf/ndex.properties
+```
+
+### A note on logging output
+
+The bundled `logback.xml` writes to `../logs/ndex.log` relative to the current
+working directory. When the tool is launched from a directory where `../logs`
+does not resolve to a real, writable path (e.g. from `/home/ndex`, where it
+resolves to `/logs`), file logging silently fails and the console stays mostly
+quiet during the run. The work still proceeds.
+
+To see progress, either run from a directory where `../logs` points at an
+existing writable log directory, or monitor the database directly in a second
+terminal (see the `unlist-public-none` section for an example).
+
+## Commands
+
+| Command | Scope | What it does |
+|---|---|---|
+| `all` | User + group + all networks | Full rebuild: user index, group index, then every eligible network's global index. |
+| `user` | User index | Rebuilds only the user search index. |
+| `group` | Group index | Rebuilds only the group search index. |
+| `all-networks-online` | All networks | Rebuilds network indexes without the `islocked=false` precondition; tolerates per-network failures and keeps going. |
+| `global-networks` | Global network index | Rebuilds the global network index only (no per-network query cores). |
+| `all-local` | Per-network query cores | Creates the per-network Solr query cores for networks at or above the autocreate node-count threshold. |
+| `nfs` | NFS indexes | Placeholder; currently a no-op. |
+| `unlist-public-none` | Maintenance | Flips `PUBLIC` + `solr_idx_lvl=NONE` networks to `UNLISTED` and moves them from `public-nfs` to `private-nfs`. |
+| `<networkUUID>` | Single network | Rebuilds the index for one network by UUID. |
+
+### `all`
+
+```bash
+java -cp "..." org.ndexbio.common.solr.SolrIndexBuilder all
+```
+
+Runs three phases in order: rebuild the user index, rebuild the group index,
+then rebuild the global index for every network that is complete, not deleted,
+validated, not locked, and has no error. Sleeps 2 seconds every 500 networks to
+ease load on Solr. This is the heaviest command and the most likely to stress
+Solr heap on a large server.
+
+### `user`
+
+```bash
+java -cp "..." org.ndexbio.common.solr.SolrIndexBuilder user
+```
+
+Creates the user core if needed and reindexes every verified, non-deleted user.
+
+### `group`
+
+```bash
+java -cp "..." org.ndexbio.common.solr.SolrIndexBuilder group
+```
+
+Creates the group core if needed and reindexes every non-deleted group.
+
+### `all-networks-online`
+
+```bash
+java -cp "..." org.ndexbio.common.solr.SolrIndexBuilder all-networks-online
+```
+
+Rebuilds network indexes for all complete, non-deleted, validated networks with
+no error — note this command does **not** require `islocked=false`, so it can
+run against networks that are currently locked. Each network is wrapped in its
+own try/catch, so a single failure is logged and the loop continues. Sleeps 2
+seconds every 500 networks.
+
+### `global-networks`
+
+```bash
+java -cp "..." org.ndexbio.common.solr.SolrIndexBuilder global-networks
+```
+
+Rebuilds only the global network index (the cross-network search doc), skipping
+the per-network query cores. Same eligibility filter as `all` (complete, not
+deleted, validated, not locked, no error). Sleeps 2 seconds every 1000 networks.
+
+### `all-local`
+
+```bash
+java -cp "..." org.ndexbio.common.solr.SolrIndexBuilder all-local
+```
+
+Creates the per-network Solr query core for each network that is complete, not
+deleted, validated, not locked, has no error, has a CX2 file, and meets or
+exceeds the autocreate node-count threshold. If a core already exists for a
+network, that case is detected and skipped rather than treated as an error.
+Logs how many were checked vs. created.
+
+### `nfs`
+
+```bash
+java -cp "..." org.ndexbio.common.solr.SolrIndexBuilder nfs
+```
+
+Currently a placeholder with no implementation. Running it does nothing.
+
+### `unlist-public-none`
+
+```bash
+java -cp "..." org.ndexbio.common.solr.SolrIndexBuilder unlist-public-none
+```
+
+Maintenance command for the `public-nfs` cleanup. It finds every network with
+`visibility = 'PUBLIC'` and `solr_idx_lvl = 'NONE'` that is not deleted, flips
+each to `UNLISTED` in Postgres, and runs the Solr delete + rebuild so the file
+index entry moves from `public-nfs` to `private-nfs`.
+
+Behavior details:
+
+- **Per-network locking.** Each network is locked for the duration of its
+  conversion and unlocked in a `finally`, with a commit so the unlock persists
+  on the shared `autoCommit=false` connection.
+- **Commit-then-compensate.** The visibility flip is committed before the Solr
+  work runs. If a Solr step fails, a compensating `UPDATE` restores the network
+  to `PUBLIC` so Postgres and Solr don't drift apart.
+- **Continues on failure.** A failed network is logged and counted; the loop
+  moves on. Already-converted networks remain `UNLISTED`.
+- **`ignoreCxFiles=true`** on the rebuild, because these `solr_idx_lvl=NONE`
+  networks may not have CX aspect files on disk to index from.
+
+**Before running:**
+
+Clear any stale row locks left by a previously crashed run, or the lock step
+will throw `NetworkConcurrentModificationException` on those rows:
+
+```sql
+SELECT COUNT(*) FROM network WHERE islocked = true;
+UPDATE network SET islocked = false WHERE islocked = true;
+```
+
+Sanity-check the target count so you know how much work is queued:
+
+```sql
+SELECT COUNT(*) FROM network
+WHERE visibility='PUBLIC' AND solr_idx_lvl='NONE' AND is_deleted=false;
+```
+
+**Monitor progress** (file logging is usually silent — see the logging note
+above) by watching the target count tick down in a second terminal:
+
+```bash
+watch -n 5 "psql -d ndex -c \"SELECT COUNT(*) FROM network WHERE visibility='PUBLIC' AND solr_idx_lvl='NONE' AND is_deleted=false;\""
+```
+
+### Single network by UUID
+
+```bash
+java -cp "..." org.ndexbio.common.solr.SolrIndexBuilder 6d19dd59-0e56-11eb-9eee-0ac135e8bacf
+```
+
+Any argument that isn't one of the named commands is treated as a network UUID.
+The network's index is rebuilt (global plus per-network query core if it meets
+the threshold) and the global index is committed at the end. An invalid UUID
+will throw an `IllegalArgumentException` from `UUID.fromString`.
+
+## Pre-run checklist
+
+1. **Confirm the target server.** `ndex.properties` decides which DB and Solr
+   the run hits — verify it before launching, especially on shared boxes.
+2. **Confirm Solr heap.** Large rebuilds (`all`, `global-networks`,
+   `all-networks-online`) can OOM Solr if `SOLR_JAVA_MEM` is left at the 512MB
+   default. Check `solr.in.sh` has an explicit heap (e.g.
+   `SOLR_JAVA_MEM="-Xms2g -Xmx4g"`) and that Solr was restarted after any change.
+3. **Clear stale locks** if a prior run crashed (see `unlist-public-none`).
+4. **Have a progress monitor ready** (DB query in a second terminal), since
+   console output is often empty.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `NoClassDefFoundError: .../SolrServerException` | App jar on classpath without `WEB-INF/lib` | Use the full quoted `-cp` with `WEB-INF/lib/*` and `WEB-INF/classes`. |
+| `NetworkConcurrentModificationException` on first/most networks | Stale `islocked=true` rows from a crashed run | `UPDATE network SET islocked=false WHERE islocked=true;` then rerun. |
+| No console output, looks hung | `../logs` doesn't resolve from CWD, file logging failed | Run from a dir where `../logs` is writable, or monitor the DB count. |
+| Solr goes down mid-run | Solr heap too small (512MB default) | Set `SOLR_JAVA_MEM` in `solr.in.sh`, restart Solr, rerun. |

--- a/docker/test/integration-test.sh
+++ b/docker/test/integration-test.sh
@@ -31,7 +31,7 @@ TEST_USER2="ndextest2"
 TEST_PASS2="NDExTest2!"
 TEST_EMAIL2="ndextest2@ndex-integration.local"
 
-TOTAL_API_CALLS=31
+TOTAL_API_CALLS=33
 PASSED=0
 CALL_NUM=0
 STEP_NUM=0
@@ -653,6 +653,68 @@ if [[ -z "${REMOTE_NDEX_URL}" ]]; then
     api_pass "GET /v3/networks/${V3_UUIDS[0]}/summary → 200 OK, errorMessage cleared after successful reindex"
   else
     api_fail "GET /v3/networks/${V3_UUIDS[0]}/summary → HTTP ${POST_HTTP}. errorMessage was not cleared. Body: ${POST_BODY:0:400}"
+  fi
+fi
+
+# ── STEP: unlist-public-none converts PUBLIC/NONE networks to UNLISTED ────────
+
+if [[ -z "${REMOTE_NDEX_URL}" ]]; then
+  step "SolrIndexBuilder unlist-public-none converts PUBLIC+NONE networks to UNLISTED"
+
+  # Force the BindingDB network to solr_idx_lvl='NONE' so it is a candidate.
+  docker exec "${CONTAINER_NAME}" bash -c "
+    DB_USER=\$(grep '^NdexDBUsername=' /apps/ndex/config/ndex.properties | cut -d= -f2-)
+    DB_PASS=\$(grep '^NdexDBDBPassword=' /apps/ndex/config/ndex.properties | cut -d= -f2-)
+    PGPASSWORD=\"\$DB_PASS\" psql -h 127.0.0.1 -p 5432 -U \"\$DB_USER\" -d ndex \
+      -c \"UPDATE network SET solr_idx_lvl = 'NONE' WHERE \\\"UUID\\\" = '${V3_PUB_UUID}'\"
+  "
+
+  docker exec "${CONTAINER_NAME}" bash -c "
+    ndexConfigurationPath=/apps/ndex/config/ndex.properties \
+    java -cp '/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/*:/usr/local/tomcat/webapps/ROOT/WEB-INF/classes' \
+      org.ndexbio.common.solr.SolrIndexBuilder unlist-public-none
+  "
+
+  # Assert DB row was flipped to UNLISTED.
+  DB_VISIBILITY=$(docker exec "${CONTAINER_NAME}" bash -c "
+    DB_USER=\$(grep '^NdexDBUsername=' /apps/ndex/config/ndex.properties | cut -d= -f2-)
+    DB_PASS=\$(grep '^NdexDBDBPassword=' /apps/ndex/config/ndex.properties | cut -d= -f2-)
+    PGPASSWORD=\"\$DB_PASS\" psql -h 127.0.0.1 -p 5432 -U \"\$DB_USER\" -d ndex -tA \
+      -c \"SELECT visibility FROM network WHERE \\\"UUID\\\" = '${V3_PUB_UUID}'\"
+  ")
+  if [[ "${DB_VISIBILITY}" == "UNLISTED" ]]; then
+    echo "  DB check passed: visibility='UNLISTED' for network ${V3_PUB_UUID}"
+  else
+    api_fail "DB check failed: expected visibility='UNLISTED' but got '${DB_VISIBILITY}' for network ${V3_PUB_UUID}"
+  fi
+
+  CALL_NUM=$((CALL_NUM+1))
+  echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: GET /v3/networks/${V3_PUB_UUID}/summary (auth, expect UNLISTED)"
+  SUMM_RESP=$(curl -s -w "\n%{http_code}" -u "${TEST_USER}:${TEST_PASS}" \
+    "${BASE_URL}/v3/networks/${V3_PUB_UUID}/summary")
+  SUMM_HTTP=$(echo "${SUMM_RESP}" | tail -1)
+  SUMM_BODY=$(echo "${SUMM_RESP}" | head -1)
+  if [[ "${SUMM_HTTP}" == "200" ]] && echo "${SUMM_BODY}" | grep -q '"UNLISTED"'; then
+    api_pass "GET /v3/networks/${V3_PUB_UUID}/summary (auth) → 200 OK, visibility=UNLISTED"
+  else
+    api_fail "GET /v3/networks/${V3_PUB_UUID}/summary (auth) → HTTP ${SUMM_HTTP}. Expected visibility=UNLISTED. Body: ${SUMM_BODY:0:400}"
+  fi
+
+  # Verify Solr was re-indexed: an anonymous PUBLIC search must no longer find this UUID.
+  # Authenticated owners still see their own UNLISTED networks (userAdmin filter), so
+  # anonymous is the right caller — it uses the pure "exclude UNLISTED" Solr filter.
+  CALL_NUM=$((CALL_NUM+1))
+  echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: POST /v3/search/files?visibility=PUBLIC (anon, expect UUID absent — Solr doc updated to UNLISTED)"
+  SEARCH_RESP=$(curl -s -w "\n%{http_code}" \
+    -X POST -H "Content-Type: application/json" \
+    -d "{\"searchString\":\"BindingDB\"}" \
+    "${BASE_URL}/v3/search/files?visibility=PUBLIC")
+  SEARCH_HTTP=$(echo "${SEARCH_RESP}" | tail -1)
+  SEARCH_BODY=$(echo "${SEARCH_RESP}" | head -1)
+  if [[ "${SEARCH_HTTP}" == "200" ]] && ! echo "${SEARCH_BODY}" | grep -q "${V3_PUB_UUID}"; then
+    api_pass "POST /v3/search/files?visibility=PUBLIC (anon) → 200 OK, UUID absent (Solr doc updated to UNLISTED)"
+  else
+    api_fail "POST /v3/search/files?visibility=PUBLIC (anon) → HTTP ${SEARCH_HTTP}, UUID still present (Solr re-index did not run or visibility field not updated). Body: ${SEARCH_BODY:0:400}"
   fi
 fi
 

--- a/src/main/java/org/ndexbio/common/solr/SolrIndexBuilder.java
+++ b/src/main/java/org/ndexbio/common/solr/SolrIndexBuilder.java
@@ -533,8 +533,9 @@ public class SolrIndexBuilder implements AutoCloseable {
 	private static void unlistPublicNoneNetworks() throws Exception {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO()) {
 			unlistPublicNoneNetworks(dao, (networkId, ownerId, ownerName) -> {
-				// ignoreCxFiles=true: these networks have solr_idx_lvl=NONE
-				// and may not have CX aspect files on disk to index from.
+				// ignoreCxFiles=true: skips CX2 aspect reads (these networks may have no CX2
+				// files on disk). The CX1 AspectIterator fallback still runs but returns nothing
+				// for NONE-indexed networks, so only metadata is indexed.
 				new SolrTaskDeleteFile(networkId, VisibilityType.PUBLIC).run();
 				new SolrTaskRebuildFileIdx(networkId, ownerId, ownerName,
 						VisibilityType.UNLISTED, FileType.NETWORK, false, true).run();
@@ -592,6 +593,7 @@ public class SolrIndexBuilder implements AutoCloseable {
 					db.commit();
 				} finally {
 					if (locked) {
+						try { db.rollback(); } catch (SQLException rbe) { /* best-effort: clear aborted txn before unlock */ }
 						try { dao.unlockNetwork(networkId); }
 						catch (SQLException unlockEx) {
 							logger.error("CRITICAL: Network {} is stuck locked — manual intervention required: {}",
@@ -617,11 +619,15 @@ public class SolrIndexBuilder implements AutoCloseable {
 							dao.lockNetwork(networkId);
 							revertLocked = true;
 							revertPst.setObject(1, networkId);
-							revertPst.executeUpdate();
+							int revertRows = revertPst.executeUpdate();
+							if (revertRows != 1) {
+								throw new NdexException("Expected 1 row reverted for " + networkId + " but got " + revertRows);
+							}
 							db.commit();
 							logger.info("Reverted visibility to PUBLIC for network {}", networkId);
 						} finally {
 							if (revertLocked) {
+								try { db.rollback(); } catch (SQLException rbe) { /* best-effort: clear aborted txn before unlock */ }
 								try { dao.unlockNetwork(networkId); }
 								catch (SQLException unlockEx) {
 									logger.error("CRITICAL: Network {} is stuck locked — manual intervention required: {}",

--- a/src/main/java/org/ndexbio/common/solr/SolrIndexBuilder.java
+++ b/src/main/java/org/ndexbio/common/solr/SolrIndexBuilder.java
@@ -24,12 +24,17 @@ import org.ndexbio.cxio.aspects.datamodels.NodeAttributesElement;
 import org.ndexbio.cxio.aspects.datamodels.NodesElement;
 import org.ndexbio.model.cx.FunctionTermElement;
 import org.ndexbio.model.exceptions.NdexException;
+import org.ndexbio.model.object.FileType;
 import org.ndexbio.model.object.Group;
 import org.ndexbio.model.object.Permissions;
 import org.ndexbio.model.object.User;
 import org.ndexbio.model.object.network.NetworkIndexLevel;
 import org.ndexbio.model.object.network.NetworkSummary;
+import org.ndexbio.model.object.network.VisibilityType;
 import org.ndexbio.rest.Configuration;
+import org.ndexbio.task.NdexServerQueue;
+import org.ndexbio.task.SolrTaskDeleteFile;
+import org.ndexbio.task.SolrTaskRebuildFileIdx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,123 +43,123 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 
 public class SolrIndexBuilder implements AutoCloseable {
 
-    protected static Logger logger = LoggerFactory.getLogger(SolrIndexBuilder.class);
-	
-	  NetworkGlobalIndexManager globalIdx ;
-	
+	protected static Logger logger = LoggerFactory.getLogger(SolrIndexBuilder.class);
+
+	NetworkGlobalIndexManager globalIdx ;
+
 	public SolrIndexBuilder () throws NdexException, SolrServerException, IOException {
-		  globalIdx = new NetworkGlobalIndexManager();
-	      globalIdx.createCoreIfNotExists();
-		
+		globalIdx = new NetworkGlobalIndexManager();
+		globalIdx.createCoreIfNotExists();
+
 	}
-	
-	
-	private  void rebuildNetworkIndex (UUID networkid, boolean ignoreDeletion ) throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
+
+
+	private void rebuildNetworkIndex (UUID networkid, boolean ignoreDeletion ) throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO()) {
-		  logger.info("Rebuild solr index of network " + networkid);
-		  NetworkSummary summary = dao.getNetworkSummaryById(networkid);
-		  if (summary == null)
-			  throw new NdexException ("Network "+ networkid + " not found in the server." );
-		  
-		  dao.lockNetwork(networkid);
-		  try (SingleNetworkSolrIdxManager idx2 = new SingleNetworkSolrIdxManager(networkid.toString())) {
-		  
-			  if (!ignoreDeletion) {
-				try {
-					globalIdx.deleteNetwork(networkid.toString());
-					globalIdx.commit();
-					idx2.dropIndex();
-				} catch (IOException | SolrServerException | NdexException e) {
-					e.printStackTrace();
-					logger.warn("Warning: Failed to delete node Index for network " + networkid.toString());
+			logger.info("Rebuild solr index of network " + networkid);
+			NetworkSummary summary = dao.getNetworkSummaryById(networkid);
+			if (summary == null)
+				throw new NdexException ("Network "+ networkid + " not found in the server." );
+
+			dao.lockNetwork(networkid);
+			try (SingleNetworkSolrIdxManager idx2 = new SingleNetworkSolrIdxManager(networkid.toString())) {
+
+				if (!ignoreDeletion) {
+					try {
+						globalIdx.deleteNetwork(networkid.toString());
+						globalIdx.commit();
+						idx2.dropIndex();
+					} catch (IOException | SolrServerException | NdexException e) {
+						e.printStackTrace();
+						logger.warn("Warning: Failed to delete node Index for network " + networkid.toString());
+					}
+
 				}
-				
-			  }		
-			  if (summary.getNodeCount() >= SingleNetworkSolrIdxManager.AUTOCREATE_THRESHHOLD ) {
-					
+				if (summary.getNodeCount() >= SingleNetworkSolrIdxManager.AUTOCREATE_THRESHHOLD ) {
+
 					idx2.createIndex(null);
 					idx2.close();
-				
-				    logger.info("Solr index for query created.");
-			  } 
-		  
-			  if ( summary.getIndexLevel() != NetworkIndexLevel.NONE) {
-				  // build the solr document obj
-				  List<Map<Permissions, Collection<String>>> permissionTable =  dao.getAllMembershipsOnNetwork(networkid);
-				  Map<Permissions,Collection<String>> userMemberships = permissionTable.get(0);
-				  Map<Permissions,Collection<String>> grpMemberships = permissionTable.get(1);
-				  globalIdx.createIndexDocFromSummary(summary,summary.getOwner(),
-					userMemberships.get(Permissions.READ),
-					userMemberships.get(Permissions.WRITE),
-					grpMemberships.get(Permissions.READ),
-					grpMemberships.get(Permissions.WRITE));
 
-				  //process node attribute aspect and add to solr doc
-				  String pathPrefix = Configuration.getInstance().getNdexRoot() + "/data/" ; 
-			
-				  try (AspectIterator<NetworkAttributesElement> it = new AspectIterator<>(networkid.toString(), 
-					  NetworkAttributesElement.ASPECT_NAME, NetworkAttributesElement.class, pathPrefix)) {
-					  while (it.hasNext()) {
-						  NetworkAttributesElement e = it.next();
-					
-						  List<String> indexWarnings = globalIdx.addCXNetworkAttrToIndex(e);	
-						  if ( !indexWarnings.isEmpty())
-							  for (String warning : indexWarnings) 
-								  System.err.println("Warning: " + warning);
-					
-					  }
-				  }
+					logger.info("Solr index for query created.");
+				}
 
-		  
-				  if (summary.getIndexLevel() == NetworkIndexLevel.ALL) {	
-					  try (AspectIterator<FunctionTermElement> it = new AspectIterator<>(networkid.toString(), 
-							  FunctionTermElement.ASPECT_NAME, FunctionTermElement.class, pathPrefix)) {
-						  while (it.hasNext()) {
-							  FunctionTermElement fun = it.next();
-					
-							  globalIdx.addFunctionTermToIndex(fun);
+				if ( summary.getIndexLevel() != NetworkIndexLevel.NONE) {
+					// build the solr document obj
+					List<Map<Permissions, Collection<String>>> permissionTable = dao.getAllMembershipsOnNetwork(networkid);
+					Map<Permissions,Collection<String>> userMemberships = permissionTable.get(0);
+					Map<Permissions,Collection<String>> grpMemberships = permissionTable.get(1);
+					globalIdx.createIndexDocFromSummary(summary,summary.getOwner(),
+							userMemberships.get(Permissions.READ),
+							userMemberships.get(Permissions.WRITE),
+							grpMemberships.get(Permissions.READ),
+							grpMemberships.get(Permissions.WRITE));
 
-						  }
-					  }
+					//process node attribute aspect and add to solr doc
+					String pathPrefix = Configuration.getInstance().getNdexRoot() + "/data/" ;
 
-					  try (AspectIterator<NodeAttributesElement> it = new AspectIterator<>(networkid.toString(), 
-						  NodeAttributesElement.ASPECT_NAME, NodeAttributesElement.class, pathPrefix)) {
-						  while (it.hasNext()) {
-							  NodeAttributesElement e = it.next();					
-							  globalIdx.addCXNodeAttrToIndex(e);	
-						  }
-					  }
+					try (AspectIterator<NetworkAttributesElement> it = new AspectIterator<>(networkid.toString(),
+							NetworkAttributesElement.ASPECT_NAME, NetworkAttributesElement.class, pathPrefix)) {
+						while (it.hasNext()) {
+							NetworkAttributesElement e = it.next();
 
-					  try (AspectIterator<NodesElement> it = new AspectIterator<>(networkid.toString(), 
-							  NodesElement.ASPECT_NAME, NodesElement.class, pathPrefix)) {
-						  while (it.hasNext()) {
-							  NodesElement e = it.next();					
-							  globalIdx.addCXNodeToIndex(e);	
-						  }
-					  }
-						
-				  }	
-				  globalIdx.commit();
+							List<String> indexWarnings = globalIdx.addCXNetworkAttrToIndex(e);
+							if ( !indexWarnings.isEmpty())
+								for (String warning : indexWarnings)
+									System.err.println("Warning: " + warning);
 
-				  logger.info("Solr index of network " + networkid + " created.");
-			  } 
-		  } finally {
-			  dao.unlockNetwork(networkid);
-		  }	 
-		}  
+						}
+					}
+
+
+					if (summary.getIndexLevel() == NetworkIndexLevel.ALL) {
+						try (AspectIterator<FunctionTermElement> it = new AspectIterator<>(networkid.toString(),
+								FunctionTermElement.ASPECT_NAME, FunctionTermElement.class, pathPrefix)) {
+							while (it.hasNext()) {
+								FunctionTermElement fun = it.next();
+
+								globalIdx.addFunctionTermToIndex(fun);
+
+							}
+						}
+
+						try (AspectIterator<NodeAttributesElement> it = new AspectIterator<>(networkid.toString(),
+								NodeAttributesElement.ASPECT_NAME, NodeAttributesElement.class, pathPrefix)) {
+							while (it.hasNext()) {
+								NodeAttributesElement e = it.next();
+								globalIdx.addCXNodeAttrToIndex(e);
+							}
+						}
+
+						try (AspectIterator<NodesElement> it = new AspectIterator<>(networkid.toString(),
+								NodesElement.ASPECT_NAME, NodesElement.class, pathPrefix)) {
+							while (it.hasNext()) {
+								NodesElement e = it.next();
+								globalIdx.addCXNodeToIndex(e);
+							}
+						}
+
+					}
+					globalIdx.commit();
+
+					logger.info("Solr index of network " + networkid + " created.");
+				}
+			} finally {
+				dao.unlockNetwork(networkid);
+			}
+		}
 	}
-	
-	
-	private  void rebuildNetworkIndexInGlobalIdx (UUID networkid , boolean ignoreDeletion ) throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
+
+
+	private void rebuildNetworkIndexInGlobalIdx (UUID networkid , boolean ignoreDeletion ) throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO()) {
 			logger.info("Rebuild global index of network " +networkid);
-		 
-			 NetworkSummary summary = dao.getNetworkSummaryById(networkid);
-			 if (summary == null)
-				  throw new NdexException ("Network "+ networkid + " not found in the server." );
-			  			
+
+			NetworkSummary summary = dao.getNetworkSummaryById(networkid);
+			if (summary == null)
+				throw new NdexException ("Network "+ networkid + " not found in the server." );
+
 			//dao.lockNetwork(networkid);
-		  
+
 			if (!ignoreDeletion) {
 				try {
 					globalIdx.deleteNetwork(networkid.toString());
@@ -163,267 +168,267 @@ public class SolrIndexBuilder implements AutoCloseable {
 					e.printStackTrace();
 					logger.warn("Warning: Failed to delete node Index for network " + networkid.toString());
 				}
-				
-			 }		
-		  
-			 if ( summary.getIndexLevel() != NetworkIndexLevel.NONE) {
-				  // build the solr document obj
-				  List<Map<Permissions, Collection<String>>> permissionTable =  dao.getAllMembershipsOnNetwork(networkid);
-				  Map<Permissions,Collection<String>> userMemberships = permissionTable.get(0);
-				  Map<Permissions,Collection<String>> grpMemberships = permissionTable.get(1);
-				  globalIdx.createIndexDocFromSummary(summary,summary.getOwner(),
-					userMemberships.get(Permissions.READ),
-					userMemberships.get(Permissions.WRITE),
-					grpMemberships.get(Permissions.READ),
-					grpMemberships.get(Permissions.WRITE));
 
-				  //process node attribute aspect and add to solr doc
-				  String pathPrefix = Configuration.getInstance().getNdexRoot() + "/data/" ; 
-			
-				  try (AspectIterator<NetworkAttributesElement> it = new AspectIterator<>(networkid.toString(), 
-					  NetworkAttributesElement.ASPECT_NAME, NetworkAttributesElement.class, pathPrefix)) {
-					  while (it.hasNext()) {
-						  NetworkAttributesElement e = it.next();
-					
-						  List<String> indexWarnings = globalIdx.addCXNetworkAttrToIndex(e);	
-						  if ( !indexWarnings.isEmpty())
-							  for (String warning : indexWarnings) 
-								  System.err.println("Warning: " + warning);
-					
-					  }
-				  }
-	  
-				  if (summary.getIndexLevel() == NetworkIndexLevel.ALL) {	
-					  try (AspectIterator<FunctionTermElement> it = new AspectIterator<>(networkid.toString(), 
-							  FunctionTermElement.ASPECT_NAME, FunctionTermElement.class, pathPrefix)) {
-						  while (it.hasNext()) {
-							  FunctionTermElement fun = it.next();
-					
-							  globalIdx.addFunctionTermToIndex(fun);
+			}
 
-						  }
-					  }
+			if ( summary.getIndexLevel() != NetworkIndexLevel.NONE) {
+				// build the solr document obj
+				List<Map<Permissions, Collection<String>>> permissionTable = dao.getAllMembershipsOnNetwork(networkid);
+				Map<Permissions,Collection<String>> userMemberships = permissionTable.get(0);
+				Map<Permissions,Collection<String>> grpMemberships = permissionTable.get(1);
+				globalIdx.createIndexDocFromSummary(summary,summary.getOwner(),
+						userMemberships.get(Permissions.READ),
+						userMemberships.get(Permissions.WRITE),
+						grpMemberships.get(Permissions.READ),
+						grpMemberships.get(Permissions.WRITE));
 
-					  try (AspectIterator<NodeAttributesElement> it = new AspectIterator<>(networkid.toString(), 
-						  NodeAttributesElement.ASPECT_NAME, NodeAttributesElement.class, pathPrefix)) {
-						  while (it.hasNext()) {
-							  NodeAttributesElement e = it.next();					
-							  globalIdx.addCXNodeAttrToIndex(e);	
-						  }
-					  }
+				//process node attribute aspect and add to solr doc
+				String pathPrefix = Configuration.getInstance().getNdexRoot() + "/data/" ;
 
-					  try (AspectIterator<NodesElement> it = new AspectIterator<>(networkid.toString(), 
-							  NodesElement.ASPECT_NAME, NodesElement.class, pathPrefix)) {
-						  while (it.hasNext()) {
-							  NodesElement e = it.next();					
-							  globalIdx.addCXNodeToIndex(e);	
-						  }
-					  }
-						
-				  }	
-				  globalIdx.commit();
-			
-				 // dao.unlockNetwork(networkid);
-				  logger.info("Solr index of network " + networkid + " created.");
-			  } 
-		  	 
-		}  
-	}
-	
-	
-	private static  void rebuildLocalNetworkIndex (UUID networkid, boolean ignoreDeletion ) throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
-		try (PostgresNetworkDAO dao = new PostgresNetworkDAO()) {
-		  logger.info("Rebuild local index of " + networkid);
-		  NetworkSummary summary = dao.getNetworkSummaryById(networkid);
-		  if (summary == null)
-			  throw new NdexException ("Network "+ networkid + " not found in the server." );
-		  
-		  //dao.lockNetwork(networkid);
-		  try (SingleNetworkSolrIdxManager idx2 = new SingleNetworkSolrIdxManager(networkid.toString())) {
-		  
-			  if (!ignoreDeletion) {
-				try {
-					idx2.dropIndex();
-				} catch (IOException | SolrServerException | NdexException e) {
-					e.printStackTrace();
-					logger.warn("Warning: Failed to delete node Index for network " + networkid.toString());
+				try (AspectIterator<NetworkAttributesElement> it = new AspectIterator<>(networkid.toString(),
+						NetworkAttributesElement.ASPECT_NAME, NetworkAttributesElement.class, pathPrefix)) {
+					while (it.hasNext()) {
+						NetworkAttributesElement e = it.next();
+
+						List<String> indexWarnings = globalIdx.addCXNetworkAttrToIndex(e);
+						if ( !indexWarnings.isEmpty())
+							for (String warning : indexWarnings)
+								System.err.println("Warning: " + warning);
+
+					}
 				}
-				
-			  }		
-			  if (summary.getNodeCount() >= SingleNetworkSolrIdxManager.AUTOCREATE_THRESHHOLD ) {
-					
+
+				if (summary.getIndexLevel() == NetworkIndexLevel.ALL) {
+					try (AspectIterator<FunctionTermElement> it = new AspectIterator<>(networkid.toString(),
+							FunctionTermElement.ASPECT_NAME, FunctionTermElement.class, pathPrefix)) {
+						while (it.hasNext()) {
+							FunctionTermElement fun = it.next();
+
+							globalIdx.addFunctionTermToIndex(fun);
+
+						}
+					}
+
+					try (AspectIterator<NodeAttributesElement> it = new AspectIterator<>(networkid.toString(),
+							NodeAttributesElement.ASPECT_NAME, NodeAttributesElement.class, pathPrefix)) {
+						while (it.hasNext()) {
+							NodeAttributesElement e = it.next();
+							globalIdx.addCXNodeAttrToIndex(e);
+						}
+					}
+
+					try (AspectIterator<NodesElement> it = new AspectIterator<>(networkid.toString(),
+							NodesElement.ASPECT_NAME, NodesElement.class, pathPrefix)) {
+						while (it.hasNext()) {
+							NodesElement e = it.next();
+							globalIdx.addCXNodeToIndex(e);
+						}
+					}
+
+				}
+				globalIdx.commit();
+
+				// dao.unlockNetwork(networkid);
+				logger.info("Solr index of network " + networkid + " created.");
+			}
+
+		}
+	}
+
+
+	private static void rebuildLocalNetworkIndex (UUID networkid, boolean ignoreDeletion ) throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
+		try (PostgresNetworkDAO dao = new PostgresNetworkDAO()) {
+			logger.info("Rebuild local index of " + networkid);
+			NetworkSummary summary = dao.getNetworkSummaryById(networkid);
+			if (summary == null)
+				throw new NdexException ("Network "+ networkid + " not found in the server." );
+
+			//dao.lockNetwork(networkid);
+			try (SingleNetworkSolrIdxManager idx2 = new SingleNetworkSolrIdxManager(networkid.toString())) {
+
+				if (!ignoreDeletion) {
+					try {
+						idx2.dropIndex();
+					} catch (IOException | SolrServerException | NdexException e) {
+						e.printStackTrace();
+						logger.warn("Warning: Failed to delete node Index for network " + networkid.toString());
+					}
+
+				}
+				if (summary.getNodeCount() >= SingleNetworkSolrIdxManager.AUTOCREATE_THRESHHOLD ) {
+
 					idx2.createIndex(null);
 					idx2.close();
-				
-				    logger.info("Solr index for query created.");
-			  }   			 	
-			
-		  }	 
-		  //dao.unlockNetwork(networkid);
 
-		}  
+					logger.info("Solr index for query created.");
+				}
+
+			}
+			//dao.unlockNetwork(networkid);
+
+		}
 	}
 
-	
-	
-	private  void rebuildAll() throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
+
+
+	private void rebuildAll() throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO ()) {
 			@SuppressWarnings("resource")
 			Connection db = dao.getDBConnection();
 			String sqlStr = "select \"UUID\" from network n where n.iscomplete and n.is_deleted=false and n.is_validated and n.islocked=false and n.error is null";
-			
+
 			int i = 0;
 			try (PreparedStatement pst = db.prepareStatement(sqlStr)) {
 				try ( ResultSet rs = pst.executeQuery()) {
 					while (rs.next()) {
-				       //int nodeCount = rs.getInt(2);
-					   rebuildNetworkIndex((UUID)rs.getObject(1), true);
-					   i ++;
-					   if ( i % 500 == 0 ) {
-						   System.err.println("Loaded " + i + " records to solr. sleep 2 seconds");
-						//   globalIdx.commit();
-						   try {
-							  Thread.sleep(2000);
-						   } catch (InterruptedException e) {
-							  // TODO Auto-generated catch block
-							  e.printStackTrace();
-						   }
-					   }	   
+						//int nodeCount = rs.getInt(2);
+						rebuildNetworkIndex((UUID)rs.getObject(1), true);
+						i ++;
+						if ( i % 500 == 0 ) {
+							System.err.println("Loaded " + i + " records to solr. sleep 2 seconds");
+							// globalIdx.commit();
+							try {
+								Thread.sleep(2000);
+							} catch (InterruptedException e) {
+								// TODO Auto-generated catch block
+								e.printStackTrace();
+							}
+						}
 					}
 				}
 			}
 		}
-	//	globalIdx.commit();
+		// globalIdx.commit();
 		logger.info("Indexes of all networks have been rebuilt.");
 	}
-	
 
-	private  void rebuildGlobalIdx() throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
+
+	private void rebuildGlobalIdx() throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO ()) {
 			@SuppressWarnings("resource")
 			Connection db = dao.getDBConnection();
 			String sqlStr = "select \"UUID\" from network n where n.iscomplete and n.is_deleted=false and n.is_validated and n.islocked=false and n.error is null";
-			
+
 			int i = 0;
 			try (PreparedStatement pst = db.prepareStatement(sqlStr)) {
 				try ( ResultSet rs = pst.executeQuery()) {
 					while (rs.next()) {
-				       //int nodeCount = rs.getInt(2);
+						//int nodeCount = rs.getInt(2);
 						rebuildNetworkIndexInGlobalIdx((UUID)rs.getObject(1), true);
-					   i ++;
-					   if ( i % 1000 == 0 ) {
-						   System.err.println("Loaded " + i + " records to solr. sleep 2 seconds");
-						//   globalIdx.commit();
-						   try {
-							  Thread.sleep(2000);
-						   } catch (InterruptedException e) {
-							  // TODO Auto-generated catch block
-							  e.printStackTrace();
-						   }
-					   }	   
+						i ++;
+						if ( i % 1000 == 0 ) {
+							System.err.println("Loaded " + i + " records to solr. sleep 2 seconds");
+							// globalIdx.commit();
+							try {
+								Thread.sleep(2000);
+							} catch (InterruptedException e) {
+								// TODO Auto-generated catch block
+								e.printStackTrace();
+							}
+						}
 					}
 				}
 			}
 		}
-	//	globalIdx.commit();
+		// globalIdx.commit();
 		logger.info("Indexes of all networks have been rebuilt.");
 	}
-	
 
-	private static  void rebuildAllLocalIdx() throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
+
+	private static void rebuildAllLocalIdx() throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO ()) {
 			@SuppressWarnings("resource")
 			Connection db = dao.getDBConnection();
-			String sqlStr = "select \"UUID\" from network n where n.iscomplete and n.is_deleted=false and n.is_validated and n.islocked=false and n.error is null and cx2_file_size is not null and nodecount >= " 
+			String sqlStr = "select \"UUID\" from network n where n.iscomplete and n.is_deleted=false and n.is_validated and n.islocked=false and n.error is null and cx2_file_size is not null and nodecount >= "
 					+ SingleNetworkSolrIdxManager.AUTOCREATE_THRESHHOLD ;
-			
+
 			int i = 0;
-			int j = 0; 
+			int j = 0;
 			try (PreparedStatement pst = db.prepareStatement(sqlStr)) {
 				try ( ResultSet rs = pst.executeQuery()) {
 					while (rs.next()) {
-				       //int nodeCount = rs.getInt(2);
+						//int nodeCount = rs.getInt(2);
 						UUID netid = (UUID)rs.getObject(1);
 						try {
 							rebuildLocalNetworkIndex(netid, true);
 							j++;
 						} catch (HttpSolrClient.RemoteSolrException e4) {
 							if ( e4.getMessage().indexOf("Core with name '"+
-						             netid.toString() +  "' already exists") == -1) {
+									netid.toString() + "' already exists") == -1) {
 								e4.printStackTrace();
 								throw new NdexException("Unexpected Solr Exception: " + e4.getMessage());
-							}	
+							}
 							logger.info("index exists. Ignore creating it.");
-						} 
-					   i ++;
-					   if ( i % 500 == 0 ) {
-						   System.err.println("Loaded " + i + " records to solr. sleep 2 seconds");
-						//   globalIdx.commit();
-						   try {
-							  Thread.sleep(2000);
-						   } catch (InterruptedException e) {
-							  // TODO Auto-generated catch block
-							  e.printStackTrace();
-						   }
-					   }	   
+						}
+						i ++;
+						if ( i % 500 == 0 ) {
+							System.err.println("Loaded " + i + " records to solr. sleep 2 seconds");
+							// globalIdx.commit();
+							try {
+								Thread.sleep(2000);
+							} catch (InterruptedException e) {
+								// TODO Auto-generated catch block
+								e.printStackTrace();
+							}
+						}
 					}
 				}
 			}
 			logger.info("Local index of " + i + " networks have been checked. " + j + " are created." );
 		}
-	//	globalIdx.commit();
+		// globalIdx.commit();
 	}
 
-	
-	private  void rebuildAllNetworksOnline() throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
+
+	private void rebuildAllNetworksOnline() throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO ()) {
 			@SuppressWarnings("resource")
 			Connection db = dao.getDBConnection();
 			String sqlStr = "select \"UUID\" from network n where n.iscomplete and n.is_deleted=false and n.is_validated and n.error is null";
-			
+
 			int i = 0;
 			try (PreparedStatement pst = db.prepareStatement(sqlStr)) {
 				try ( ResultSet rs = pst.executeQuery()) {
 					while (rs.next()) {
-				       //int nodeCount = rs.getInt(2);
-					   UUID networkId = (UUID)rs.getObject(1);
-					   try {
-						   
-						   rebuildNetworkIndex(networkId, false);
-					   } catch(Exception ex){
-						   logger.error("Failed to rebuild index for network: " + networkId.toString());
-					   }
-					   i ++;
-					   if ( i % 500 == 0 ) {
-						   System.err.println("Loaded " + i + " records to solr. sleep 2 seconds");
-						//   globalIdx.commit();
-						   try {
-							  Thread.sleep(2000);
-						   } catch (InterruptedException e) {
-							  // TODO Auto-generated catch block
-							  e.printStackTrace();
-						   }
-					   }	   
+						//int nodeCount = rs.getInt(2);
+						UUID networkId = (UUID)rs.getObject(1);
+						try {
+
+							rebuildNetworkIndex(networkId, false);
+						} catch(Exception ex){
+							logger.error("Failed to rebuild index for network: " + networkId.toString());
+						}
+						i ++;
+						if ( i % 500 == 0 ) {
+							System.err.println("Loaded " + i + " records to solr. sleep 2 seconds");
+							// globalIdx.commit();
+							try {
+								Thread.sleep(2000);
+							} catch (InterruptedException e) {
+								// TODO Auto-generated catch block
+								e.printStackTrace();
+							}
+						}
 					}
 				}
 			}
 		}
-	//	globalIdx.commit();
+		// globalIdx.commit();
 		logger.info("Indexes of all networks have been rebuilt.");
 	}
 
-	
-	private  void rebuildSingleNetworkIndex (UUID networkid) throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
+
+	private void rebuildSingleNetworkIndex (UUID networkid) throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO()) {
-		  logger.info("Rebuild solr index of network " + networkid);
-		  NetworkSummary summary = dao.getNetworkSummaryById(networkid);
-		  if (summary == null)
-			  throw new NdexException ("Network "+ networkid + " not found in the server." );
-		  
-		  rebuildNetworkIndex(networkid, false);
-		}  
-	}	  
-	
+			logger.info("Rebuild solr index of network " + networkid);
+			NetworkSummary summary = dao.getNetworkSummaryById(networkid);
+			if (summary == null)
+				throw new NdexException ("Network "+ networkid + " not found in the server." );
+
+			rebuildNetworkIndex(networkid, false);
+		}
+	}
+
 	private static void rebuildUserIndex() throws Exception {
 		logger.info("Start rebuild user index.");
 		try (UserIndexManager umgr = new UserIndexManager()) {
@@ -456,23 +461,23 @@ public class SolrIndexBuilder implements AutoCloseable {
 		}
 		logger.info("User index has been rebuilt.");
 	}
-	
+
 	private static void rebuildGroupIndex() throws Exception {
 		logger.info("Start rebuild group index.");
 		try (GroupIndexManager umgr = new GroupIndexManager()) {
 
 			umgr.createCoreIfNotExists();
-		/*	String coreName = GroupIndexManager.coreName;
-			CoreAdminRequest.Create creator = new CoreAdminRequest.Create();
-			creator.setCoreName(coreName);
-			creator.setConfigSet(coreName);
-			CoreAdminResponse foo = creator.process(umgr.client);
+ /* String coreName = GroupIndexManager.coreName;
+ CoreAdminRequest.Create creator = new CoreAdminRequest.Create();
+ creator.setCoreName(coreName);
+ creator.setConfigSet(coreName);
+ CoreAdminResponse foo = creator.process(umgr.client);
 
-			if (foo.getStatus() != 0) {
-				throw new NdexException("Failed to create solrIndex for " + coreName + ". Error: "
-						+ foo.getResponseHeader().toString());
-			}
-			logger.info("Solr core " + coreName + " created.");*/
+ if (foo.getStatus() != 0) {
+ throw new NdexException("Failed to create solrIndex for " + coreName + ". Error: "
+ + foo.getResponseHeader().toString());
+ }
+ logger.info("Solr core " + coreName + " created.");*/
 
 
 			try (GroupDAO dao = new GroupDAO()) {
@@ -500,61 +505,150 @@ public class SolrIndexBuilder implements AutoCloseable {
 					}
 				}
 			}
-			
+
 			logger.info("Group index has been rebuilt.");
 		}
 	}
-	
-	private static void rebuildNFSIdx(){
-		
+	/**
+	 * Find all networks where visibility='PUBLIC' and solr_idx_lvl='NONE',
+	 * flip them to UNLISTED in Postgres, and queue Solr delete+rebuild tasks
+	 * so the file index moves from public-nfs to private-nfs.
+	 *
+	 * Per-network commit; on failure the current network is rolled back and
+	 * the loop continues. Already-processed networks remain UNLISTED.
+	 */
+	private static void unlistPublicNoneNetworks() throws SQLException, NdexException, IOException {
+		logger.info("Finding PUBLIC networks with solr_idx_lvl='NONE'...");
+
+		try (PostgresNetworkDAO dao = new PostgresNetworkDAO()) {
+			@SuppressWarnings("resource")
+			Connection db = dao.getDBConnection();
+			boolean priorAutoCommit = db.getAutoCommit();
+			db.setAutoCommit(false);
+
+			int total = 0;
+			int processed = 0;
+			int failed = 0;
+
+			try {
+				// 1. Collect targets (UUID, ownerId, ownerName) up front so the iterating
+				// ResultSet isn't held open across writes/commits.
+				List<Object[]> targets = new java.util.ArrayList<>();
+				String selectSql = "SELECT \"UUID\", owneruuid, \"owner\" FROM network "
+						+ "WHERE visibility = 'PUBLIC' AND solr_idx_lvl = 'NONE' AND is_deleted = false";
+				try (PreparedStatement pst = db.prepareStatement(selectSql);
+					 ResultSet rs = pst.executeQuery()) {
+					while (rs.next()) {
+						targets.add(new Object[] {
+								(UUID) rs.getObject(1),
+								(UUID) rs.getObject(2),
+								rs.getString(3)
+						});
+					}
+				}
+				total = targets.size();
+				logger.info("Found {} networks to convert from PUBLIC to UNLISTED.", total);
+				if (total == 0) {
+					db.commit();
+					return;
+				}
+
+				String updateSql = "UPDATE network SET visibility = 'UNLISTED' WHERE \"UUID\" = ?";
+				try (PreparedStatement updatePst = db.prepareStatement(updateSql)) {
+					for (Object[] row : targets) {
+						UUID networkId = (UUID) row[0];
+						UUID ownerId = (UUID) row[1];
+						String ownerName = (String) row[2];
+
+						try {
+							// 2. DB: flip visibility
+							updatePst.setObject(1, networkId);
+							int rows = updatePst.executeUpdate();
+							if (rows != 1) {
+								throw new NdexException("Expected 1 row updated for " + networkId
+										+ " but got " + rows);
+							}
+							db.commit();
+
+							// 3. Solr: delete from public-nfs, rebuild in private-nfs.
+							// ignoreCxFiles=true because these networks have solr_idx_lvl=NONE
+							// and may not have CX aspect files on disk to index from.
+							new SolrTaskDeleteFile(networkId, VisibilityType.PUBLIC).run();
+							new SolrTaskRebuildFileIdx(networkId, ownerId, ownerName,
+									VisibilityType.UNLISTED, FileType.NETWORK, false, true).run();
+
+							processed++;
+							if (processed % 500 == 0) {
+								logger.info("Processed {}/{} ({}%)",
+										processed, total, (processed * 100) / total);
+							}
+						} catch (Exception e) {
+							db.rollback();
+							failed++;
+							logger.error("Failed to convert network {}: {}", networkId, e.getMessage(), e);
+						}
+					}
+				}
+				logger.info("Done. processed={}, failed={}, total={}", processed, failed, total);
+			} finally {
+				db.setAutoCommit(priorAutoCommit);
+			}
+		}
 	}
-	
+
+	private static void rebuildNFSIdx(){
+
+	}
+
 	public static void main(String[] args) throws Exception {
-	//	SolrIndexBuilder i = new SolrIndexBuider();
+		// SolrIndexBuilder i = new SolrIndexBuider();
 		Configuration configuration = Configuration.createInstance();
 
 		NdexDatabase.createNdexDatabase(configuration.getDBURL(), configuration.getDBUser(),
 				configuration.getDBPasswd(), 10);
-	
+
 		try (SolrIndexBuilder builder = new SolrIndexBuilder()) {
-		if ( args.length == 1) {
-			switch ( args[0]) {
-			case "all":
-				SolrIndexBuilder.rebuildUserIndex();
-				SolrIndexBuilder.rebuildGroupIndex();
-				builder.rebuildAll();
-				break;
-			case "user":
-				SolrIndexBuilder.rebuildUserIndex();
-				break;
-			case "group":
-				SolrIndexBuilder.rebuildGroupIndex();
-				break;
-			case "all-networks-online":
-				builder.rebuildAllNetworksOnline();
-				break;
-			case "global-networks":
-				builder.rebuildGlobalIdx();
-				break;
-			case "all-local":
-				SolrIndexBuilder.rebuildAllLocalIdx();
-				break;
-			case "nfs":
-				SolrIndexBuilder.rebuildNFSIdx();
-				break;
-			default:	
-				builder.rebuildSingleNetworkIndex(UUID.fromString(args[0]));
-				builder.globalIdx.commit();
-				
+			if ( args.length == 1) {
+				switch ( args[0]) {
+					case "all":
+						SolrIndexBuilder.rebuildUserIndex();
+						SolrIndexBuilder.rebuildGroupIndex();
+						builder.rebuildAll();
+						break;
+					case "user":
+						SolrIndexBuilder.rebuildUserIndex();
+						break;
+					case "group":
+						SolrIndexBuilder.rebuildGroupIndex();
+						break;
+					case "all-networks-online":
+						builder.rebuildAllNetworksOnline();
+						break;
+					case "global-networks":
+						builder.rebuildGlobalIdx();
+						break;
+					case "all-local":
+						SolrIndexBuilder.rebuildAllLocalIdx();
+						break;
+					case "nfs":
+						SolrIndexBuilder.rebuildNFSIdx();
+						break;
+					case "unlist-public-none":
+						SolrIndexBuilder.unlistPublicNoneNetworks();
+						break;
+					default:
+						builder.rebuildSingleNetworkIndex(UUID.fromString(args[0]));
+						builder.globalIdx.commit();
+
+				}
+				logger.info("Index rebuild process finished.");
+			} else {
+				System.err.println("Supported argument: all/nfs/user/group/all-networks-online/global-networks/all-local/<networkUUID>");
+				//System.out.println("For the boolean argument after network ID, true means rebuild the Single Network index.");
 			}
-			logger.info("Index rebuild process finished.");
-		} else {
-			System.err.println("Supported argument: all/nfs/user/group/all-networks-online/global-networks/all-local/<networkUUID>");
-			//System.out.println("For the boolean argument after network ID, true means rebuild the Single Network index.");
+
 		}
-		
-		}
-		
+
 	}
 
 
@@ -564,3 +658,4 @@ public class SolrIndexBuilder implements AutoCloseable {
 	}
 
 }
+

--- a/src/main/java/org/ndexbio/common/solr/SolrIndexBuilder.java
+++ b/src/main/java/org/ndexbio/common/solr/SolrIndexBuilder.java
@@ -32,7 +32,6 @@ import org.ndexbio.model.object.network.NetworkIndexLevel;
 import org.ndexbio.model.object.network.NetworkSummary;
 import org.ndexbio.model.object.network.VisibilityType;
 import org.ndexbio.rest.Configuration;
-import org.ndexbio.task.NdexServerQueue;
 import org.ndexbio.task.SolrTaskDeleteFile;
 import org.ndexbio.task.SolrTaskRebuildFileIdx;
 import org.slf4j.Logger;
@@ -54,7 +53,7 @@ public class SolrIndexBuilder implements AutoCloseable {
 	}
 
 
-	private void rebuildNetworkIndex (UUID networkid, boolean ignoreDeletion ) throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
+	private  void rebuildNetworkIndex (UUID networkid, boolean ignoreDeletion ) throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO()) {
 			logger.info("Rebuild solr index of network " + networkid);
 			NetworkSummary summary = dao.getNetworkSummaryById(networkid);
@@ -85,7 +84,7 @@ public class SolrIndexBuilder implements AutoCloseable {
 
 				if ( summary.getIndexLevel() != NetworkIndexLevel.NONE) {
 					// build the solr document obj
-					List<Map<Permissions, Collection<String>>> permissionTable = dao.getAllMembershipsOnNetwork(networkid);
+					List<Map<Permissions, Collection<String>>> permissionTable =  dao.getAllMembershipsOnNetwork(networkid);
 					Map<Permissions,Collection<String>> userMemberships = permissionTable.get(0);
 					Map<Permissions,Collection<String>> grpMemberships = permissionTable.get(1);
 					globalIdx.createIndexDocFromSummary(summary,summary.getOwner(),
@@ -150,7 +149,7 @@ public class SolrIndexBuilder implements AutoCloseable {
 	}
 
 
-	private void rebuildNetworkIndexInGlobalIdx (UUID networkid , boolean ignoreDeletion ) throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
+	private  void rebuildNetworkIndexInGlobalIdx (UUID networkid , boolean ignoreDeletion ) throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO()) {
 			logger.info("Rebuild global index of network " +networkid);
 
@@ -173,7 +172,7 @@ public class SolrIndexBuilder implements AutoCloseable {
 
 			if ( summary.getIndexLevel() != NetworkIndexLevel.NONE) {
 				// build the solr document obj
-				List<Map<Permissions, Collection<String>>> permissionTable = dao.getAllMembershipsOnNetwork(networkid);
+				List<Map<Permissions, Collection<String>>> permissionTable =  dao.getAllMembershipsOnNetwork(networkid);
 				Map<Permissions,Collection<String>> userMemberships = permissionTable.get(0);
 				Map<Permissions,Collection<String>> grpMemberships = permissionTable.get(1);
 				globalIdx.createIndexDocFromSummary(summary,summary.getOwner(),
@@ -236,7 +235,7 @@ public class SolrIndexBuilder implements AutoCloseable {
 	}
 
 
-	private static void rebuildLocalNetworkIndex (UUID networkid, boolean ignoreDeletion ) throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
+	private static  void rebuildLocalNetworkIndex (UUID networkid, boolean ignoreDeletion ) throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO()) {
 			logger.info("Rebuild local index of " + networkid);
 			NetworkSummary summary = dao.getNetworkSummaryById(networkid);
@@ -271,7 +270,7 @@ public class SolrIndexBuilder implements AutoCloseable {
 
 
 
-	private void rebuildAll() throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
+	private  void rebuildAll() throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO ()) {
 			@SuppressWarnings("resource")
 			Connection db = dao.getDBConnection();
@@ -286,7 +285,7 @@ public class SolrIndexBuilder implements AutoCloseable {
 						i ++;
 						if ( i % 500 == 0 ) {
 							System.err.println("Loaded " + i + " records to solr. sleep 2 seconds");
-							// globalIdx.commit();
+							//   globalIdx.commit();
 							try {
 								Thread.sleep(2000);
 							} catch (InterruptedException e) {
@@ -298,12 +297,12 @@ public class SolrIndexBuilder implements AutoCloseable {
 				}
 			}
 		}
-		// globalIdx.commit();
+		//	globalIdx.commit();
 		logger.info("Indexes of all networks have been rebuilt.");
 	}
 
 
-	private void rebuildGlobalIdx() throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
+	private  void rebuildGlobalIdx() throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO ()) {
 			@SuppressWarnings("resource")
 			Connection db = dao.getDBConnection();
@@ -318,7 +317,7 @@ public class SolrIndexBuilder implements AutoCloseable {
 						i ++;
 						if ( i % 1000 == 0 ) {
 							System.err.println("Loaded " + i + " records to solr. sleep 2 seconds");
-							// globalIdx.commit();
+							//   globalIdx.commit();
 							try {
 								Thread.sleep(2000);
 							} catch (InterruptedException e) {
@@ -330,12 +329,12 @@ public class SolrIndexBuilder implements AutoCloseable {
 				}
 			}
 		}
-		// globalIdx.commit();
+		//	globalIdx.commit();
 		logger.info("Indexes of all networks have been rebuilt.");
 	}
 
 
-	private static void rebuildAllLocalIdx() throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
+	private static  void rebuildAllLocalIdx() throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO ()) {
 			@SuppressWarnings("resource")
 			Connection db = dao.getDBConnection();
@@ -354,7 +353,7 @@ public class SolrIndexBuilder implements AutoCloseable {
 							j++;
 						} catch (HttpSolrClient.RemoteSolrException e4) {
 							if ( e4.getMessage().indexOf("Core with name '"+
-									netid.toString() + "' already exists") == -1) {
+									netid.toString() +  "' already exists") == -1) {
 								e4.printStackTrace();
 								throw new NdexException("Unexpected Solr Exception: " + e4.getMessage());
 							}
@@ -363,7 +362,7 @@ public class SolrIndexBuilder implements AutoCloseable {
 						i ++;
 						if ( i % 500 == 0 ) {
 							System.err.println("Loaded " + i + " records to solr. sleep 2 seconds");
-							// globalIdx.commit();
+							//   globalIdx.commit();
 							try {
 								Thread.sleep(2000);
 							} catch (InterruptedException e) {
@@ -376,11 +375,11 @@ public class SolrIndexBuilder implements AutoCloseable {
 			}
 			logger.info("Local index of " + i + " networks have been checked. " + j + " are created." );
 		}
-		// globalIdx.commit();
+		//	globalIdx.commit();
 	}
 
 
-	private void rebuildAllNetworksOnline() throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
+	private  void rebuildAllNetworksOnline() throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO ()) {
 			@SuppressWarnings("resource")
 			Connection db = dao.getDBConnection();
@@ -401,7 +400,7 @@ public class SolrIndexBuilder implements AutoCloseable {
 						i ++;
 						if ( i % 500 == 0 ) {
 							System.err.println("Loaded " + i + " records to solr. sleep 2 seconds");
-							// globalIdx.commit();
+							//   globalIdx.commit();
 							try {
 								Thread.sleep(2000);
 							} catch (InterruptedException e) {
@@ -413,12 +412,12 @@ public class SolrIndexBuilder implements AutoCloseable {
 				}
 			}
 		}
-		// globalIdx.commit();
+		//	globalIdx.commit();
 		logger.info("Indexes of all networks have been rebuilt.");
 	}
 
 
-	private void rebuildSingleNetworkIndex (UUID networkid) throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
+	private  void rebuildSingleNetworkIndex (UUID networkid) throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO()) {
 			logger.info("Rebuild solr index of network " + networkid);
 			NetworkSummary summary = dao.getNetworkSummaryById(networkid);
@@ -467,17 +466,17 @@ public class SolrIndexBuilder implements AutoCloseable {
 		try (GroupIndexManager umgr = new GroupIndexManager()) {
 
 			umgr.createCoreIfNotExists();
- /* String coreName = GroupIndexManager.coreName;
- CoreAdminRequest.Create creator = new CoreAdminRequest.Create();
- creator.setCoreName(coreName);
- creator.setConfigSet(coreName);
- CoreAdminResponse foo = creator.process(umgr.client);
+		/*	String coreName = GroupIndexManager.coreName;
+			CoreAdminRequest.Create creator = new CoreAdminRequest.Create();
+			creator.setCoreName(coreName);
+			creator.setConfigSet(coreName);
+			CoreAdminResponse foo = creator.process(umgr.client);
 
- if (foo.getStatus() != 0) {
- throw new NdexException("Failed to create solrIndex for " + coreName + ". Error: "
- + foo.getResponseHeader().toString());
- }
- logger.info("Solr core " + coreName + " created.");*/
+			if (foo.getStatus() != 0) {
+				throw new NdexException("Failed to create solrIndex for " + coreName + ". Error: "
+						+ foo.getResponseHeader().toString());
+			}
+			logger.info("Solr core " + coreName + " created.");*/
 
 
 			try (GroupDAO dao = new GroupDAO()) {
@@ -511,11 +510,14 @@ public class SolrIndexBuilder implements AutoCloseable {
 	}
 	/**
 	 * Find all networks where visibility='PUBLIC' and solr_idx_lvl='NONE',
-	 * flip them to UNLISTED in Postgres, and queue Solr delete+rebuild tasks
-	 * so the file index moves from public-nfs to private-nfs.
+	 * flip them to UNLISTED in Postgres, and synchronously run Solr delete+rebuild
+	 * tasks so the file index moves from public-nfs to private-nfs.
 	 *
-	 * Per-network commit; on failure the current network is rolled back and
-	 * the loop continues. Already-processed networks remain UNLISTED.
+	 * Each network is locked for the duration of its conversion. The visibility
+	 * flip is committed before the Solr work runs; if a Solr step fails, a
+	 * compensating UPDATE restores the network to PUBLIC so Postgres and Solr do
+	 * not drift out of sync. The loop continues on failure; successfully
+	 * processed networks remain UNLISTED.
 	 */
 	private static void unlistPublicNoneNetworks() throws SQLException, NdexException, IOException {
 		logger.info("Finding PUBLIC networks with solr_idx_lvl='NONE'...");
@@ -532,7 +534,7 @@ public class SolrIndexBuilder implements AutoCloseable {
 
 			try {
 				// 1. Collect targets (UUID, ownerId, ownerName) up front so the iterating
-				// ResultSet isn't held open across writes/commits.
+				//    ResultSet isn't held open across writes/commits.
 				List<Object[]> targets = new java.util.ArrayList<>();
 				String selectSql = "SELECT \"UUID\", owneruuid, \"owner\" FROM network "
 						+ "WHERE visibility = 'PUBLIC' AND solr_idx_lvl = 'NONE' AND is_deleted = false";
@@ -557,35 +559,52 @@ public class SolrIndexBuilder implements AutoCloseable {
 				try (PreparedStatement updatePst = db.prepareStatement(updateSql)) {
 					for (Object[] row : targets) {
 						UUID networkId = (UUID) row[0];
-						UUID ownerId = (UUID) row[1];
+						UUID ownerId   = (UUID) row[1];
 						String ownerName = (String) row[2];
 
 						try {
-							// 2. DB: flip visibility
-							updatePst.setObject(1, networkId);
-							int rows = updatePst.executeUpdate();
-							if (rows != 1) {
-								throw new NdexException("Expected 1 row updated for " + networkId
-										+ " but got " + rows);
-							}
-							db.commit();
+							dao.lockNetwork(networkId);
+							try {
+								// 2. DB: flip visibility and commit.
+								updatePst.setObject(1, networkId);
+								int rows = updatePst.executeUpdate();
+								if (rows != 1) {
+									throw new NdexException("Expected 1 row updated for " + networkId
+											+ " but got " + rows);
+								}
+								db.commit();
 
-							// 3. Solr: delete from public-nfs, rebuild in private-nfs.
-							// ignoreCxFiles=true because these networks have solr_idx_lvl=NONE
-							// and may not have CX aspect files on disk to index from.
-							new SolrTaskDeleteFile(networkId, VisibilityType.PUBLIC).run();
-							new SolrTaskRebuildFileIdx(networkId, ownerId, ownerName,
-									VisibilityType.UNLISTED, FileType.NETWORK, false, true).run();
+								// 3. Solr: delete from public-nfs, rebuild in private-nfs.
+								//    ignoreCxFiles=true because these networks have solr_idx_lvl=NONE
+								//    and may not have CX aspect files on disk to index from.
+								new SolrTaskDeleteFile(networkId, VisibilityType.PUBLIC).run();
+								new SolrTaskRebuildFileIdx(networkId, ownerId, ownerName,
+										VisibilityType.UNLISTED, FileType.NETWORK, false, true).run();
 
-							processed++;
-							if (processed % 500 == 0) {
-								logger.info("Processed {}/{} ({}%)",
-										processed, total, (processed * 100) / total);
+								processed++;
+								if (processed % 500 == 0) {
+									logger.info("Processed {}/{} ({}%)",
+											processed, total, (processed * 100) / total);
+								}
+							} finally {
+								dao.unlockNetwork(networkId);
+								db.commit();
 							}
 						} catch (Exception e) {
-							db.rollback();
 							failed++;
 							logger.error("Failed to convert network {}: {}", networkId, e.getMessage(), e);
+
+							// Visibility flip may already be committed; compensate back to
+							// PUBLIC so Postgres and Solr don't drift out of sync.
+							try (PreparedStatement revertPst = db.prepareStatement(
+									"UPDATE network SET visibility = 'PUBLIC' WHERE \"UUID\" = ?")) {
+								revertPst.setObject(1, networkId);
+								revertPst.executeUpdate();
+								db.commit();
+							} catch (Exception revertEx) {
+								logger.error("Failed to revert visibility to PUBLIC for network {}: {}",
+										networkId, revertEx.getMessage(), revertEx);
+							}
 						}
 					}
 				}
@@ -601,7 +620,7 @@ public class SolrIndexBuilder implements AutoCloseable {
 	}
 
 	public static void main(String[] args) throws Exception {
-		// SolrIndexBuilder i = new SolrIndexBuider();
+		//	SolrIndexBuilder i = new SolrIndexBuider();
 		Configuration configuration = Configuration.createInstance();
 
 		NdexDatabase.createNdexDatabase(configuration.getDBURL(), configuration.getDBUser(),
@@ -643,7 +662,7 @@ public class SolrIndexBuilder implements AutoCloseable {
 				}
 				logger.info("Index rebuild process finished.");
 			} else {
-				System.err.println("Supported argument: all/nfs/user/group/all-networks-online/global-networks/all-local/<networkUUID>");
+				System.err.println("Supported argument: all/nfs/user/group/all-networks-online/global-networks/all-local/unlist-public-none/<networkUUID>");
 				//System.out.println("For the boolean argument after network ID, true means rebuild the Single Network index.");
 			}
 
@@ -658,4 +677,3 @@ public class SolrIndexBuilder implements AutoCloseable {
 	}
 
 }
-

--- a/src/main/java/org/ndexbio/common/solr/SolrIndexBuilder.java
+++ b/src/main/java/org/ndexbio/common/solr/SolrIndexBuilder.java
@@ -508,111 +508,131 @@ public class SolrIndexBuilder implements AutoCloseable {
 			logger.info("Group index has been rebuilt.");
 		}
 	}
+	/** Executes the Solr delete+rebuild tasks for one network during unlist. */
+	@FunctionalInterface
+	interface SolrProcessor {
+		void process(UUID networkId, UUID ownerId, String ownerName) throws Exception;
+	}
+
 	/**
 	 * Find all networks where visibility='PUBLIC' and solr_idx_lvl='NONE',
-	 * flip them to UNLISTED in Postgres, and synchronously run Solr delete+rebuild
-	 * tasks so the file index moves from public-nfs to private-nfs.
+	 * flip them to UNLISTED in Postgres, then synchronously run Solr delete+rebuild
+	 * tasks so the file index is updated in public-nfs (both PUBLIC and UNLISTED
+	 * networks use the public-nfs core; visibility controls query-time filtering).
 	 *
-	 * Each network is locked for the duration of its conversion. The visibility
-	 * flip is committed before the Solr work runs; if a Solr step fails, a
-	 * compensating UPDATE restores the network to PUBLIC so Postgres and Solr do
-	 * not drift out of sync. The loop continues on failure; successfully
+	 * Per-network: (1) acquire lock, UPDATE visibility, commit, release lock;
+	 * (2) run Solr tasks with no lock held. On any failure, attempts a compensating
+	 * UPDATE back to PUBLIC (also under lock) then rethrows immediately — already-
 	 * processed networks remain UNLISTED.
 	 */
-	private static void unlistPublicNoneNetworks() throws SQLException, NdexException, IOException {
+	private static void unlistPublicNoneNetworks() throws Exception {
+		try (PostgresNetworkDAO dao = new PostgresNetworkDAO()) {
+			unlistPublicNoneNetworks(dao, (networkId, ownerId, ownerName) -> {
+				// ignoreCxFiles=true: these networks have solr_idx_lvl=NONE
+				// and may not have CX aspect files on disk to index from.
+				new SolrTaskDeleteFile(networkId, VisibilityType.PUBLIC).run();
+				new SolrTaskRebuildFileIdx(networkId, ownerId, ownerName,
+						VisibilityType.UNLISTED, FileType.NETWORK, false, true).run();
+			});
+		}
+	}
+
+	static void unlistPublicNoneNetworks(PostgresNetworkDAO dao, SolrProcessor solrProcessor) throws Exception {
 		logger.info("Finding PUBLIC networks with solr_idx_lvl='NONE'...");
 
-		try (PostgresNetworkDAO dao = new PostgresNetworkDAO()) {
-			@SuppressWarnings("resource")
-			Connection db = dao.getDBConnection();
-			boolean priorAutoCommit = db.getAutoCommit();
-			db.setAutoCommit(false);
+		@SuppressWarnings("resource")
+		Connection db = dao.getDBConnection();
+		db.setAutoCommit(false);
 
-			int total = 0;
-			int processed = 0;
-			int failed = 0;
+		int total = 0;
+		int processed = 0;
 
-			try {
-				// 1. Collect targets (UUID, ownerId, ownerName) up front so the iterating
-				//    ResultSet isn't held open across writes/commits.
-				List<Object[]> targets = new java.util.ArrayList<>();
-				String selectSql = "SELECT \"UUID\", owneruuid, \"owner\" FROM network "
-						+ "WHERE visibility = 'PUBLIC' AND solr_idx_lvl = 'NONE' AND is_deleted = false";
-				try (PreparedStatement pst = db.prepareStatement(selectSql);
-					 ResultSet rs = pst.executeQuery()) {
-					while (rs.next()) {
-						targets.add(new Object[] {
-								(UUID) rs.getObject(1),
-								(UUID) rs.getObject(2),
-								rs.getString(3)
-						});
+		// Collect targets up front so the ResultSet isn't held open across writes/commits.
+		List<Object[]> targets = new java.util.ArrayList<>();
+		String selectSql = "SELECT \"UUID\", owneruuid, \"owner\" FROM network "
+				+ "WHERE visibility = 'PUBLIC' AND solr_idx_lvl = 'NONE' AND is_deleted = false";
+		try (PreparedStatement pst = db.prepareStatement(selectSql);
+			 ResultSet rs = pst.executeQuery()) {
+			while (rs.next()) {
+				targets.add(new Object[] {
+						(UUID) rs.getObject(1),
+						(UUID) rs.getObject(2),
+						rs.getString(3)
+				});
+			}
+		}
+		total = targets.size();
+		logger.info("Found {} networks to convert from PUBLIC to UNLISTED.", total);
+
+		String updateSql = "UPDATE network SET visibility = 'UNLISTED' WHERE \"UUID\" = ?";
+		String revertSql = "UPDATE network SET visibility = 'PUBLIC'   WHERE \"UUID\" = ?";
+		try (PreparedStatement updatePst = db.prepareStatement(updateSql);
+			 PreparedStatement revertPst = db.prepareStatement(revertSql)) {
+			for (Object[] row : targets) {
+				UUID networkId = (UUID) row[0];
+				UUID ownerId   = (UUID) row[1];
+				String ownerName = (String) row[2];
+
+				// Phase 1: DB update under lock.
+				boolean locked = false;
+				try {
+					dao.lockNetwork(networkId);
+					locked = true;
+					updatePst.setObject(1, networkId);
+					int rows = updatePst.executeUpdate();
+					if (rows != 1) {
+						throw new NdexException("Expected 1 row updated for " + networkId
+								+ " but got " + rows);
 					}
-				}
-				total = targets.size();
-				logger.info("Found {} networks to convert from PUBLIC to UNLISTED.", total);
-				if (total == 0) {
 					db.commit();
-					return;
-				}
-
-				String updateSql = "UPDATE network SET visibility = 'UNLISTED' WHERE \"UUID\" = ?";
-				try (PreparedStatement updatePst = db.prepareStatement(updateSql)) {
-					for (Object[] row : targets) {
-						UUID networkId = (UUID) row[0];
-						UUID ownerId   = (UUID) row[1];
-						String ownerName = (String) row[2];
-
-						try {
-							dao.lockNetwork(networkId);
-							try {
-								// 2. DB: flip visibility and commit.
-								updatePst.setObject(1, networkId);
-								int rows = updatePst.executeUpdate();
-								if (rows != 1) {
-									throw new NdexException("Expected 1 row updated for " + networkId
-											+ " but got " + rows);
-								}
-								db.commit();
-
-								// 3. Solr: delete from public-nfs, rebuild in private-nfs.
-								//    ignoreCxFiles=true because these networks have solr_idx_lvl=NONE
-								//    and may not have CX aspect files on disk to index from.
-								new SolrTaskDeleteFile(networkId, VisibilityType.PUBLIC).run();
-								new SolrTaskRebuildFileIdx(networkId, ownerId, ownerName,
-										VisibilityType.UNLISTED, FileType.NETWORK, false, true).run();
-
-								processed++;
-								if (processed % 500 == 0) {
-									logger.info("Processed {}/{} ({}%)",
-											processed, total, (processed * 100) / total);
-								}
-							} finally {
-								dao.unlockNetwork(networkId);
-								db.commit();
-							}
-						} catch (Exception e) {
-							failed++;
-							logger.error("Failed to convert network {}: {}", networkId, e.getMessage(), e);
-
-							// Visibility flip may already be committed; compensate back to
-							// PUBLIC so Postgres and Solr don't drift out of sync.
-							try (PreparedStatement revertPst = db.prepareStatement(
-									"UPDATE network SET visibility = 'PUBLIC' WHERE \"UUID\" = ?")) {
-								revertPst.setObject(1, networkId);
-								revertPst.executeUpdate();
-								db.commit();
-							} catch (Exception revertEx) {
-								logger.error("Failed to revert visibility to PUBLIC for network {}: {}",
-										networkId, revertEx.getMessage(), revertEx);
-							}
+				} finally {
+					if (locked) {
+						try { dao.unlockNetwork(networkId); }
+						catch (SQLException unlockEx) {
+							logger.error("CRITICAL: Network {} is stuck locked — manual intervention required: {}",
+									networkId, unlockEx.getMessage(), unlockEx);
 						}
 					}
 				}
-				logger.info("Done. processed={}, failed={}, total={}", processed, failed, total);
-			} finally {
-				db.setAutoCommit(priorAutoCommit);
+
+				// Phase 2: Solr work — no lock held.
+				try {
+					solrProcessor.process(networkId, ownerId, ownerName);
+					processed++;
+					if (processed % 500 == 0) {
+						logger.info("Processed {}/{} ({}%)",
+								processed, total, (processed * 100) / total);
+					}
+				} catch (Exception e) {
+					logger.error("Failed Solr tasks for network {}: {}", networkId, e.getMessage(), e);
+					// Visibility was committed; compensate back to PUBLIC under a fresh lock.
+					try {
+						boolean revertLocked = false;
+						try {
+							dao.lockNetwork(networkId);
+							revertLocked = true;
+							revertPst.setObject(1, networkId);
+							revertPst.executeUpdate();
+							db.commit();
+							logger.info("Reverted visibility to PUBLIC for network {}", networkId);
+						} finally {
+							if (revertLocked) {
+								try { dao.unlockNetwork(networkId); }
+								catch (SQLException unlockEx) {
+									logger.error("CRITICAL: Network {} is stuck locked — manual intervention required: {}",
+											networkId, unlockEx.getMessage(), unlockEx);
+								}
+							}
+						}
+					} catch (Exception revertEx) {
+						logger.error("CRITICAL: Failed to revert visibility to PUBLIC for network {}: {}",
+								networkId, revertEx.getMessage(), revertEx);
+					}
+					throw e;
+				}
 			}
 		}
+		logger.info("Done. processed={}, total={}", processed, total);
 	}
 
 	private static void rebuildNFSIdx(){

--- a/src/main/java/org/ndexbio/common/solr/SolrIndexBuilder.java
+++ b/src/main/java/org/ndexbio/common/solr/SolrIndexBuilder.java
@@ -42,123 +42,123 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 
 public class SolrIndexBuilder implements AutoCloseable {
 
-	protected static Logger logger = LoggerFactory.getLogger(SolrIndexBuilder.class);
-
-	NetworkGlobalIndexManager globalIdx ;
-
+    protected static Logger logger = LoggerFactory.getLogger(SolrIndexBuilder.class);
+	
+	  NetworkGlobalIndexManager globalIdx ;
+	
 	public SolrIndexBuilder () throws NdexException, SolrServerException, IOException {
-		globalIdx = new NetworkGlobalIndexManager();
-		globalIdx.createCoreIfNotExists();
-
+		  globalIdx = new NetworkGlobalIndexManager();
+	      globalIdx.createCoreIfNotExists();
+		
 	}
-
-
+	
+	
 	private  void rebuildNetworkIndex (UUID networkid, boolean ignoreDeletion ) throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO()) {
-			logger.info("Rebuild solr index of network " + networkid);
-			NetworkSummary summary = dao.getNetworkSummaryById(networkid);
-			if (summary == null)
-				throw new NdexException ("Network "+ networkid + " not found in the server." );
-
-			dao.lockNetwork(networkid);
-			try (SingleNetworkSolrIdxManager idx2 = new SingleNetworkSolrIdxManager(networkid.toString())) {
-
-				if (!ignoreDeletion) {
-					try {
-						globalIdx.deleteNetwork(networkid.toString());
-						globalIdx.commit();
-						idx2.dropIndex();
-					} catch (IOException | SolrServerException | NdexException e) {
-						e.printStackTrace();
-						logger.warn("Warning: Failed to delete node Index for network " + networkid.toString());
-					}
-
+		  logger.info("Rebuild solr index of network " + networkid);
+		  NetworkSummary summary = dao.getNetworkSummaryById(networkid);
+		  if (summary == null)
+			  throw new NdexException ("Network "+ networkid + " not found in the server." );
+		  
+		  dao.lockNetwork(networkid);
+		  try (SingleNetworkSolrIdxManager idx2 = new SingleNetworkSolrIdxManager(networkid.toString())) {
+		  
+			  if (!ignoreDeletion) {
+				try {
+					globalIdx.deleteNetwork(networkid.toString());
+					globalIdx.commit();
+					idx2.dropIndex();
+				} catch (IOException | SolrServerException | NdexException e) {
+					e.printStackTrace();
+					logger.warn("Warning: Failed to delete node Index for network " + networkid.toString());
 				}
-				if (summary.getNodeCount() >= SingleNetworkSolrIdxManager.AUTOCREATE_THRESHHOLD ) {
-
+				
+			  }		
+			  if (summary.getNodeCount() >= SingleNetworkSolrIdxManager.AUTOCREATE_THRESHHOLD ) {
+					
 					idx2.createIndex(null);
 					idx2.close();
+				
+				    logger.info("Solr index for query created.");
+			  } 
+		  
+			  if ( summary.getIndexLevel() != NetworkIndexLevel.NONE) {
+				  // build the solr document obj
+				  List<Map<Permissions, Collection<String>>> permissionTable =  dao.getAllMembershipsOnNetwork(networkid);
+				  Map<Permissions,Collection<String>> userMemberships = permissionTable.get(0);
+				  Map<Permissions,Collection<String>> grpMemberships = permissionTable.get(1);
+				  globalIdx.createIndexDocFromSummary(summary,summary.getOwner(),
+					userMemberships.get(Permissions.READ),
+					userMemberships.get(Permissions.WRITE),
+					grpMemberships.get(Permissions.READ),
+					grpMemberships.get(Permissions.WRITE));
 
-					logger.info("Solr index for query created.");
-				}
+				  //process node attribute aspect and add to solr doc
+				  String pathPrefix = Configuration.getInstance().getNdexRoot() + "/data/" ; 
+			
+				  try (AspectIterator<NetworkAttributesElement> it = new AspectIterator<>(networkid.toString(), 
+					  NetworkAttributesElement.ASPECT_NAME, NetworkAttributesElement.class, pathPrefix)) {
+					  while (it.hasNext()) {
+						  NetworkAttributesElement e = it.next();
+					
+						  List<String> indexWarnings = globalIdx.addCXNetworkAttrToIndex(e);	
+						  if ( !indexWarnings.isEmpty())
+							  for (String warning : indexWarnings) 
+								  System.err.println("Warning: " + warning);
+					
+					  }
+				  }
 
-				if ( summary.getIndexLevel() != NetworkIndexLevel.NONE) {
-					// build the solr document obj
-					List<Map<Permissions, Collection<String>>> permissionTable =  dao.getAllMembershipsOnNetwork(networkid);
-					Map<Permissions,Collection<String>> userMemberships = permissionTable.get(0);
-					Map<Permissions,Collection<String>> grpMemberships = permissionTable.get(1);
-					globalIdx.createIndexDocFromSummary(summary,summary.getOwner(),
-							userMemberships.get(Permissions.READ),
-							userMemberships.get(Permissions.WRITE),
-							grpMemberships.get(Permissions.READ),
-							grpMemberships.get(Permissions.WRITE));
+		  
+				  if (summary.getIndexLevel() == NetworkIndexLevel.ALL) {	
+					  try (AspectIterator<FunctionTermElement> it = new AspectIterator<>(networkid.toString(), 
+							  FunctionTermElement.ASPECT_NAME, FunctionTermElement.class, pathPrefix)) {
+						  while (it.hasNext()) {
+							  FunctionTermElement fun = it.next();
+					
+							  globalIdx.addFunctionTermToIndex(fun);
 
-					//process node attribute aspect and add to solr doc
-					String pathPrefix = Configuration.getInstance().getNdexRoot() + "/data/" ;
+						  }
+					  }
 
-					try (AspectIterator<NetworkAttributesElement> it = new AspectIterator<>(networkid.toString(),
-							NetworkAttributesElement.ASPECT_NAME, NetworkAttributesElement.class, pathPrefix)) {
-						while (it.hasNext()) {
-							NetworkAttributesElement e = it.next();
+					  try (AspectIterator<NodeAttributesElement> it = new AspectIterator<>(networkid.toString(), 
+						  NodeAttributesElement.ASPECT_NAME, NodeAttributesElement.class, pathPrefix)) {
+						  while (it.hasNext()) {
+							  NodeAttributesElement e = it.next();					
+							  globalIdx.addCXNodeAttrToIndex(e);	
+						  }
+					  }
 
-							List<String> indexWarnings = globalIdx.addCXNetworkAttrToIndex(e);
-							if ( !indexWarnings.isEmpty())
-								for (String warning : indexWarnings)
-									System.err.println("Warning: " + warning);
+					  try (AspectIterator<NodesElement> it = new AspectIterator<>(networkid.toString(), 
+							  NodesElement.ASPECT_NAME, NodesElement.class, pathPrefix)) {
+						  while (it.hasNext()) {
+							  NodesElement e = it.next();					
+							  globalIdx.addCXNodeToIndex(e);	
+						  }
+					  }
+						
+				  }	
+				  globalIdx.commit();
 
-						}
-					}
-
-
-					if (summary.getIndexLevel() == NetworkIndexLevel.ALL) {
-						try (AspectIterator<FunctionTermElement> it = new AspectIterator<>(networkid.toString(),
-								FunctionTermElement.ASPECT_NAME, FunctionTermElement.class, pathPrefix)) {
-							while (it.hasNext()) {
-								FunctionTermElement fun = it.next();
-
-								globalIdx.addFunctionTermToIndex(fun);
-
-							}
-						}
-
-						try (AspectIterator<NodeAttributesElement> it = new AspectIterator<>(networkid.toString(),
-								NodeAttributesElement.ASPECT_NAME, NodeAttributesElement.class, pathPrefix)) {
-							while (it.hasNext()) {
-								NodeAttributesElement e = it.next();
-								globalIdx.addCXNodeAttrToIndex(e);
-							}
-						}
-
-						try (AspectIterator<NodesElement> it = new AspectIterator<>(networkid.toString(),
-								NodesElement.ASPECT_NAME, NodesElement.class, pathPrefix)) {
-							while (it.hasNext()) {
-								NodesElement e = it.next();
-								globalIdx.addCXNodeToIndex(e);
-							}
-						}
-
-					}
-					globalIdx.commit();
-
-					logger.info("Solr index of network " + networkid + " created.");
-				}
-			} finally {
-				dao.unlockNetwork(networkid);
-			}
-		}
+				  logger.info("Solr index of network " + networkid + " created.");
+			  } 
+		  } finally {
+			  dao.unlockNetwork(networkid);
+		  }	 
+		}  
 	}
-
-
+	
+	
 	private  void rebuildNetworkIndexInGlobalIdx (UUID networkid , boolean ignoreDeletion ) throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO()) {
 			logger.info("Rebuild global index of network " +networkid);
-
-			NetworkSummary summary = dao.getNetworkSummaryById(networkid);
-			if (summary == null)
-				throw new NdexException ("Network "+ networkid + " not found in the server." );
-
+		 
+			 NetworkSummary summary = dao.getNetworkSummaryById(networkid);
+			 if (summary == null)
+				  throw new NdexException ("Network "+ networkid + " not found in the server." );
+			  			
 			//dao.lockNetwork(networkid);
-
+		  
 			if (!ignoreDeletion) {
 				try {
 					globalIdx.deleteNetwork(networkid.toString());
@@ -167,267 +167,267 @@ public class SolrIndexBuilder implements AutoCloseable {
 					e.printStackTrace();
 					logger.warn("Warning: Failed to delete node Index for network " + networkid.toString());
 				}
+				
+			 }		
+		  
+			 if ( summary.getIndexLevel() != NetworkIndexLevel.NONE) {
+				  // build the solr document obj
+				  List<Map<Permissions, Collection<String>>> permissionTable =  dao.getAllMembershipsOnNetwork(networkid);
+				  Map<Permissions,Collection<String>> userMemberships = permissionTable.get(0);
+				  Map<Permissions,Collection<String>> grpMemberships = permissionTable.get(1);
+				  globalIdx.createIndexDocFromSummary(summary,summary.getOwner(),
+					userMemberships.get(Permissions.READ),
+					userMemberships.get(Permissions.WRITE),
+					grpMemberships.get(Permissions.READ),
+					grpMemberships.get(Permissions.WRITE));
 
-			}
+				  //process node attribute aspect and add to solr doc
+				  String pathPrefix = Configuration.getInstance().getNdexRoot() + "/data/" ; 
+			
+				  try (AspectIterator<NetworkAttributesElement> it = new AspectIterator<>(networkid.toString(), 
+					  NetworkAttributesElement.ASPECT_NAME, NetworkAttributesElement.class, pathPrefix)) {
+					  while (it.hasNext()) {
+						  NetworkAttributesElement e = it.next();
+					
+						  List<String> indexWarnings = globalIdx.addCXNetworkAttrToIndex(e);	
+						  if ( !indexWarnings.isEmpty())
+							  for (String warning : indexWarnings) 
+								  System.err.println("Warning: " + warning);
+					
+					  }
+				  }
+	  
+				  if (summary.getIndexLevel() == NetworkIndexLevel.ALL) {	
+					  try (AspectIterator<FunctionTermElement> it = new AspectIterator<>(networkid.toString(), 
+							  FunctionTermElement.ASPECT_NAME, FunctionTermElement.class, pathPrefix)) {
+						  while (it.hasNext()) {
+							  FunctionTermElement fun = it.next();
+					
+							  globalIdx.addFunctionTermToIndex(fun);
 
-			if ( summary.getIndexLevel() != NetworkIndexLevel.NONE) {
-				// build the solr document obj
-				List<Map<Permissions, Collection<String>>> permissionTable =  dao.getAllMembershipsOnNetwork(networkid);
-				Map<Permissions,Collection<String>> userMemberships = permissionTable.get(0);
-				Map<Permissions,Collection<String>> grpMemberships = permissionTable.get(1);
-				globalIdx.createIndexDocFromSummary(summary,summary.getOwner(),
-						userMemberships.get(Permissions.READ),
-						userMemberships.get(Permissions.WRITE),
-						grpMemberships.get(Permissions.READ),
-						grpMemberships.get(Permissions.WRITE));
+						  }
+					  }
 
-				//process node attribute aspect and add to solr doc
-				String pathPrefix = Configuration.getInstance().getNdexRoot() + "/data/" ;
+					  try (AspectIterator<NodeAttributesElement> it = new AspectIterator<>(networkid.toString(), 
+						  NodeAttributesElement.ASPECT_NAME, NodeAttributesElement.class, pathPrefix)) {
+						  while (it.hasNext()) {
+							  NodeAttributesElement e = it.next();					
+							  globalIdx.addCXNodeAttrToIndex(e);	
+						  }
+					  }
 
-				try (AspectIterator<NetworkAttributesElement> it = new AspectIterator<>(networkid.toString(),
-						NetworkAttributesElement.ASPECT_NAME, NetworkAttributesElement.class, pathPrefix)) {
-					while (it.hasNext()) {
-						NetworkAttributesElement e = it.next();
-
-						List<String> indexWarnings = globalIdx.addCXNetworkAttrToIndex(e);
-						if ( !indexWarnings.isEmpty())
-							for (String warning : indexWarnings)
-								System.err.println("Warning: " + warning);
-
-					}
-				}
-
-				if (summary.getIndexLevel() == NetworkIndexLevel.ALL) {
-					try (AspectIterator<FunctionTermElement> it = new AspectIterator<>(networkid.toString(),
-							FunctionTermElement.ASPECT_NAME, FunctionTermElement.class, pathPrefix)) {
-						while (it.hasNext()) {
-							FunctionTermElement fun = it.next();
-
-							globalIdx.addFunctionTermToIndex(fun);
-
-						}
-					}
-
-					try (AspectIterator<NodeAttributesElement> it = new AspectIterator<>(networkid.toString(),
-							NodeAttributesElement.ASPECT_NAME, NodeAttributesElement.class, pathPrefix)) {
-						while (it.hasNext()) {
-							NodeAttributesElement e = it.next();
-							globalIdx.addCXNodeAttrToIndex(e);
-						}
-					}
-
-					try (AspectIterator<NodesElement> it = new AspectIterator<>(networkid.toString(),
-							NodesElement.ASPECT_NAME, NodesElement.class, pathPrefix)) {
-						while (it.hasNext()) {
-							NodesElement e = it.next();
-							globalIdx.addCXNodeToIndex(e);
-						}
-					}
-
-				}
-				globalIdx.commit();
-
-				// dao.unlockNetwork(networkid);
-				logger.info("Solr index of network " + networkid + " created.");
-			}
-
-		}
+					  try (AspectIterator<NodesElement> it = new AspectIterator<>(networkid.toString(), 
+							  NodesElement.ASPECT_NAME, NodesElement.class, pathPrefix)) {
+						  while (it.hasNext()) {
+							  NodesElement e = it.next();					
+							  globalIdx.addCXNodeToIndex(e);	
+						  }
+					  }
+						
+				  }	
+				  globalIdx.commit();
+			
+				 // dao.unlockNetwork(networkid);
+				  logger.info("Solr index of network " + networkid + " created.");
+			  } 
+		  	 
+		}  
 	}
-
-
+	
+	
 	private static  void rebuildLocalNetworkIndex (UUID networkid, boolean ignoreDeletion ) throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO()) {
-			logger.info("Rebuild local index of " + networkid);
-			NetworkSummary summary = dao.getNetworkSummaryById(networkid);
-			if (summary == null)
-				throw new NdexException ("Network "+ networkid + " not found in the server." );
-
-			//dao.lockNetwork(networkid);
-			try (SingleNetworkSolrIdxManager idx2 = new SingleNetworkSolrIdxManager(networkid.toString())) {
-
-				if (!ignoreDeletion) {
-					try {
-						idx2.dropIndex();
-					} catch (IOException | SolrServerException | NdexException e) {
-						e.printStackTrace();
-						logger.warn("Warning: Failed to delete node Index for network " + networkid.toString());
-					}
-
+		  logger.info("Rebuild local index of " + networkid);
+		  NetworkSummary summary = dao.getNetworkSummaryById(networkid);
+		  if (summary == null)
+			  throw new NdexException ("Network "+ networkid + " not found in the server." );
+		  
+		  //dao.lockNetwork(networkid);
+		  try (SingleNetworkSolrIdxManager idx2 = new SingleNetworkSolrIdxManager(networkid.toString())) {
+		  
+			  if (!ignoreDeletion) {
+				try {
+					idx2.dropIndex();
+				} catch (IOException | SolrServerException | NdexException e) {
+					e.printStackTrace();
+					logger.warn("Warning: Failed to delete node Index for network " + networkid.toString());
 				}
-				if (summary.getNodeCount() >= SingleNetworkSolrIdxManager.AUTOCREATE_THRESHHOLD ) {
-
+				
+			  }		
+			  if (summary.getNodeCount() >= SingleNetworkSolrIdxManager.AUTOCREATE_THRESHHOLD ) {
+					
 					idx2.createIndex(null);
 					idx2.close();
+				
+				    logger.info("Solr index for query created.");
+			  }   			 	
+			
+		  }	 
+		  //dao.unlockNetwork(networkid);
 
-					logger.info("Solr index for query created.");
-				}
-
-			}
-			//dao.unlockNetwork(networkid);
-
-		}
+		}  
 	}
 
-
-
+	
+	
 	private  void rebuildAll() throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO ()) {
 			@SuppressWarnings("resource")
 			Connection db = dao.getDBConnection();
 			String sqlStr = "select \"UUID\" from network n where n.iscomplete and n.is_deleted=false and n.is_validated and n.islocked=false and n.error is null";
-
+			
 			int i = 0;
 			try (PreparedStatement pst = db.prepareStatement(sqlStr)) {
 				try ( ResultSet rs = pst.executeQuery()) {
 					while (rs.next()) {
-						//int nodeCount = rs.getInt(2);
-						rebuildNetworkIndex((UUID)rs.getObject(1), true);
-						i ++;
-						if ( i % 500 == 0 ) {
-							System.err.println("Loaded " + i + " records to solr. sleep 2 seconds");
-							//   globalIdx.commit();
-							try {
-								Thread.sleep(2000);
-							} catch (InterruptedException e) {
-								// TODO Auto-generated catch block
-								e.printStackTrace();
-							}
-						}
+				       //int nodeCount = rs.getInt(2);
+					   rebuildNetworkIndex((UUID)rs.getObject(1), true);
+					   i ++;
+					   if ( i % 500 == 0 ) {
+						   System.err.println("Loaded " + i + " records to solr. sleep 2 seconds");
+						//   globalIdx.commit();
+						   try {
+							  Thread.sleep(2000);
+						   } catch (InterruptedException e) {
+							  // TODO Auto-generated catch block
+							  e.printStackTrace();
+						   }
+					   }	   
 					}
 				}
 			}
 		}
-		//	globalIdx.commit();
+	//	globalIdx.commit();
 		logger.info("Indexes of all networks have been rebuilt.");
 	}
-
+	
 
 	private  void rebuildGlobalIdx() throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO ()) {
 			@SuppressWarnings("resource")
 			Connection db = dao.getDBConnection();
 			String sqlStr = "select \"UUID\" from network n where n.iscomplete and n.is_deleted=false and n.is_validated and n.islocked=false and n.error is null";
-
+			
 			int i = 0;
 			try (PreparedStatement pst = db.prepareStatement(sqlStr)) {
 				try ( ResultSet rs = pst.executeQuery()) {
 					while (rs.next()) {
-						//int nodeCount = rs.getInt(2);
+				       //int nodeCount = rs.getInt(2);
 						rebuildNetworkIndexInGlobalIdx((UUID)rs.getObject(1), true);
-						i ++;
-						if ( i % 1000 == 0 ) {
-							System.err.println("Loaded " + i + " records to solr. sleep 2 seconds");
-							//   globalIdx.commit();
-							try {
-								Thread.sleep(2000);
-							} catch (InterruptedException e) {
-								// TODO Auto-generated catch block
-								e.printStackTrace();
-							}
-						}
+					   i ++;
+					   if ( i % 1000 == 0 ) {
+						   System.err.println("Loaded " + i + " records to solr. sleep 2 seconds");
+						//   globalIdx.commit();
+						   try {
+							  Thread.sleep(2000);
+						   } catch (InterruptedException e) {
+							  // TODO Auto-generated catch block
+							  e.printStackTrace();
+						   }
+					   }	   
 					}
 				}
 			}
 		}
-		//	globalIdx.commit();
+	//	globalIdx.commit();
 		logger.info("Indexes of all networks have been rebuilt.");
 	}
-
+	
 
 	private static  void rebuildAllLocalIdx() throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO ()) {
 			@SuppressWarnings("resource")
 			Connection db = dao.getDBConnection();
-			String sqlStr = "select \"UUID\" from network n where n.iscomplete and n.is_deleted=false and n.is_validated and n.islocked=false and n.error is null and cx2_file_size is not null and nodecount >= "
+			String sqlStr = "select \"UUID\" from network n where n.iscomplete and n.is_deleted=false and n.is_validated and n.islocked=false and n.error is null and cx2_file_size is not null and nodecount >= " 
 					+ SingleNetworkSolrIdxManager.AUTOCREATE_THRESHHOLD ;
-
+			
 			int i = 0;
-			int j = 0;
+			int j = 0; 
 			try (PreparedStatement pst = db.prepareStatement(sqlStr)) {
 				try ( ResultSet rs = pst.executeQuery()) {
 					while (rs.next()) {
-						//int nodeCount = rs.getInt(2);
+				       //int nodeCount = rs.getInt(2);
 						UUID netid = (UUID)rs.getObject(1);
 						try {
 							rebuildLocalNetworkIndex(netid, true);
 							j++;
 						} catch (HttpSolrClient.RemoteSolrException e4) {
 							if ( e4.getMessage().indexOf("Core with name '"+
-									netid.toString() +  "' already exists") == -1) {
+						             netid.toString() +  "' already exists") == -1) {
 								e4.printStackTrace();
 								throw new NdexException("Unexpected Solr Exception: " + e4.getMessage());
-							}
+							}	
 							logger.info("index exists. Ignore creating it.");
-						}
-						i ++;
-						if ( i % 500 == 0 ) {
-							System.err.println("Loaded " + i + " records to solr. sleep 2 seconds");
-							//   globalIdx.commit();
-							try {
-								Thread.sleep(2000);
-							} catch (InterruptedException e) {
-								// TODO Auto-generated catch block
-								e.printStackTrace();
-							}
-						}
+						} 
+					   i ++;
+					   if ( i % 500 == 0 ) {
+						   System.err.println("Loaded " + i + " records to solr. sleep 2 seconds");
+						//   globalIdx.commit();
+						   try {
+							  Thread.sleep(2000);
+						   } catch (InterruptedException e) {
+							  // TODO Auto-generated catch block
+							  e.printStackTrace();
+						   }
+					   }	   
 					}
 				}
 			}
 			logger.info("Local index of " + i + " networks have been checked. " + j + " are created." );
 		}
-		//	globalIdx.commit();
+	//	globalIdx.commit();
 	}
 
-
+	
 	private  void rebuildAllNetworksOnline() throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO ()) {
 			@SuppressWarnings("resource")
 			Connection db = dao.getDBConnection();
 			String sqlStr = "select \"UUID\" from network n where n.iscomplete and n.is_deleted=false and n.is_validated and n.error is null";
-
+			
 			int i = 0;
 			try (PreparedStatement pst = db.prepareStatement(sqlStr)) {
 				try ( ResultSet rs = pst.executeQuery()) {
 					while (rs.next()) {
-						//int nodeCount = rs.getInt(2);
-						UUID networkId = (UUID)rs.getObject(1);
-						try {
-
-							rebuildNetworkIndex(networkId, false);
-						} catch(Exception ex){
-							logger.error("Failed to rebuild index for network: " + networkId.toString());
-						}
-						i ++;
-						if ( i % 500 == 0 ) {
-							System.err.println("Loaded " + i + " records to solr. sleep 2 seconds");
-							//   globalIdx.commit();
-							try {
-								Thread.sleep(2000);
-							} catch (InterruptedException e) {
-								// TODO Auto-generated catch block
-								e.printStackTrace();
-							}
-						}
+				       //int nodeCount = rs.getInt(2);
+					   UUID networkId = (UUID)rs.getObject(1);
+					   try {
+						   
+						   rebuildNetworkIndex(networkId, false);
+					   } catch(Exception ex){
+						   logger.error("Failed to rebuild index for network: " + networkId.toString());
+					   }
+					   i ++;
+					   if ( i % 500 == 0 ) {
+						   System.err.println("Loaded " + i + " records to solr. sleep 2 seconds");
+						//   globalIdx.commit();
+						   try {
+							  Thread.sleep(2000);
+						   } catch (InterruptedException e) {
+							  // TODO Auto-generated catch block
+							  e.printStackTrace();
+						   }
+					   }	   
 					}
 				}
 			}
 		}
-		//	globalIdx.commit();
+	//	globalIdx.commit();
 		logger.info("Indexes of all networks have been rebuilt.");
 	}
 
-
+	
 	private  void rebuildSingleNetworkIndex (UUID networkid) throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO()) {
-			logger.info("Rebuild solr index of network " + networkid);
-			NetworkSummary summary = dao.getNetworkSummaryById(networkid);
-			if (summary == null)
-				throw new NdexException ("Network "+ networkid + " not found in the server." );
-
-			rebuildNetworkIndex(networkid, false);
-		}
-	}
-
+		  logger.info("Rebuild solr index of network " + networkid);
+		  NetworkSummary summary = dao.getNetworkSummaryById(networkid);
+		  if (summary == null)
+			  throw new NdexException ("Network "+ networkid + " not found in the server." );
+		  
+		  rebuildNetworkIndex(networkid, false);
+		}  
+	}	  
+	
 	private static void rebuildUserIndex() throws Exception {
 		logger.info("Start rebuild user index.");
 		try (UserIndexManager umgr = new UserIndexManager()) {
@@ -460,7 +460,7 @@ public class SolrIndexBuilder implements AutoCloseable {
 		}
 		logger.info("User index has been rebuilt.");
 	}
-
+	
 	private static void rebuildGroupIndex() throws Exception {
 		logger.info("Start rebuild group index.");
 		try (GroupIndexManager umgr = new GroupIndexManager()) {
@@ -504,10 +504,15 @@ public class SolrIndexBuilder implements AutoCloseable {
 					}
 				}
 			}
-
+			
 			logger.info("Group index has been rebuilt.");
 		}
 	}
+	
+	private static void rebuildNFSIdx(){
+
+	}
+
 	/** Executes the Solr delete+rebuild tasks for one network during unlist. */
 	@FunctionalInterface
 	interface SolrProcessor {
@@ -635,59 +640,55 @@ public class SolrIndexBuilder implements AutoCloseable {
 		logger.info("Done. processed={}, total={}", processed, total);
 	}
 
-	private static void rebuildNFSIdx(){
-
-	}
-
 	public static void main(String[] args) throws Exception {
-		//	SolrIndexBuilder i = new SolrIndexBuider();
+	//	SolrIndexBuilder i = new SolrIndexBuider();
 		Configuration configuration = Configuration.createInstance();
 
 		NdexDatabase.createNdexDatabase(configuration.getDBURL(), configuration.getDBUser(),
 				configuration.getDBPasswd(), 10);
-
+	
 		try (SolrIndexBuilder builder = new SolrIndexBuilder()) {
-			if ( args.length == 1) {
-				switch ( args[0]) {
-					case "all":
-						SolrIndexBuilder.rebuildUserIndex();
-						SolrIndexBuilder.rebuildGroupIndex();
-						builder.rebuildAll();
-						break;
-					case "user":
-						SolrIndexBuilder.rebuildUserIndex();
-						break;
-					case "group":
-						SolrIndexBuilder.rebuildGroupIndex();
-						break;
-					case "all-networks-online":
-						builder.rebuildAllNetworksOnline();
-						break;
-					case "global-networks":
-						builder.rebuildGlobalIdx();
-						break;
-					case "all-local":
-						SolrIndexBuilder.rebuildAllLocalIdx();
-						break;
-					case "nfs":
-						SolrIndexBuilder.rebuildNFSIdx();
-						break;
-					case "unlist-public-none":
-						SolrIndexBuilder.unlistPublicNoneNetworks();
-						break;
-					default:
-						builder.rebuildSingleNetworkIndex(UUID.fromString(args[0]));
-						builder.globalIdx.commit();
-
-				}
-				logger.info("Index rebuild process finished.");
-			} else {
-				System.err.println("Supported argument: all/nfs/user/group/all-networks-online/global-networks/all-local/unlist-public-none/<networkUUID>");
-				//System.out.println("For the boolean argument after network ID, true means rebuild the Single Network index.");
+		if ( args.length == 1) {
+			switch ( args[0]) {
+			case "all":
+				SolrIndexBuilder.rebuildUserIndex();
+				SolrIndexBuilder.rebuildGroupIndex();
+				builder.rebuildAll();
+				break;
+			case "user":
+				SolrIndexBuilder.rebuildUserIndex();
+				break;
+			case "group":
+				SolrIndexBuilder.rebuildGroupIndex();
+				break;
+			case "all-networks-online":
+				builder.rebuildAllNetworksOnline();
+				break;
+			case "global-networks":
+				builder.rebuildGlobalIdx();
+				break;
+			case "all-local":
+				SolrIndexBuilder.rebuildAllLocalIdx();
+				break;
+			case "nfs":
+				SolrIndexBuilder.rebuildNFSIdx();
+				break;
+			case "unlist-public-none":
+				SolrIndexBuilder.unlistPublicNoneNetworks();
+				break;
+			default:
+				builder.rebuildSingleNetworkIndex(UUID.fromString(args[0]));
+				builder.globalIdx.commit();
+				
 			}
-
+			logger.info("Index rebuild process finished.");
+		} else {
+			System.err.println("Supported argument: all/nfs/user/group/all-networks-online/global-networks/all-local/unlist-public-none/<networkUUID>");
+			//System.out.println("For the boolean argument after network ID, true means rebuild the Single Network index.");
 		}
-
+		
+		}
+		
 	}
 
 

--- a/src/test/java/org/ndexbio/common/solr/TestUnlistPublicNoneNetworks.java
+++ b/src/test/java/org/ndexbio/common/solr/TestUnlistPublicNoneNetworks.java
@@ -69,12 +69,16 @@ public class TestUnlistPublicNoneNetworks {
     @Test
     public void testEmptyResultSet_noWorkDone() throws Exception {
         PreparedStatement mockSelectPst = createNiceMock(PreparedStatement.class);
-        PreparedStatement mockUpdatePst = createNiceMock(PreparedStatement.class);
-        PreparedStatement mockRevertPst = createNiceMock(PreparedStatement.class);
+        PreparedStatement mockUpdatePst = createMock(PreparedStatement.class);
+        PreparedStatement mockRevertPst = createMock(PreparedStatement.class);
         ResultSet mockRs = createNiceMock(ResultSet.class);
 
         expect(mockSelectPst.executeQuery()).andReturn(mockRs);
         expect(mockRs.next()).andReturn(false);
+        mockUpdatePst.close();
+        expectLastCall();
+        mockRevertPst.close();
+        expectLastCall();
 
         Connection mockConn = setupMockConnection(
                 mockSelectPst, mockUpdatePst, mockRevertPst,
@@ -97,7 +101,7 @@ public class TestUnlistPublicNoneNetworks {
     public void testHappyPath_visibilityFlippedAndSolrCalled() throws Exception {
         PreparedStatement mockSelectPst = createNiceMock(PreparedStatement.class);
         PreparedStatement mockUpdatePst = createNiceMock(PreparedStatement.class);
-        PreparedStatement mockRevertPst = createNiceMock(PreparedStatement.class);
+        PreparedStatement mockRevertPst = createMock(PreparedStatement.class);
         PreparedStatement mockLockPst   = createNiceMock(PreparedStatement.class);
         PreparedStatement mockUnlockPst = createNiceMock(PreparedStatement.class);
         ResultSet mockRs = createNiceMock(ResultSet.class);
@@ -110,6 +114,8 @@ public class TestUnlistPublicNoneNetworks {
 
         expect(mockLockPst.executeUpdate()).andReturn(1);
         expect(mockUpdatePst.executeUpdate()).andReturn(1);
+        mockRevertPst.close();
+        expectLastCall();
 
         Connection mockConn = setupMockConnection(
                 mockSelectPst, mockUpdatePst, mockRevertPst, mockLockPst, mockUnlockPst);

--- a/src/test/java/org/ndexbio/common/solr/TestUnlistPublicNoneNetworks.java
+++ b/src/test/java/org/ndexbio/common/solr/TestUnlistPublicNoneNetworks.java
@@ -12,6 +12,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.easymock.EasyMock.*;
@@ -211,6 +212,61 @@ public class TestUnlistPublicNoneNetworks {
         }
 
         assertFalse("SolrProcessor must not be called when DB update fails", solrCalled.get());
+        verify(mockConn, mockSelectPst, mockUpdatePst, mockRevertPst, mockLockPst, mockUnlockPst, mockRs);
+    }
+
+    /**
+     * Two networks in the result set; Solr fails on the first.
+     * Verifies the routine does NOT continue to the second network — it exits immediately
+     * after compensating the first, proving fast-fail rather than continue-on-error.
+     */
+    @Test
+    public void testFastFailStopsAfterFirstNetworkException() throws Exception {
+        UUID networkId2  = UUID.randomUUID();
+        UUID ownerId2    = UUID.randomUUID();
+
+        PreparedStatement mockSelectPst = createNiceMock(PreparedStatement.class);
+        PreparedStatement mockUpdatePst = createNiceMock(PreparedStatement.class);
+        PreparedStatement mockRevertPst = createNiceMock(PreparedStatement.class);
+        PreparedStatement mockLockPst   = createNiceMock(PreparedStatement.class);
+        PreparedStatement mockUnlockPst = createNiceMock(PreparedStatement.class);
+        ResultSet mockRs = createNiceMock(ResultSet.class);
+
+        // Two rows returned from SELECT.
+        expect(mockSelectPst.executeQuery()).andReturn(mockRs);
+        expect(mockRs.next()).andReturn(true).andReturn(true).andReturn(false);
+        expect(mockRs.getObject(1)).andReturn(NETWORK_ID).andReturn(networkId2);
+        expect(mockRs.getObject(2)).andReturn(OWNER_ID).andReturn(ownerId2);
+        expect(mockRs.getString(3)).andReturn(OWNER_NAME).andReturn("owner2");
+
+        // Phase 1 lock for network 1, then compensation lock after Solr fails (2 total).
+        // Network 2 is never reached, so no additional lock calls.
+        expect(mockLockPst.executeUpdate()).andReturn(1).times(2);
+        expect(mockUpdatePst.executeUpdate()).andReturn(1);  // network 1 only
+        expect(mockRevertPst.executeUpdate()).andReturn(1);  // compensation for network 1 only
+
+        Connection mockConn = setupMockConnection(
+                mockSelectPst, mockUpdatePst, mockRevertPst, mockLockPst, mockUnlockPst);
+
+        RuntimeException solrEx = new RuntimeException("Solr down");
+        AtomicInteger solrCallCount = new AtomicInteger(0);
+        SolrIndexBuilder.SolrProcessor solrProcessor = (id, oId, oName) -> {
+            solrCallCount.incrementAndGet();
+            throw solrEx;
+        };
+
+        replay(mockConn, mockSelectPst, mockUpdatePst, mockRevertPst, mockLockPst, mockUnlockPst, mockRs);
+
+        PostgresNetworkDAO dao = daoWithConnection(mockConn);
+        try {
+            SolrIndexBuilder.unlistPublicNoneNetworks(dao, solrProcessor);
+            fail("Expected exception to propagate");
+        } catch (RuntimeException e) {
+            assertSame("Original exception must be rethrown", solrEx, e);
+        }
+
+        assertEquals("SolrProcessor must be called exactly once — second network not reached", 1, solrCallCount.get());
+        // verify() also confirms mockRevertPst.executeUpdate() fired (compensation ran for network 1)
         verify(mockConn, mockSelectPst, mockUpdatePst, mockRevertPst, mockLockPst, mockUnlockPst, mockRs);
     }
 }

--- a/src/test/java/org/ndexbio/common/solr/TestUnlistPublicNoneNetworks.java
+++ b/src/test/java/org/ndexbio/common/solr/TestUnlistPublicNoneNetworks.java
@@ -1,0 +1,216 @@
+package org.ndexbio.common.solr;
+
+import org.easymock.IAnswer;
+import org.junit.Test;
+import org.ndexbio.common.models.dao.postgresql.PostgresNetworkDAO;
+import org.ndexbio.model.exceptions.NdexException;
+
+import java.lang.reflect.Constructor;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+public class TestUnlistPublicNoneNetworks {
+
+    private static final UUID NETWORK_ID = UUID.randomUUID();
+    private static final UUID OWNER_ID   = UUID.randomUUID();
+    private static final String OWNER_NAME = "testowner";
+
+    /**
+     * Dispatches prepareStatement() calls to mock PSTs by SQL content so all
+     * SQL variants in the routine can be intercepted with a single expect.
+     */
+    private static IAnswer<PreparedStatement> pstDispatcher(
+            PreparedStatement selectPst,
+            PreparedStatement updatePst,
+            PreparedStatement revertPst,
+            PreparedStatement lockPst,
+            PreparedStatement unlockPst) {
+        return () -> {
+            String sql = (String) getCurrentArguments()[0];
+            if (sql.contains("solr_idx_lvl"))            return selectPst;
+            if (sql.contains("'UNLISTED'"))               return updatePst;
+            if (sql.contains("SET visibility = 'PUBLIC'")) return revertPst;
+            if (sql.contains("islocked= true"))           return lockPst;
+            if (sql.contains("islocked=?"))               return unlockPst;
+            throw new IllegalArgumentException("Unexpected SQL in test: " + sql);
+        };
+    }
+
+    private static PostgresNetworkDAO daoWithConnection(Connection conn) throws Exception {
+        Constructor<PostgresNetworkDAO> ctor = PostgresNetworkDAO.class.getDeclaredConstructor(Connection.class);
+        ctor.setAccessible(true);
+        return ctor.newInstance(conn);
+    }
+
+    private static Connection setupMockConnection(
+            PreparedStatement selectPst,
+            PreparedStatement updatePst,
+            PreparedStatement revertPst,
+            PreparedStatement lockPst,
+            PreparedStatement unlockPst) throws SQLException {
+        Connection mockConn = createNiceMock(Connection.class);
+        expect(mockConn.prepareStatement(anyString()))
+                .andAnswer(pstDispatcher(selectPst, updatePst, revertPst, lockPst, unlockPst))
+                .anyTimes();
+        return mockConn;
+    }
+
+    // ── Tests ──────────────────────────────────────────────────────────────────
+
+    @Test
+    public void testEmptyResultSet_noWorkDone() throws Exception {
+        PreparedStatement mockSelectPst = createNiceMock(PreparedStatement.class);
+        PreparedStatement mockUpdatePst = createNiceMock(PreparedStatement.class);
+        PreparedStatement mockRevertPst = createNiceMock(PreparedStatement.class);
+        ResultSet mockRs = createNiceMock(ResultSet.class);
+
+        expect(mockSelectPst.executeQuery()).andReturn(mockRs);
+        expect(mockRs.next()).andReturn(false);
+
+        Connection mockConn = setupMockConnection(
+                mockSelectPst, mockUpdatePst, mockRevertPst,
+                createNiceMock(PreparedStatement.class),
+                createNiceMock(PreparedStatement.class));
+
+        AtomicBoolean solrCalled = new AtomicBoolean(false);
+        SolrIndexBuilder.SolrProcessor solrProcessor = (id, oId, oName) -> solrCalled.set(true);
+
+        replay(mockConn, mockSelectPst, mockUpdatePst, mockRevertPst, mockRs);
+
+        PostgresNetworkDAO dao = daoWithConnection(mockConn);
+        SolrIndexBuilder.unlistPublicNoneNetworks(dao, solrProcessor);
+
+        assertFalse("SolrProcessor must not be called for empty result set", solrCalled.get());
+        verify(mockConn, mockSelectPst, mockUpdatePst, mockRevertPst, mockRs);
+    }
+
+    @Test
+    public void testHappyPath_visibilityFlippedAndSolrCalled() throws Exception {
+        PreparedStatement mockSelectPst = createNiceMock(PreparedStatement.class);
+        PreparedStatement mockUpdatePst = createNiceMock(PreparedStatement.class);
+        PreparedStatement mockRevertPst = createNiceMock(PreparedStatement.class);
+        PreparedStatement mockLockPst   = createNiceMock(PreparedStatement.class);
+        PreparedStatement mockUnlockPst = createNiceMock(PreparedStatement.class);
+        ResultSet mockRs = createNiceMock(ResultSet.class);
+
+        expect(mockSelectPst.executeQuery()).andReturn(mockRs);
+        expect(mockRs.next()).andReturn(true).andReturn(false);
+        expect(mockRs.getObject(1)).andReturn(NETWORK_ID);
+        expect(mockRs.getObject(2)).andReturn(OWNER_ID);
+        expect(mockRs.getString(3)).andReturn(OWNER_NAME);
+
+        expect(mockLockPst.executeUpdate()).andReturn(1);
+        expect(mockUpdatePst.executeUpdate()).andReturn(1);
+
+        Connection mockConn = setupMockConnection(
+                mockSelectPst, mockUpdatePst, mockRevertPst, mockLockPst, mockUnlockPst);
+
+        AtomicReference<UUID>   capturedId        = new AtomicReference<>();
+        AtomicReference<UUID>   capturedOwnerId   = new AtomicReference<>();
+        AtomicReference<String> capturedOwnerName = new AtomicReference<>();
+        SolrIndexBuilder.SolrProcessor solrProcessor = (id, oId, oName) -> {
+            capturedId.set(id);
+            capturedOwnerId.set(oId);
+            capturedOwnerName.set(oName);
+        };
+
+        replay(mockConn, mockSelectPst, mockUpdatePst, mockRevertPst, mockLockPst, mockUnlockPst, mockRs);
+
+        PostgresNetworkDAO dao = daoWithConnection(mockConn);
+        SolrIndexBuilder.unlistPublicNoneNetworks(dao, solrProcessor);
+
+        assertEquals(NETWORK_ID,  capturedId.get());
+        assertEquals(OWNER_ID,    capturedOwnerId.get());
+        assertEquals(OWNER_NAME,  capturedOwnerName.get());
+        verify(mockConn, mockSelectPst, mockUpdatePst, mockRevertPst, mockLockPst, mockUnlockPst, mockRs);
+    }
+
+    @Test
+    public void testSolrFailure_compensatesAndFastFails() throws Exception {
+        PreparedStatement mockSelectPst = createNiceMock(PreparedStatement.class);
+        PreparedStatement mockUpdatePst = createNiceMock(PreparedStatement.class);
+        PreparedStatement mockRevertPst = createNiceMock(PreparedStatement.class);
+        PreparedStatement mockLockPst   = createNiceMock(PreparedStatement.class);
+        PreparedStatement mockUnlockPst = createNiceMock(PreparedStatement.class);
+        ResultSet mockRs = createNiceMock(ResultSet.class);
+
+        expect(mockSelectPst.executeQuery()).andReturn(mockRs);
+        expect(mockRs.next()).andReturn(true).andReturn(false);
+        expect(mockRs.getObject(1)).andReturn(NETWORK_ID);
+        expect(mockRs.getObject(2)).andReturn(OWNER_ID);
+        expect(mockRs.getString(3)).andReturn(OWNER_NAME);
+
+        // Phase 1 lock + compensation lock (2 total)
+        expect(mockLockPst.executeUpdate()).andReturn(1).times(2);
+        expect(mockUpdatePst.executeUpdate()).andReturn(1);
+        // Compensating revert must happen
+        expect(mockRevertPst.executeUpdate()).andReturn(1);
+
+        Connection mockConn = setupMockConnection(
+                mockSelectPst, mockUpdatePst, mockRevertPst, mockLockPst, mockUnlockPst);
+
+        RuntimeException solrEx = new RuntimeException("Solr unavailable");
+        SolrIndexBuilder.SolrProcessor solrProcessor = (id, oId, oName) -> { throw solrEx; };
+
+        replay(mockConn, mockSelectPst, mockUpdatePst, mockRevertPst, mockLockPst, mockUnlockPst, mockRs);
+
+        PostgresNetworkDAO dao = daoWithConnection(mockConn);
+        try {
+            SolrIndexBuilder.unlistPublicNoneNetworks(dao, solrProcessor);
+            fail("Expected exception to propagate");
+        } catch (RuntimeException e) {
+            assertSame("Original Solr exception must be rethrown", solrEx, e);
+        }
+
+        // verify() confirms mockRevertPst.executeUpdate() was called (compensating update ran)
+        verify(mockConn, mockSelectPst, mockUpdatePst, mockRevertPst, mockLockPst, mockUnlockPst, mockRs);
+    }
+
+    @Test
+    public void testDbUpdateFailure_noSolrCallAndFastFails() throws Exception {
+        PreparedStatement mockSelectPst = createNiceMock(PreparedStatement.class);
+        PreparedStatement mockUpdatePst = createNiceMock(PreparedStatement.class);
+        PreparedStatement mockRevertPst = createNiceMock(PreparedStatement.class);
+        PreparedStatement mockLockPst   = createNiceMock(PreparedStatement.class);
+        PreparedStatement mockUnlockPst = createNiceMock(PreparedStatement.class);
+        ResultSet mockRs = createNiceMock(ResultSet.class);
+
+        expect(mockSelectPst.executeQuery()).andReturn(mockRs);
+        expect(mockRs.next()).andReturn(true).andReturn(false);
+        expect(mockRs.getObject(1)).andReturn(NETWORK_ID);
+        expect(mockRs.getObject(2)).andReturn(OWNER_ID);
+        expect(mockRs.getString(3)).andReturn(OWNER_NAME);
+
+        expect(mockLockPst.executeUpdate()).andReturn(1);
+        // Update returns 0 rows — triggers NdexException from phase 1
+        expect(mockUpdatePst.executeUpdate()).andReturn(0);
+
+        Connection mockConn = setupMockConnection(
+                mockSelectPst, mockUpdatePst, mockRevertPst, mockLockPst, mockUnlockPst);
+
+        AtomicBoolean solrCalled = new AtomicBoolean(false);
+        SolrIndexBuilder.SolrProcessor solrProcessor = (id, oId, oName) -> solrCalled.set(true);
+
+        replay(mockConn, mockSelectPst, mockUpdatePst, mockRevertPst, mockLockPst, mockUnlockPst, mockRs);
+
+        PostgresNetworkDAO dao = daoWithConnection(mockConn);
+        try {
+            SolrIndexBuilder.unlistPublicNoneNetworks(dao, solrProcessor);
+            fail("Expected NdexException to propagate");
+        } catch (NdexException e) {
+            assertTrue("Exception message must include network UUID",
+                    e.getMessage().contains(NETWORK_ID.toString()));
+        }
+
+        assertFalse("SolrProcessor must not be called when DB update fails", solrCalled.get());
+        verify(mockConn, mockSelectPst, mockUpdatePst, mockRevertPst, mockLockPst, mockUnlockPst, mockRs);
+    }
+}


### PR DESCRIPTION
This is a refactor and enhancement of existing #95 
* network lock was reduced to just db update period, is not held over reindex op
* fast fails the re-indexing process upon first error of any kind, attempts to back out the last network if db was changed.
* added unit and integration tests
