### PR TITLE
UD-3163 - Adds check for valid UUID for v3 search endpoints with UUID as a path param

### DIFF
--- a/src/main/java/org/ndexbio/rest/services/v3/SearchServiceV3.java
+++ b/src/main/java/org/ndexbio/rest/services/v3/SearchServiceV3.java
@@ -168,12 +168,7 @@ public class SearchServiceV3 extends NdexService  {
 		if ( queryParameters.getSearchDepth() <1) {
 			queryParameters.setSearchDepth(1);
 		}
-		UUID networkId;
-		try {
-			networkId = UUID.fromString(networkIdStr);
-		} catch (IllegalArgumentException e) {
-			throw new BadRequestException("'" + networkIdStr + "' is not a valid network UUID.");
-		}
+		UUID networkId = parseUuid(networkIdStr);
 
 		UUID userId = getLoggedInUserId();
 		if (  saveAsNetwork) {
@@ -261,12 +256,7 @@ public class SearchServiceV3 extends NdexService  {
 			queryParameters.setSearchDepth(1);
 		}
 
-		UUID networkId;
-		try {
-			networkId = UUID.fromString(networkIdStr);
-		} catch (IllegalArgumentException e) {
-			throw new BadRequestException("'" + networkIdStr + "' is not a valid network UUID.");
-		}
+		UUID networkId = parseUuid(networkIdStr);
 		UUID userId = getLoggedInUserId();
 		if (  saveAsNetwork) {
 			if (userId == null)
@@ -354,12 +344,7 @@ public class SearchServiceV3 extends NdexService  {
 		
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO())  {
 			UUID userId = getLoggedInUserId();
-			UUID networkId;
-			try {
-				networkId = UUID.fromString(networkIdStr);
-			} catch (IllegalArgumentException e) {
-				throw new BadRequestException("'" + networkIdStr + "' is not a valid network UUID.");
-			}
+			UUID networkId = parseUuid(networkIdStr);
 			if ( dao.isReadable(networkId, userId) || dao.accessKeyIsValid(networkId, accessKey)) {
 				List<CxMetadata> md = dao.getCx2MetaDataList(networkId);
 			
@@ -413,7 +398,17 @@ public class SearchServiceV3 extends NdexService  {
 			throw new UnauthorizedOperationException ("Unauthorized access to network " + networkId);
 		}
 	}
-	
+
+	private UUID parseUuid(String uuidStr) throws BadRequestException {
+		UUID networkId;
+		try {
+			networkId = UUID.fromString(uuidStr);
+		} catch (IllegalArgumentException e) {
+			throw new BadRequestException("'" + uuidStr + "' is not a valid network UUID.");
+		}
+		return networkId;
+
+	}
 	protected class NodeAttrsFilterThread extends Thread {
 		
 		private PipedOutputStream out;

--- a/src/main/java/org/ndexbio/rest/services/v3/SearchServiceV3.java
+++ b/src/main/java/org/ndexbio/rest/services/v3/SearchServiceV3.java
@@ -168,7 +168,12 @@ public class SearchServiceV3 extends NdexService  {
 		if ( queryParameters.getSearchDepth() <1) {
 			queryParameters.setSearchDepth(1);
 		}
-		UUID networkId = UUID.fromString(networkIdStr);
+		UUID networkId;
+		try {
+			networkId = UUID.fromString(networkIdStr);
+		} catch (IllegalArgumentException e) {
+			throw new BadRequestException("'" + networkIdStr + "' is not a valid network UUID.");
+		}
 
 		UUID userId = getLoggedInUserId();
 		if (  saveAsNetwork) {
@@ -256,8 +261,12 @@ public class SearchServiceV3 extends NdexService  {
 			queryParameters.setSearchDepth(1);
 		}
 
-		UUID networkId = UUID.fromString(networkIdStr);
-
+		UUID networkId;
+		try {
+			networkId = UUID.fromString(networkIdStr);
+		} catch (IllegalArgumentException e) {
+			throw new BadRequestException("'" + networkIdStr + "' is not a valid network UUID.");
+		}
 		UUID userId = getLoggedInUserId();
 		if (  saveAsNetwork) {
 			if (userId == null)
@@ -345,7 +354,12 @@ public class SearchServiceV3 extends NdexService  {
 		
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO())  {
 			UUID userId = getLoggedInUserId();
-			UUID networkId = UUID.fromString(networkIdStr);
+			UUID networkId;
+			try {
+				networkId = UUID.fromString(networkIdStr);
+			} catch (IllegalArgumentException e) {
+				throw new BadRequestException("'" + networkIdStr + "' is not a valid network UUID.");
+			}
 			if ( dao.isReadable(networkId, userId) || dao.accessKeyIsValid(networkId, accessKey)) {
 				List<CxMetadata> md = dao.getCx2MetaDataList(networkId);
 			

--- a/src/main/java/org/ndexbio/rest/services/v3/SearchServiceV3.java
+++ b/src/main/java/org/ndexbio/rest/services/v3/SearchServiceV3.java
@@ -332,8 +332,6 @@ public class SearchServiceV3 extends NdexService  {
 	@POST
 	@Path("/networks/{networkId}/nodes")
 	@Produces("application/json")
-
-	
 	public Response getNodeAttributes (@PathParam("networkId") final String networkIdStr,
 			@QueryParam("accesskey") String accessKey,
 			final CXObjectFilter filterObject) throws SQLException, IOException, NdexException {
@@ -341,10 +339,9 @@ public class SearchServiceV3 extends NdexService  {
 		if(filterObject.getAttributeNames().size()==0) {
 			throw new BadRequestException("At least one attribute name is reqired in the 'attributeNames' field.");
 		}
-		
+		UUID networkId = parseUuid(networkIdStr);
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO())  {
 			UUID userId = getLoggedInUserId();
-			UUID networkId = parseUuid(networkIdStr);
 			if ( dao.isReadable(networkId, userId) || dao.accessKeyIsValid(networkId, accessKey)) {
 				List<CxMetadata> md = dao.getCx2MetaDataList(networkId);
 			
@@ -400,6 +397,9 @@ public class SearchServiceV3 extends NdexService  {
 	}
 
 	private UUID parseUuid(String uuidStr) throws BadRequestException {
+		if (uuidStr == null) {
+			throw new BadRequestException("Network UUID is required.");
+		}
 		UUID networkId;
 		try {
 			networkId = UUID.fromString(uuidStr);
@@ -407,7 +407,6 @@ public class SearchServiceV3 extends NdexService  {
 			throw new BadRequestException("'" + uuidStr + "' is not a valid network UUID.");
 		}
 		return networkId;
-
 	}
 	protected class NodeAttrsFilterThread extends Thread {
 		

--- a/src/main/java/org/ndexbio/rest/services/v3/SearchServiceV3.java
+++ b/src/main/java/org/ndexbio/rest/services/v3/SearchServiceV3.java
@@ -337,7 +337,7 @@ public class SearchServiceV3 extends NdexService  {
 			final CXObjectFilter filterObject) throws SQLException, IOException, NdexException {
 		
 		if(filterObject.getAttributeNames().size()==0) {
-			throw new BadRequestException("At least one attribute name is reqired in the 'attributeNames' field.");
+			throw new BadRequestException("At least one attribute name is required in the 'attributeNames' field.");
 		}
 		UUID networkId = parseUuid(networkIdStr);
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO())  {

--- a/src/main/java/org/ndexbio/rest/services/v3/SearchServiceV3.java
+++ b/src/main/java/org/ndexbio/rest/services/v3/SearchServiceV3.java
@@ -396,7 +396,7 @@ public class SearchServiceV3 extends NdexService  {
 		}
 	}
 
-	private UUID parseUuid(String uuidStr) throws BadRequestException {
+	UUID parseUuid(String uuidStr) throws BadRequestException {
 		if (uuidStr == null) {
 			throw new BadRequestException("Network UUID is required.");
 		}

--- a/src/test/java/org/ndexbio/rest/services/v3/TestSearchServiceV3.java
+++ b/src/test/java/org/ndexbio/rest/services/v3/TestSearchServiceV3.java
@@ -1,0 +1,122 @@
+package org.ndexbio.rest.services.v3;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.ndexbio.model.exceptions.BadRequestException;
+import org.ndexbio.model.network.query.CXObjectFilter;
+import org.ndexbio.model.object.CXSimplePathQuery;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+public class TestSearchServiceV3 {
+
+    private static final SearchServiceV3 _searchService = new SearchServiceV3(null);
+
+    // ---------- parseUuid: direct unit tests ----------
+
+    @Test
+    public void parseUuidValid() throws BadRequestException {
+        String input = "550e8400-e29b-41d4-a716-446655440000";
+        UUID result = _searchService.parseUuid(input);
+        Assert.assertEquals(UUID.fromString(input), result);
+    }
+
+    @Test
+    public void parseUuidRoundTrip() throws BadRequestException {
+        UUID original = UUID.randomUUID();
+        UUID result = _searchService.parseUuid(original.toString());
+        Assert.assertEquals(original, result);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void parseUuidMalformed() throws BadRequestException {
+        _searchService.parseUuid("not-a-uuid");
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void parseUuidEmpty() throws BadRequestException {
+        _searchService.parseUuid("");
+    }
+
+    // Passes now that the null guard is in place.
+    @Test(expected = BadRequestException.class)
+    public void parseUuidNull() throws BadRequestException {
+        _searchService.parseUuid(null);
+    }
+
+    // ---------- controllers: malformed UUID must be rejected before any DAO work ----------
+
+    @Test(expected = BadRequestException.class)
+    public void queryNetworkAsCXRejectsBadUuid() throws Exception {
+        _searchService.queryNetworkAsCX("not-a-uuid", null, false, false, validPathQuery());
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void interconnectQueryRejectsBadUuid() throws Exception {
+        _searchService.interconnectQuery("not-a-uuid", null, false, false, validPathQuery());
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void getNodeAttributesRejectsBadUuid() throws Exception {
+        _searchService.getNodeAttributes("not-a-uuid", null, filterWithOneAttr());
+    }
+
+    // ---------- controllers: a VALID uuid is NOT rejected as malformed ----------
+    // A valid UUID gets past parseUuid and then fails downstream (no DB/Configuration
+    // in unit-test context -> NullPointerException). Any non-BadRequestException proves
+    // parsing accepted the UUID, which is what we're asserting here.
+
+    @Test
+    public void queryNetworkAsCXAcceptsValidUuid() {
+        try {
+            _searchService.queryNetworkAsCX(UUID.randomUUID().toString(), null, false, false, validPathQuery());
+        } catch (BadRequestException e) {
+            Assert.fail("Valid UUID should not be rejected as a bad request: " + e.getMessage());
+        } catch (Exception expectedDownstream) {
+            // DAO/Configuration failure is expected: proves we got past parseUuid.
+        }
+    }
+
+    @Test
+    public void interconnectQueryAcceptsValidUuid() {
+        try {
+            _searchService.interconnectQuery(UUID.randomUUID().toString(), null, false, false, validPathQuery());
+        } catch (BadRequestException e) {
+            Assert.fail("Valid UUID should not be rejected as a bad request: " + e.getMessage());
+        } catch (Exception expectedDownstream) {
+            // expected
+        }
+    }
+
+    @Test
+    public void getNodeAttributesAcceptsValidUuid() {
+        try {
+            // Non-empty attributeNames so the only possible BadRequestException
+            // would be from the UUID itself (which is valid here).
+            _searchService.getNodeAttributes(UUID.randomUUID().toString(), null, filterWithOneAttr());
+        } catch (BadRequestException e) {
+            Assert.fail("Valid UUID should not be rejected as a bad request: " + e.getMessage());
+        } catch (Exception expectedDownstream) {
+            // expected
+        }
+    }
+
+    // ---------- helpers ----------
+
+    private static CXSimplePathQuery validPathQuery() {
+        CXSimplePathQuery q = new CXSimplePathQuery();
+        q.setSearchString("test");
+        q.setSearchDepth(1);
+        return q;
+    }
+
+    private static CXObjectFilter filterWithOneAttr() {
+        CXObjectFilter f = new CXObjectFilter();
+        Set<String> names = new HashSet<>();
+        names.add("name");
+        f.setAttributeNames(names);
+        return f;
+    }
+}


### PR DESCRIPTION
Returns badrequest instead of generic 500 error