### PR TITLE
Add oath register and reset urls to admin status payload

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -313,6 +313,7 @@ solrUrl           = "http://solr.example.com:8983/solr"
 hostUri           = "http://ndex.example.com:8080"
 keycloakIssuer    = "http://keycloak.example.com:8085/realms/ndex"
 keycloakPublicKey = "<base64-DER-encoded public key>"
+keycloakClientId  = ""               # optional: enables oauth_register_url / oauth_reset_url in /v3/admin/status
 ```
 
 Include only the sections relevant to your deployment. For full microservices topology examples with complete `config.toml` samples, see [RUNBOOK.md](./RUNBOOK.md).

--- a/docker/RUNBOOK.md
+++ b/docker/RUNBOOK.md
@@ -334,6 +334,7 @@ solrUrl           = "http://<SERVICES_HOST>:8983/solr"
 hostUri           = "http://<NDEX_HOST>:8080"
 keycloakIssuer    = "http://<KEYCLOAK_HOST>:8085/realms/ndex"
 keycloakPublicKey = "<value from Step 7>"
+keycloakClientId  = ""               # optional: enables oauth_register_url / oauth_reset_url in /v3/admin/status
 EOF
 chmod 600 $BASE/ndex-config.toml
 ```

--- a/docker/apps/ndex/default/config/ndex.properties
+++ b/docker/apps/ndex/default/config/ndex.properties
@@ -47,6 +47,7 @@ USE_GOOGLE_AUTHENTICATION=false
 ## Keycloak — filled in by start.sh on first boot from local default or --config [ndex]
 USE_KEYCLOAK_AUTHENTICATION=true
 KEYCLOAK_ISSUER=__NDEX_KEYCLOAK_ISSUER__
+KEYCLOAK_CLIENT_ID=__NDEX_KEYCLOAK_CLIENT_ID__
 ALLOWED_ADMIN_HOSTS=localhost
 ## RSA public key (base64 DER) — filled in by start.sh on first boot
 KEYCLOAK_PUBLIC_KEY=__NDEX_KEYCLOAK_PUBLIC_KEY__

--- a/docker/apps/ndex/default/config/ndex.properties
+++ b/docker/apps/ndex/default/config/ndex.properties
@@ -47,6 +47,9 @@ USE_GOOGLE_AUTHENTICATION=false
 ## Keycloak — filled in by start.sh on first boot from local default or --config [ndex]
 USE_KEYCLOAK_AUTHENTICATION=true
 KEYCLOAK_ISSUER=__NDEX_KEYCLOAK_ISSUER__
+## Optional: when set, /v3/admin/status returns oauth_register_url and oauth_reset_url
+## derived from KEYCLOAK_ISSUER. These URLs are used by Cytoscape (cy-ndex-2) to
+## provide Sign Up and Reset Password links in its sign-in dialog.
 KEYCLOAK_CLIENT_ID=__NDEX_KEYCLOAK_CLIENT_ID__
 ALLOWED_ADMIN_HOSTS=localhost
 ## RSA public key (base64 DER) — filled in by start.sh on first boot

--- a/docker/scripts/start.sh
+++ b/docker/scripts/start.sh
@@ -421,6 +421,7 @@ SQL
       HOST_URI=$(_toml_get      "${NDEX_CONFIG_FILE}" ndex hostUri)
       KC_ISSUER=$(_toml_get     "${NDEX_CONFIG_FILE}" ndex keycloakIssuer)
       KC_PUBLIC_KEY=$(_toml_get "${NDEX_CONFIG_FILE}" ndex keycloakPublicKey)
+      KC_CLIENT_ID=$(_toml_get  "${NDEX_CONFIG_FILE}" ndex keycloakClientId)
     else
       # Monolithic: use localhost defaults; KC cert values applied every boot below
       SMTP_HOST="localhost"
@@ -428,6 +429,7 @@ SQL
       HOST_URI="http://localhost:8080"
       KC_ISSUER=""
       KC_PUBLIC_KEY=""
+      KC_CLIENT_ID=""
     fi
 
     sed -i "s|__NDEX_SMTP_HOST__|${SMTP_HOST}|g"               /apps/ndex/config/ndex.properties
@@ -435,6 +437,7 @@ SQL
     sed -i "s|__NDEX_HOST_URI__|${HOST_URI}|g"                 /apps/ndex/config/ndex.properties
     sed -i "s|__NDEX_KEYCLOAK_ISSUER__|${KC_ISSUER}|g"         /apps/ndex/config/ndex.properties
     sed -i "s|__NDEX_KEYCLOAK_PUBLIC_KEY__|${KC_PUBLIC_KEY}|g" /apps/ndex/config/ndex.properties
+    sed -i "s|__NDEX_KEYCLOAK_CLIENT_ID__|${KC_CLIENT_ID}|g"   /apps/ndex/config/ndex.properties
 
     touch /apps/ndex/config/.initialized
     echo "==> NDEx configuration initialized."

--- a/docker/scripts/start.sh
+++ b/docker/scripts/start.sh
@@ -452,9 +452,10 @@ SQL
       if [[ -f /apps/keycloak/config/cert.pem ]]; then
         _kc_pub=$(openssl x509 -in /apps/keycloak/config/cert.pem -pubkey -noout \
           | openssl rsa -pubin -pubout -outform DER | base64 -w 0)
-        sed -i "s|^KEYCLOAK_PUBLIC_KEY=.*|KEYCLOAK_PUBLIC_KEY=${_kc_pub}|"           /apps/ndex/config/ndex.properties
-        sed -i "s|^KEYCLOAK_ISSUER=.*|KEYCLOAK_ISSUER=http://localhost:8085/realms/ndex|" /apps/ndex/config/ndex.properties
-        sed -i "s|^USE_KEYCLOAK_AUTHENTICATION=.*|USE_KEYCLOAK_AUTHENTICATION=true|" /apps/ndex/config/ndex.properties
+        sed -i "s|^KEYCLOAK_PUBLIC_KEY=.*|KEYCLOAK_PUBLIC_KEY=${_kc_pub}|"                /apps/ndex/config/ndex.properties
+        sed -i "s|^KEYCLOAK_ISSUER=.*|KEYCLOAK_ISSUER=http://localhost:8085/realms/ndex|"  /apps/ndex/config/ndex.properties
+        sed -i "s|^KEYCLOAK_CLIENT_ID=.*|KEYCLOAK_CLIENT_ID=ndex-app|"                    /apps/ndex/config/ndex.properties
+        sed -i "s|^USE_KEYCLOAK_AUTHENTICATION=.*|USE_KEYCLOAK_AUTHENTICATION=true|"       /apps/ndex/config/ndex.properties
         echo "==> Keycloak authentication configured from cert.pem."
       else
         echo "WARN: --keycloak enabled but cert.pem not found at /apps/keycloak/config/cert.pem" >&2

--- a/docker/scripts/start.sh
+++ b/docker/scripts/start.sh
@@ -543,7 +543,7 @@ fi
 
 # ── Phase 9: Assemble supervisord.conf ────────────────────────────────────────
 echo "==> Assembling supervisord.conf..."
-SUPERVISORD_CONF=/tmp/supervisord.conf
+SUPERVISORD_CONF=/etc/supervisor/supervisord.conf
 cat /opt/ndex-supervisord/header.conf > "${SUPERVISORD_CONF}"
 [[ "${ENABLE_POSTGRES}" == "true" ]] && cat /opt/ndex-supervisord/postgres.conf >> "${SUPERVISORD_CONF}"
 [[ "${ENABLE_KEYCLOAK}" == "true" ]] && cat /opt/ndex-supervisord/keycloak.conf >> "${SUPERVISORD_CONF}"

--- a/docker/test/integration-test.sh
+++ b/docker/test/integration-test.sh
@@ -556,7 +556,7 @@ http.createServer((req, res) => {
 }).listen(8284);
 "
 
-  docker exec "${CONTAINER_NAME}" supervisorctl -c /tmp/supervisord.conf restart ndex
+  docker exec "${CONTAINER_NAME}" supervisorctl restart ndex
 
   echo "  Tomcat restart issued — waiting for NDEx to become responsive..."
   MAX_WAIT=90
@@ -726,7 +726,7 @@ if [[ -z "${REMOTE_NDEX_URL}" ]]; then
   echo "  Injecting AUTHENTICATED_USER_ONLY=true into ndex.properties and restarting Tomcat..."
   docker exec "${CONTAINER_NAME}" bash -c \
     "echo 'AUTHENTICATED_USER_ONLY=true' >> /apps/ndex/config/ndex.properties"
-  docker exec "${CONTAINER_NAME}" supervisorctl -c /tmp/supervisord.conf restart ndex
+  docker exec "${CONTAINER_NAME}" supervisorctl restart ndex
 
   echo "  Tomcat restart issued — waiting for NDEx to become responsive..."
   MAX_WAIT=90

--- a/src/main/java/org/ndexbio/rest/Configuration.java
+++ b/src/main/java/org/ndexbio/rest/Configuration.java
@@ -525,6 +525,8 @@ public class Configuration
     public String getRestAPIPrefix() {return restAPIPrefix;}
 	public String getMigrationPassword() {return migrationPassword;}
 
+	public String getKeycloakClientId() { return getProperty("KEYCLOAK_CLIENT_ID"); }
+
 
 	public boolean getUseADAuthentication() {
 		return useADAuthentication;

--- a/src/main/java/org/ndexbio/rest/services/v3/AdminServiceV3.java
+++ b/src/main/java/org/ndexbio/rest/services/v3/AdminServiceV3.java
@@ -45,10 +45,25 @@ public class AdminServiceV3 extends NdexService {
 	@NdexOpenFunction
 	@Path("/status")
 	@Produces("application/json")
-	public NdexStatus getStatus(
+	public NdexStatusV3 getStatus(
 			@DefaultValue("short") @QueryParam("format") String format) throws NdexException, SQLException	{
-		AdminServiceV2 adminService = new AdminServiceV2(this._httpRequest );
-		return adminService.getStatus(format);
+		AdminServiceV2 adminService = new AdminServiceV2(this._httpRequest);
+		NdexStatus base = adminService.getStatus(format);
+		NdexStatusV3 status = new NdexStatusV3(base);
+
+		Configuration config = Configuration.getInstance();
+		String useKeycloak = config.getProperty("USE_KEYCLOAK_AUTHENTICATION");
+		if ("true".equalsIgnoreCase(useKeycloak)) {
+			String issuer = config.getProperty("KEYCLOAK_ISSUER");
+			String clientId = config.getKeycloakClientId();
+			String hostUri = config.getHostURI();
+			if (issuer != null && !issuer.isBlank() && clientId != null && !clientId.isBlank()) {
+				status.setOauthRegisterUrl(status.buildRegisterUrl(issuer, clientId, hostUri));
+				status.setOauthResetUrl(status.buildResetUrl(issuer, clientId));
+			}
+		}
+
+		return status;
 	}
 	
 	

--- a/src/main/java/org/ndexbio/rest/services/v3/NdexStatusV3.java
+++ b/src/main/java/org/ndexbio/rest/services/v3/NdexStatusV3.java
@@ -1,0 +1,47 @@
+package org.ndexbio.rest.services.v3;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.ndexbio.model.object.NdexStatus;
+
+public class NdexStatusV3 extends NdexStatus {
+
+    @JsonProperty("oauth_register_url")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String oauthRegisterUrl;
+
+    @JsonProperty("oauth_reset_url")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String oauthResetUrl;
+
+    public NdexStatusV3() {
+        super();
+    }
+
+    public NdexStatusV3(NdexStatus base) {
+        super();
+        setNetworkCount(base.getNetworkCount());
+        setUserCount(base.getUserCount());
+        setGroupCount(base.getGroupCount());
+        setProperties(base.getProperties());
+        setMessage(base.getMessage());
+    }
+
+    public String getOauthRegisterUrl() { return oauthRegisterUrl; }
+    public void setOauthRegisterUrl(String url) { this.oauthRegisterUrl = url; }
+
+    public String getOauthResetUrl() { return oauthResetUrl; }
+    public void setOauthResetUrl(String url) { this.oauthResetUrl = url; }
+
+    String buildRegisterUrl(String issuer, String clientId, String hostUri) {
+        return issuer + "/protocol/openid-connect/registrations"
+                + "?client_id=" + clientId
+                + "&response_type=code"
+                + "&redirect_uri=" + hostUri;
+    }
+
+    String buildResetUrl(String issuer, String clientId) {
+        return issuer + "/login-actions/reset-credentials"
+                + "?client_id=" + clientId;
+    }
+}

--- a/src/test/java/org/ndexbio/rest/TestConfigurationKeycloakClientId.java
+++ b/src/test/java/org/ndexbio/rest/TestConfigurationKeycloakClientId.java
@@ -1,0 +1,48 @@
+package org.ndexbio.rest;
+
+import static org.junit.Assert.*;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestConfigurationKeycloakClientId {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private void writeConfig(File file, String extra) throws IOException {
+        try (BufferedWriter bw = new BufferedWriter(new FileWriter(file))) {
+            bw.write("NdexDBURL=somedburl\n");
+            bw.write("NdexSystemUser=sysuser\n");
+            bw.write("NdexSystemUserPassword=hithere\n");
+            bw.write("NdexRoot=" + file.getParent() + "\n");
+            bw.write("HostURI=https://ndexbio.org\n");
+            bw.write("NDEX_KEY=effggekk\n");
+            bw.write("DOI_CREATOR=CqmUkFe5kW5sJVMKNQYYLg==\n");
+            bw.write("MigrationPassword=migration\n");
+            if (extra != null) bw.write(extra);
+        }
+    }
+
+    @Test
+    public void returnsClientIdWhenPresent() throws Exception {
+        File cfg = tmpFolder.newFile("ndex.properties");
+        writeConfig(cfg, "KEYCLOAK_CLIENT_ID=myclient\n");
+        Configuration.reCreateInstance(cfg.getAbsolutePath());
+        assertEquals("myclient", Configuration.getInstance().getKeycloakClientId());
+    }
+
+    @Test
+    public void returnsNullWhenAbsent() throws Exception {
+        File cfg = tmpFolder.newFile("ndex.properties");
+        writeConfig(cfg, null);
+        Configuration.reCreateInstance(cfg.getAbsolutePath());
+        assertNull(Configuration.getInstance().getKeycloakClientId());
+    }
+}

--- a/src/test/java/org/ndexbio/rest/services/v3/TestNdexStatusV3OAuthUrls.java
+++ b/src/test/java/org/ndexbio/rest/services/v3/TestNdexStatusV3OAuthUrls.java
@@ -1,0 +1,55 @@
+package org.ndexbio.rest.services.v3;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class TestNdexStatusV3OAuthUrls {
+
+    private NdexStatusV3 s = new NdexStatusV3();
+
+    @Test
+    public void registerUrlContainsIssuerAndClientId() {
+        String url = s.buildRegisterUrl("https://auth.example.org/realms/ndex", "myclient", "https://ndexbio.org");
+        assertTrue(url.startsWith("https://auth.example.org/realms/ndex/protocol/openid-connect/registrations"));
+        assertTrue(url.contains("client_id=myclient"));
+    }
+
+    @Test
+    public void registerUrlContainsRedirectUri() {
+        String url = s.buildRegisterUrl("https://auth.example.org/realms/ndex", "myclient", "https://ndexbio.org");
+        assertTrue(url.contains("redirect_uri=https://ndexbio.org"));
+    }
+
+    @Test
+    public void registerUrlContainsResponseType() {
+        String url = s.buildRegisterUrl("https://auth.example.org/realms/ndex", "myclient", "https://ndexbio.org");
+        assertTrue(url.contains("response_type=code"));
+    }
+
+    @Test
+    public void resetUrlContainsIssuerAndClientId() {
+        String url = s.buildResetUrl("https://auth.example.org/realms/ndex", "myclient");
+        assertTrue(url.startsWith("https://auth.example.org/realms/ndex/login-actions/reset-credentials"));
+        assertTrue(url.contains("client_id=myclient"));
+    }
+
+    @Test
+    public void oauthFieldsOmittedFromJsonWhenNull() throws Exception {
+        com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+        String json = mapper.writeValueAsString(new NdexStatusV3());
+        assertFalse(json.contains("oauth_register_url"));
+        assertFalse(json.contains("oauth_reset_url"));
+    }
+
+    @Test
+    public void oauthFieldsPresentInJsonWhenSet() throws Exception {
+        NdexStatusV3 status = new NdexStatusV3();
+        status.setOauthRegisterUrl("https://auth.example.org/register");
+        status.setOauthResetUrl("https://auth.example.org/reset");
+        com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+        String json = mapper.writeValueAsString(status);
+        assertTrue(json.contains("\"oauth_register_url\":\"https://auth.example.org/register\""));
+        assertTrue(json.contains("\"oauth_reset_url\":\"https://auth.example.org/reset\""));
+    }
+}

--- a/src/test/resources/ndex.properties
+++ b/src/test/resources/ndex.properties
@@ -15,6 +15,10 @@ Log-Level=info
 
 #VERIFY_NEWUSER_BY_EMAIL=true
 
+USE_KEYCLOAK_AUTHENTICATION=false
+# Optional: enables oauth_register_url / oauth_reset_url in /v3/admin/status
+KEYCLOAK_CLIENT_ID=
+
 USE_GOOGLE_AUTHENTICATION=true
 GOOGLE_OAUTH_CLIENT_ID=fake1
 GOOGLE_OAUTH_CLIENT_SECRET=fake


### PR DESCRIPTION
Need these urls to be provided by rest server so that client apps can detect what the real user register and reset urls are to present directly to users. this feature is referenced by cy-ndex-2 which makes best effort to obtain this info to show to users on NDEx profile dialog in desktop - https://github.com/cytoscape/cy-ndex-2/pull/72

The urls are optional, the oauth client id is needed to construct the full valid url so KEYCLOAK_CLIENT_ID is added as an optional config param here, if absent then oauth urls will be null in response since it can't construct without the client id.

Closes https://cytoscape.atlassian.net/browse/CW-736