### PR TITLE
Create flag for including shortcuts in networks search

### DIFF
--- a/src/main/java/org/ndexbio/common/models/dao/postgresql/PostgresNetworkDAO.java
+++ b/src/main/java/org/ndexbio/common/models/dao/postgresql/PostgresNetworkDAO.java
@@ -98,7 +98,7 @@ public class PostgresNetworkDAO extends NdexDBDAO implements NetworkDAO {
 	
 	private  static List<String> emptyStringList = new ArrayList<>(1); 
 	
-	private static Pattern uuidSearchPattern = 
+	private static Pattern uuidSearchPattern =
 			Pattern.compile("^(uuid: *)?(([0-9A-F]{8}-[0-9A-F]{4}-[1-5][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12})|(\\\"([0-9A-F]{8}-[0-9A-F]{4}-[1-5][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12})\\\"))$",
 			Pattern.CASE_INSENSITIVE);
 
@@ -1121,7 +1121,7 @@ public class PostgresNetworkDAO extends NdexDBDAO implements NetworkDAO {
 			SolrDocumentList publicResults = networkIdx.searchForNetworks(queryStr,
 					(loggedInUser == null ? null : loggedInUser.getUserName()),
 					VisibilityType.PUBLIC, top, skipBlocks * top,
-					simpleNetworkQuery.getAccountName(), simpleNetworkQuery.getPermission());
+					simpleNetworkQuery.getAccountName(), simpleNetworkQuery.getPermission(), false);
 
 			// If authenticated, also query private-nfs for the user's PRIVATE networks
 			SolrDocumentList privateResults = null;
@@ -1129,7 +1129,7 @@ public class PostgresNetworkDAO extends NdexDBDAO implements NetworkDAO {
 				privateResults = networkIdx.searchForNetworks(queryStr,
 						loggedInUser.getUserName(),
 						VisibilityType.PRIVATE, top, skipBlocks * top,
-						simpleNetworkQuery.getAccountName(), simpleNetworkQuery.getPermission());
+						simpleNetworkQuery.getAccountName(), simpleNetworkQuery.getPermission(), false);
 			}
 
 			List<NetworkSummary> results = new ArrayList<>(publicResults.size() +

--- a/src/main/java/org/ndexbio/common/models/search/NFSSearchProvider.java
+++ b/src/main/java/org/ndexbio/common/models/search/NFSSearchProvider.java
@@ -50,7 +50,7 @@ public class NFSSearchProvider implements SearchProvider {
                 documents = delegate.searchByType(query.getSearchString(), userAccessorId,
                         visibilityType,
                         blockSize, skipBlocks, ownedBy,
-                        query.getPermission(), query.getType().toString());
+                        query.getPermission(), query.getType().toString(), true);
                 allSummaries = getDocumentSummariesByEntityType(query.getType(), getUUIDsFromDocuments(documents));
 
             } else {

--- a/src/main/java/org/ndexbio/common/solr/GlobalNetworkIndexManager.java
+++ b/src/main/java/org/ndexbio/common/solr/GlobalNetworkIndexManager.java
@@ -119,10 +119,27 @@ public class GlobalNetworkIndexManager extends NFSIndexManager<NetworkSummary> {
             int limit,
             int offset,
             String adminedBy,
+            Permissions permission,
+            boolean includeShortcuts) throws IOException, SolrServerException, NdexException {
+
+        return searchByType(searchTerms, userAccount, visibilityType, limit, offset,
+                adminedBy, permission, FileType.NETWORK.toString(), includeShortcuts);
+    }
+
+    /**
+     * Backward-compatible overload. Defaults to includeShortcuts=true.
+     */
+    public SolrDocumentList searchForNetworks(
+            String searchTerms,
+            String userAccount,
+            VisibilityType visibilityType,
+            int limit,
+            int offset,
+            String adminedBy,
             Permissions permission) throws IOException, SolrServerException, NdexException {
 
-        return searchByType(searchTerms, userAccount,visibilityType, limit, offset,
-                adminedBy, permission, FileType.NETWORK.toString());
+        return searchForNetworks(searchTerms, userAccount, visibilityType, limit, offset,
+                adminedBy, permission, true);
     }
 
     public void addCX2NodeToIndex(CxNode node, Map<String, Map.Entry<String, DeclarationEntry>> attributeNameMapping)  {
@@ -215,7 +232,7 @@ public class GlobalNetworkIndexManager extends NFSIndexManager<NetworkSummary> {
             for (String indexableString : getIndexableString(node.getNodeRepresents())) {
                 doc.addField(REPRESENTS, indexableString);
             }
-            //	   if( indexableString !=null)
+            //     if( indexableString !=null)
         }
 
 
@@ -223,7 +240,7 @@ public class GlobalNetworkIndexManager extends NFSIndexManager<NetworkSummary> {
     public void addCXNodeAttrToIndex(NodeAttributesElement e)  {
 
         if ( e.getName().equals(NdexClasses.Node_P_alias)) {
-            if ( e.getDataType() == ATTRIBUTE_DATA_TYPE.LIST_OF_STRING 	&& !e.getValues().isEmpty()) {
+            if ( e.getDataType() == ATTRIBUTE_DATA_TYPE.LIST_OF_STRING  && !e.getValues().isEmpty()) {
                 for ( String v : e.getValues()) {
                     for ( String indexableString : getIndexableString(v) ){
                         doc.addField(ALIASES, indexableString);
@@ -368,7 +385,7 @@ public class GlobalNetworkIndexManager extends NFSIndexManager<NetworkSummary> {
         String[] termStringComponents = TermUtilities.getNdexQName(termString);
         if (termStringComponents != null && termStringComponents.length == 2) {
             // case 2: termString is of the form (NamespacePrefix:)*Identifier
-            //		if ( !termStringComponents[0].contains(" "))
+            //     if ( !termStringComponents[0].contains(" "))
             result.add(termString);
             result.add(termStringComponents[1]);
             return  result;

--- a/src/main/java/org/ndexbio/common/solr/GlobalNetworkIndexManager.java
+++ b/src/main/java/org/ndexbio/common/solr/GlobalNetworkIndexManager.java
@@ -110,7 +110,10 @@ public class GlobalNetworkIndexManager extends NFSIndexManager<NetworkSummary> {
     }
 
     /**
-     * Search specifically for networks (backward compatibility)
+     * Search specifically for networks.
+     *
+     * @param includeShortcuts when true, also folds in SHORTCUT docs whose targetType
+     * is NETWORK (v3 behavior); when false, returns only NETWORK docs (v2 behavior).
      */
     public SolrDocumentList searchForNetworks(
             String searchTerms,
@@ -124,22 +127,6 @@ public class GlobalNetworkIndexManager extends NFSIndexManager<NetworkSummary> {
 
         return searchByType(searchTerms, userAccount, visibilityType, limit, offset,
                 adminedBy, permission, FileType.NETWORK.toString(), includeShortcuts);
-    }
-
-    /**
-     * Backward-compatible overload. Defaults to includeShortcuts=true.
-     */
-    public SolrDocumentList searchForNetworks(
-            String searchTerms,
-            String userAccount,
-            VisibilityType visibilityType,
-            int limit,
-            int offset,
-            String adminedBy,
-            Permissions permission) throws IOException, SolrServerException, NdexException {
-
-        return searchForNetworks(searchTerms, userAccount, visibilityType, limit, offset,
-                adminedBy, permission, true);
     }
 
     public void addCX2NodeToIndex(CxNode node, Map<String, Map.Entry<String, DeclarationEntry>> attributeNameMapping)  {

--- a/src/main/java/org/ndexbio/common/solr/NFSIndexManager.java
+++ b/src/main/java/org/ndexbio/common/solr/NFSIndexManager.java
@@ -83,7 +83,7 @@ public abstract class NFSIndexManager<T> implements AutoCloseable {
     /**
      * Public wrapper function for setupIndexDocument that doesn't expose inner SolrInputDocument
      */
-    public void prepareIndexDocument(T  inputData, VisibilityType visibilityType,
+    public void prepareIndexDocument(T inputData, VisibilityType visibilityType,
                                      Collection<String> userReads,
                                      Collection<String> userEdits){
         setupIndexDocument(inputData, visibilityType);
@@ -211,7 +211,7 @@ public abstract class NFSIndexManager<T> implements AutoCloseable {
         }
 
         // Combine filters
-         String resultFilter = "(" + permissionFilter + ")" + ownerFilter;
+        String resultFilter = "(" + permissionFilter + ")" + ownerFilter;
 
         // Set up the query
         configureQuery(solrQuery, searchTerms, resultFilter, limit, offset);
@@ -233,6 +233,14 @@ public abstract class NFSIndexManager<T> implements AutoCloseable {
     /**
      * Search with entity type filter
      */
+    /**
+     * Search with entity type filter.
+     *
+     * @param includeShortcuts when true, also returns SHORTCUT docs whose targetType
+     * matches entityType (for callers that resolve results per entity type, e.g.
+     * v3 NFSSearchProvider). When false, only docs of the exact entityType are
+     * returned (for callers that assume a single type, e.g. v2 findNetworks).
+     */
     public SolrDocumentList searchByType(
             String searchTerms,
             String userAccount,
@@ -241,14 +249,17 @@ public abstract class NFSIndexManager<T> implements AutoCloseable {
             int offset,
             String ownedBy,
             Permissions permission,
-            String entityType) throws NdexException {
+            String entityType,
+            boolean includeShortcuts) throws NdexException {
 
         String typeFilter;
         if ("SHORTCUT".equalsIgnoreCase(entityType)) {
             typeFilter = " AND (" + ENTITY_TYPE + ":\"SHORTCUT\")";
-        } else {
+        } else if (includeShortcuts) {
             typeFilter = " AND ((" + ENTITY_TYPE + ":\"" + entityType + "\") OR " +
                     "(" + ENTITY_TYPE + ":\"SHORTCUT\" AND " + TARGET_TYPE + ":\"" + entityType + "\"))";
+        } else {
+            typeFilter = " AND (" + ENTITY_TYPE + ":\"" + entityType + "\")";
         }
 
         SolrQuery solrQuery = new SolrQuery();
@@ -268,6 +279,23 @@ public abstract class NFSIndexManager<T> implements AutoCloseable {
         } catch (Exception e) {
             throw new NdexException("Error accessing Solr: " + e.getMessage());
         }
+    }
+
+    /**
+     * Backward-compatible overload. Defaults to includeShortcuts=true (folds shortcuts
+     * whose targetType matches entityType into the results).
+     */
+    public SolrDocumentList searchByType(
+            String searchTerms,
+            String userAccount,
+            VisibilityType visibilityType,
+            int limit,
+            int offset,
+            String ownedBy,
+            Permissions permission,
+            String entityType) throws NdexException {
+        return searchByType(searchTerms, userAccount, visibilityType, limit, offset,
+                ownedBy, permission, entityType, true);
     }
 
     /**

--- a/src/main/java/org/ndexbio/common/solr/NFSIndexManager.java
+++ b/src/main/java/org/ndexbio/common/solr/NFSIndexManager.java
@@ -231,9 +231,6 @@ public abstract class NFSIndexManager<T> implements AutoCloseable {
     }
 
     /**
-     * Search with entity type filter
-     */
-    /**
      * Search with entity type filter.
      *
      * @param includeShortcuts when true, also returns SHORTCUT docs whose targetType
@@ -279,23 +276,6 @@ public abstract class NFSIndexManager<T> implements AutoCloseable {
         } catch (Exception e) {
             throw new NdexException("Error accessing Solr: " + e.getMessage());
         }
-    }
-
-    /**
-     * Backward-compatible overload. Defaults to includeShortcuts=true (folds shortcuts
-     * whose targetType matches entityType into the results).
-     */
-    public SolrDocumentList searchByType(
-            String searchTerms,
-            String userAccount,
-            VisibilityType visibilityType,
-            int limit,
-            int offset,
-            String ownedBy,
-            Permissions permission,
-            String entityType) throws NdexException {
-        return searchByType(searchTerms, userAccount, visibilityType, limit, offset,
-                ownedBy, permission, entityType, true);
     }
 
     /**

--- a/src/test/java/org/ndexbio/common/solr/TestFolderIndexManager.java
+++ b/src/test/java/org/ndexbio/common/solr/TestFolderIndexManager.java
@@ -719,7 +719,7 @@ public class TestFolderIndexManager {
 
         manager = new FolderIndexManager(mockWrapper);
         manager.searchByType("test", "user", VisibilityType.PUBLIC, 10, 0,
-                null, null, "FOLDER");
+                null, null, "FOLDER", true);
 
         String[] fq = queryCapture.getValue().getFilterQueries();
         assertTrue(fq[0].contains("entityType:\"FOLDER\""));

--- a/src/test/java/org/ndexbio/common/solr/TestGlobalNetworkIndexManager.java
+++ b/src/test/java/org/ndexbio/common/solr/TestGlobalNetworkIndexManager.java
@@ -777,7 +777,7 @@ public class TestGlobalNetworkIndexManager {
 
         manager = new GlobalNetworkIndexManager(mockWrapper);
         manager.searchByType("test", "user", VisibilityType.PUBLIC, 10, 0,
-                null, null, "NETWORK");
+                null, null, "NETWORK", true);
 
         String[] fq = queryCapture.getValue().getFilterQueries();
         assertTrue(fq[0].contains("entityType:\"NETWORK\""));
@@ -1085,7 +1085,7 @@ public class TestGlobalNetworkIndexManager {
         Thread.sleep(2000);
 
         SolrDocumentList results = manager.searchByType("cancer", "testOwner", VisibilityType.PUBLIC,
-                100, 0, null, null, "NETWORK");
+                100, 0, null, null, "NETWORK", true);
 
         assertNotNull(results);
         assertEquals(1, results.getNumFound());
@@ -1206,7 +1206,7 @@ public class TestGlobalNetworkIndexManager {
         Thread.sleep(2000);
 
         SolrDocumentList results = manager.searchByType("*:*", "testOwner", VisibilityType.PUBLIC,
-                100, 0, null, null, "NETWORK");
+                100, 0, null, null, "NETWORK", true);
 
         assertEquals(1, results.getNumFound());
 

--- a/src/test/java/org/ndexbio/common/solr/TestGlobalNetworkIndexManager.java
+++ b/src/test/java/org/ndexbio/common/solr/TestGlobalNetworkIndexManager.java
@@ -783,6 +783,64 @@ public class TestGlobalNetworkIndexManager {
         assertTrue(fq[0].contains("entityType:\"NETWORK\""));
     }
 
+    @Test
+    public void testSearchByType_IncludeShortcutsTrue_FoldsInMatchingShortcuts() throws Exception {
+        SolrDocumentList mockResults = new SolrDocumentList();
+        mockResults.setNumFound(0);
+
+        QueryResponse mockResponse = createMock(QueryResponse.class);
+        expect(mockResponse.getResults()).andReturn(mockResults);
+        replay(mockResponse);
+
+        mockWrapper = createMock(SolrClientWrapper.class);
+        Capture<SolrQuery> queryCapture = Capture.newInstance();
+        expect(mockWrapper.query(anyString(), capture(queryCapture)))
+                .andReturn(mockResponse);
+        mockWrapper.close();
+        expectLastCall().anyTimes();
+        replay(mockWrapper);
+
+        manager = new GlobalNetworkIndexManager(mockWrapper);
+        manager.searchByType("test", "user", VisibilityType.PUBLIC, 10, 0,
+                null, null, "NETWORK", true);
+
+        String[] fq = queryCapture.getValue().getFilterQueries();
+        // Base entityType clause is always present
+        assertTrue(fq[0].contains("entityType:\"NETWORK\""));
+        // includeShortcuts=true ORs in SHORTCUT docs whose targetType matches
+        assertTrue(fq[0].contains("entityType:\"SHORTCUT\""));
+        assertTrue(fq[0].contains("targetType:\"NETWORK\""));
+    }
+
+    @Test
+    public void testSearchByType_IncludeShortcutsFalse_OmitsShortcutClause() throws Exception {
+        SolrDocumentList mockResults = new SolrDocumentList();
+        mockResults.setNumFound(0);
+
+        QueryResponse mockResponse = createMock(QueryResponse.class);
+        expect(mockResponse.getResults()).andReturn(mockResults);
+        replay(mockResponse);
+
+        mockWrapper = createMock(SolrClientWrapper.class);
+        Capture<SolrQuery> queryCapture = Capture.newInstance();
+        expect(mockWrapper.query(anyString(), capture(queryCapture)))
+                .andReturn(mockResponse);
+        mockWrapper.close();
+        expectLastCall().anyTimes();
+        replay(mockWrapper);
+
+        manager = new GlobalNetworkIndexManager(mockWrapper);
+        manager.searchByType("test", "user", VisibilityType.PUBLIC, 10, 0,
+                null, null, "NETWORK", false);
+
+        String[] fq = queryCapture.getValue().getFilterQueries();
+        // Base entityType clause is still present
+        assertTrue(fq[0].contains("entityType:\"NETWORK\""));
+        // includeShortcuts=false must not fold in the SHORTCUT/targetType OR-clause
+        assertFalse(fq[0].contains("SHORTCUT"));
+        assertFalse(fq[0].contains("targetType"));
+    }
+
     // ========================================================================
     // QUERY FIELDS
     // ========================================================================

--- a/src/test/java/org/ndexbio/common/solr/TestShortcutIndexManager.java
+++ b/src/test/java/org/ndexbio/common/solr/TestShortcutIndexManager.java
@@ -606,7 +606,7 @@ public class TestShortcutIndexManager {
 
         manager = new ShortcutIndexManager(mockWrapper);
         manager.searchByType("test", "user", VisibilityType.PUBLIC, 10, 0,
-                null, null, "SHORTCUT");
+                null, null, "SHORTCUT", true);
 
         String[] fq = queryCapture.getValue().getFilterQueries();
         assertTrue(fq[0].contains("entityType:\"SHORTCUT\""));
@@ -834,7 +834,7 @@ public class TestShortcutIndexManager {
         Thread.sleep(2000);
 
         var results = manager.searchByType("cancer", "testOwner", VisibilityType.PUBLIC,
-                100, 0, null, null, FileType.SHORTCUT.toString());
+                100, 0, null, null, FileType.SHORTCUT.toString(), true);
 
         assertNotNull(results);
         assertEquals(1, results.getNumFound());
@@ -853,12 +853,12 @@ public class TestShortcutIndexManager {
         Thread.sleep(2000);
 
         var page1 = manager.searchByType("*:*", "testOwner", VisibilityType.PUBLIC,
-                5, 0, null, null, FileType.SHORTCUT.toString());
+                5, 0, null, null, FileType.SHORTCUT.toString(), true);
         assertEquals(5, page1.size());
         assertEquals(10, page1.getNumFound());
 
         var page2 = manager.searchByType("*:*", "testOwner", VisibilityType.PUBLIC,
-                5, 5, null, null, FileType.SHORTCUT.toString());
+                5, 5, null, null, FileType.SHORTCUT.toString(), true);
         assertEquals(5, page2.size());
     }
 
@@ -883,7 +883,7 @@ public class TestShortcutIndexManager {
         Thread.sleep(2000);
 
         var results = manager.searchByType("*:*", "testOwner", VisibilityType.PUBLIC,
-                100, 0, null, null, FileType.SHORTCUT.toString());
+                100, 0, null, null, FileType.SHORTCUT.toString(), true);
 
         assertEquals(1, results.getNumFound());
 


### PR DESCRIPTION
Remove redundant logging and network lookups on network shortcuts as networks.
Relates to https://github.com/ndexbio/ndex-rest/issues/101