### PR TITLE
getNetworkSet stops using networkset table

### DIFF
--- a/src/main/java/org/ndexbio/common/models/dao/FolderDAO.java
+++ b/src/main/java/org/ndexbio/common/models/dao/FolderDAO.java
@@ -22,6 +22,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 
 public interface FolderDAO extends AutoCloseable {
+
+	@Override
+	void close() throws SQLException;
 	
 	void commit() throws SQLException;
 	

--- a/src/main/java/org/ndexbio/common/models/dao/postgresql/NetworkSetDAO.java
+++ b/src/main/java/org/ndexbio/common/models/dao/postgresql/NetworkSetDAO.java
@@ -2,6 +2,7 @@ package org.ndexbio.common.models.dao.postgresql;
 
 import java.io.IOException;
 import java.security.SecureRandom;
+import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -11,6 +12,7 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
@@ -33,9 +35,27 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class NetworkSetDAO extends NdexDBDAO {
+	@FunctionalInterface
+	public interface FolderDAOProvider {
+		FolderDAO get() throws SQLException;
+	}
+
+	private final FolderDAOProvider folderDAOProvider;
 
 	public NetworkSetDAO() throws SQLException {
 		super();
+		this.folderDAOProvider = () -> Configuration.getInstance().getDAOFactory().getFolderDAO();
+	}
+
+	public NetworkSetDAO(Connection connection, FolderDAO folderDAO) {
+		super(connection);
+		Objects.requireNonNull(folderDAO, "folderDAO");
+		this.folderDAOProvider = () -> folderDAO;
+	}
+
+	public NetworkSetDAO(Connection connection, FolderDAOProvider folderDAOProvider) {
+		super(connection);
+		this.folderDAOProvider = Objects.requireNonNull(folderDAOProvider, "folderDAOProvider");
 	}
 
 	public void createNetworkSet(UUID setId, String name, String desc, UUID ownerId, Map<String,Object> properties) throws SQLException, DuplicateObjectException, JsonProcessingException {
@@ -131,7 +151,7 @@ public class NetworkSetDAO extends NdexDBDAO {
 	public NetworkSet getNetworkSet(UUID setId, UUID userId, String accessKey) throws SQLException, ObjectNotFoundException, UnauthorizedOperationException, JsonParseException, JsonMappingException, IOException, NdexException {
 		
 		// All network sets are now folder-backed. Query the folder using its UUID (same as old network_set UUID).
-		try (FolderDAO folderDAO = Configuration.getInstance().getDAOFactory().getFolderDAO()) {
+		try (FolderDAO folderDAO = folderDAOProvider.get()) {
 			NdexFolder folder = folderDAO.getFolder(setId, userId, accessKey);
 			
 			NetworkSet result = new NetworkSet();
@@ -205,7 +225,7 @@ public class NetworkSetDAO extends NdexDBDAO {
 		// All network sets are now folder-backed. Query folders owned by userId.
 		List<NetworkSet> result = new ArrayList<>();
 		
-		try (FolderDAO folderDAO = Configuration.getInstance().getDAOFactory().getFolderDAO()) {
+		try (FolderDAO folderDAO = folderDAOProvider.get()) {
 			// Fetch enough rows to support offset/limit semantics. In the previous implementation, limit<=0 meant "no limit".
 			final int fetchLimit = (limit > 0 ? (offset > 0 ? offset + limit : limit) : Integer.MAX_VALUE);
 			List<NdexFolder> userFolders = folderDAO.listFoldersOfUser(userId, fetchLimit);

--- a/src/main/java/org/ndexbio/common/models/dao/postgresql/NetworkSetDAO.java
+++ b/src/main/java/org/ndexbio/common/models/dao/postgresql/NetworkSetDAO.java
@@ -152,7 +152,7 @@ public class NetworkSetDAO extends NdexDBDAO {
 			// - For network-type shortcuts: replace shortcut UUID with target network UUID (only if target is ACTIVE)
 			// - Exclude deleted/in-trash network shortcuts
 			// - Deduplicate network UUIDs, preserve first-seen order
-			List<FileItemSummary> folderItems = folderDAO.listItemsInFolder(setId, true, null);
+			List<FileItemSummary> folderItems = folderDAO.listItemsInFolder(setId, true, FileType.NETWORK);
 			
 			Set<UUID> seenNetworkIds = new LinkedHashSet<>();
 			for (FileItemSummary item : folderItems) {
@@ -233,7 +233,7 @@ public class NetworkSetDAO extends NdexDBDAO {
 				// Populate networks unless summaryOnly is true
 				if (!summaryOnly) {
 					// Get folder members and normalize them according to v2 constraints
-					List<FileItemSummary> folderItems = folderDAO.listItemsInFolder(folder.getExternalId(), true, null);
+					List<FileItemSummary> folderItems = folderDAO.listItemsInFolder(folder.getExternalId(), true, FileType.NETWORK);
 					
 					Set<UUID> seenNetworkIds = new LinkedHashSet<>();
 					for (FileItemSummary item : folderItems) {

--- a/src/main/java/org/ndexbio/common/models/dao/postgresql/NetworkSetDAO.java
+++ b/src/main/java/org/ndexbio/common/models/dao/postgresql/NetworkSetDAO.java
@@ -206,8 +206,9 @@ public class NetworkSetDAO extends NdexDBDAO {
 		List<NetworkSet> result = new ArrayList<>();
 		
 		try (FolderDAO folderDAO = Configuration.getInstance().getDAOFactory().getFolderDAO()) {
-			// Get all folders owned by userId (limit is applied by listFoldersOfUser)
-			List<NdexFolder> userFolders = folderDAO.listFoldersOfUser(userId, limit);
+			// Fetch enough rows to support offset/limit semantics. In the previous implementation, limit<=0 meant "no limit".
+			final int fetchLimit = (limit > 0 ? (offset > 0 ? offset + limit : limit) : Integer.MAX_VALUE);
+			List<NdexFolder> userFolders = folderDAO.listFoldersOfUser(userId, fetchLimit);
 			
 			// Apply offset manually since FolderDAO doesn't support offset
 			int startIdx = Math.max(0, offset >= 0 ? offset : 0);

--- a/src/main/java/org/ndexbio/common/models/dao/postgresql/NetworkSetDAO.java
+++ b/src/main/java/org/ndexbio/common/models/dao/postgresql/NetworkSetDAO.java
@@ -8,22 +8,27 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import jakarta.xml.bind.DatatypeConverter;
 
+import org.ndexbio.common.models.dao.FolderDAO;
+import org.ndexbio.rest.Configuration;
 import org.ndexbio.model.exceptions.DuplicateObjectException;
 import org.ndexbio.model.exceptions.NdexException;
 import org.ndexbio.model.exceptions.ObjectNotFoundException;
 import org.ndexbio.model.exceptions.UnauthorizedOperationException;
+import org.ndexbio.model.object.FileItemSummary;
+import org.ndexbio.model.object.FileType;
 import org.ndexbio.model.object.NetworkSet;
+import org.ndexbio.model.object.NdexFolder;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -123,64 +128,45 @@ public class NetworkSetDAO extends NdexDBDAO {
 		
 	}
 	
-	public NetworkSet getNetworkSet(UUID setId, UUID userId, String accessKey) throws SQLException, ObjectNotFoundException, UnauthorizedOperationException, JsonParseException, JsonMappingException, IOException {
+	public NetworkSet getNetworkSet(UUID setId, UUID userId, String accessKey) throws SQLException, ObjectNotFoundException, UnauthorizedOperationException, JsonParseException, JsonMappingException, IOException, NdexException {
 		
-		NetworkSet result = new NetworkSet();
-		String sqlStr = "select creation_time, modification_time, owner_id, name, description, access_key, access_key_is_on, other_attributes,showcased, ndexdoi from network_set  where \"UUID\"=? and is_deleted=false";
-		
-		String dbAccessKey = null;
-		boolean dbKeyIsOn;
-		try (PreparedStatement p = db.prepareStatement(sqlStr)) {
-			p.setObject(1, setId);
-			try ( ResultSet rs = p.executeQuery()) {
-				if ( rs.next()) {
-					result.setCreationTime(rs.getTimestamp(1));
-					result.setModificationTime(rs.getTimestamp(2));
-					result.setExternalId(setId);
-					result.setOwnerId((UUID)rs.getObject(3));
-					result.setName(rs.getString(4));
-					result.setDescription(rs.getString(5));
-					dbAccessKey = rs.getString(6);
-					dbKeyIsOn = rs.getBoolean(7);
-					
-					String propStr = rs.getString(8);
-					
-					if ( propStr != null) {
-						ObjectMapper mapper = new ObjectMapper(); 
-						TypeReference<HashMap<String,Object>> typeRef 
-				            = new TypeReference<HashMap<String,Object>>() {/**/};
-
-				            HashMap<String,Object> o = mapper.readValue(propStr, typeRef); 		
-				            result.setProperties(o);
-					}
-					
-					result.setShowcased(rs.getBoolean(9));
-					result.setDoi(rs.getString(10));
-				} else
-					throw new ObjectNotFoundException("Network set" + setId + " not found in db.");
+		// All network sets are now folder-backed. Query the folder using its UUID (same as old network_set UUID).
+		try (FolderDAO folderDAO = Configuration.getInstance().getDAOFactory().getFolderDAO()) {
+			NdexFolder folder = folderDAO.getFolder(setId, userId, accessKey);
+			
+			NetworkSet result = new NetworkSet();
+			result.setExternalId(setId);
+			result.setCreationTime(folder.getCreationTime());
+			result.setModificationTime(folder.getModificationTime());
+			result.setOwnerId(UUID.fromString(folder.getOwner_id()));
+			result.setName(folder.getName());
+			result.setDescription(folder.getDescription());
+			
+			// Folders don't have showcased flag or DOI, so these are not set.
+			// showcasedOnly is treated as no-op for migrated folder-backed sets.
+			
+			// Get folder members and normalize them according to v2 constraints:
+			// - Include direct networks (FileType.NETWORK)
+			// - Exclude folders (FileType.FOLDER)
+			// - Exclude folder-type shortcuts (FileType.SHORTCUT with target_type='FOLDER')
+			// - For network-type shortcuts: replace shortcut UUID with target network UUID (only if target is ACTIVE)
+			// - Exclude deleted/in-trash network shortcuts
+			// - Deduplicate network UUIDs, preserve first-seen order
+			List<FileItemSummary> folderItems = folderDAO.listItemsInFolder(setId, true, null);
+			
+			Set<UUID> seenNetworkIds = new LinkedHashSet<>();
+			for (FileItemSummary item : folderItems) {
+				if (item.getType() == FileType.NETWORK) {
+					// Direct network member
+					seenNetworkIds.add(item.getUuid());
+				} else if (item.getType() == FileType.SHORTCUT) {
+					includeNetworkShortcut(item.getAttributes(), seenNetworkIds);
+				}
 			}
+			
+			result.setNetworks(new ArrayList<>(seenNetworkIds));
+			return result;
 		}
-		
-		boolean keyIsValid = false;
-		if (dbKeyIsOn && accessKey!= null && dbAccessKey.equals(accessKey))
-			keyIsValid = true;
-		if (!keyIsValid && accessKey!=null)
-			throw new UnauthorizedOperationException("In valid network set access key.");
-		
-		sqlStr = "select nm.network_id from network_set_member nm, network n where nm.set_id =? and n.\"UUID\"=nm.network_id and " + 
-				( keyIsValid ? " true" : PostgresNetworkDAO.createIsReadableConditionStr(userId)) ;
-		
-		try (PreparedStatement p = db.prepareStatement(sqlStr)) {
-			p.setObject(1, setId);
-			try ( ResultSet rs = p.executeQuery()) {
-				List<UUID> networkIds = result.getNetworks();
-				while ( rs.next()) {
-					networkIds.add((UUID)rs.getObject(1));
-				} 
-			}
-		}
-		
-		return result;
 	}
 
 	public void addNetworksToNetworkSet(UUID setId, Collection<UUID> networkIds) throws SQLException {
@@ -214,70 +200,80 @@ public class NetworkSetDAO extends NdexDBDAO {
 	
 	public List<NetworkSet> getNetworkSetsByUserId(UUID userId, UUID signedInUserId, int offset, int limit,
 			boolean summaryOnly, boolean showcasedOnly
-			) throws SQLException, JsonParseException, JsonMappingException, IOException {
+			) throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException {
 		
+		// All network sets are now folder-backed. Query folders owned by userId.
 		List<NetworkSet> result = new ArrayList<>();
 		
-		String sqlStr = "select creation_time, modification_time, \"UUID\", name, description, other_attributes,showcased from network_set  where owner_id=? and is_deleted=false"
-				 + (showcasedOnly? " and showcased = true" : "");
-	
-		if ( offset>=0 && limit>0) {
-			sqlStr += " limit " +limit + " offset " + offset;
-		}
-		
-		try (PreparedStatement p = db.prepareStatement(sqlStr)) {
-			p.setObject(1, userId);
-			try ( ResultSet rs = p.executeQuery()) {
-				while ( rs.next()) {
-					NetworkSet entry = new NetworkSet();
-					entry.setCreationTime(rs.getTimestamp(1));
-					entry.setModificationTime(rs.getTimestamp(2));
-					entry.setExternalId((UUID)rs.getObject(3));
-					entry.setOwnerId(userId);
-					entry.setName(rs.getString(4));
-					entry.setDescription(rs.getString(5));
-					
-					String propStr = rs.getString(6);
-					
-					if ( propStr != null) {
-						ObjectMapper mapper = new ObjectMapper(); 
-						TypeReference<HashMap<String,Object>> typeRef 
-				            = new TypeReference<HashMap<String,Object>>() {/**/};
-				            HashMap<String,Object> o = mapper.readValue(propStr, typeRef); 		
-				            entry.setProperties(o);
-					}
-					
-					entry.setShowcased(rs.getBoolean(7));
-					entry.setOwnerId(userId);
-
-					result.add(entry);
-				} 
+		try (FolderDAO folderDAO = Configuration.getInstance().getDAOFactory().getFolderDAO()) {
+			// Get all folders owned by userId (limit is applied by listFoldersOfUser)
+			List<NdexFolder> userFolders = folderDAO.listFoldersOfUser(userId, limit);
+			
+			// Apply offset manually since FolderDAO doesn't support offset
+			int startIdx = Math.max(0, offset >= 0 ? offset : 0);
+			int endIdx = Math.min(userFolders.size(), offset >= 0 && limit > 0 ? offset + limit : userFolders.size());
+			if (startIdx >= userFolders.size()) {
+				return result;
 			}
-		}
-		
-		if ( summaryOnly) {
-			for (NetworkSet entry : result) {
-				entry.setNetworks(null);
-			}
-		} else {	
-			sqlStr = "select network_id from network_set_member nm, network n where nm.set_id =? and nm.network_id = n.\"UUID\" and " + PostgresNetworkDAO.createIsReadableConditionStr(signedInUserId);
-		
-			for (NetworkSet entry : result) {
-				try (PreparedStatement p = db.prepareStatement(sqlStr)) {
-					p.setObject(1, entry.getExternalId());
-					try ( ResultSet rs = p.executeQuery()) {
-						List<UUID> networkIds = entry.getNetworks();
-						while ( rs.next()) {
-							networkIds.add((UUID)rs.getObject(1));
-						} 
+			
+			List<NdexFolder> pagedFolders = userFolders.subList(startIdx, endIdx);
+			
+			for (NdexFolder folder : pagedFolders) {
+				NetworkSet entry = new NetworkSet();
+				entry.setExternalId(folder.getExternalId());
+				entry.setCreationTime(folder.getCreationTime());
+				entry.setModificationTime(folder.getModificationTime());
+				entry.setOwnerId(userId);
+				entry.setName(folder.getName());
+				entry.setDescription(folder.getDescription());
+				
+				// Folders don't have showcased flag or DOI, so these are not set.
+				// showcasedOnly is treated as no-op for migrated folder-backed sets.
+				
+				// Populate networks unless summaryOnly is true
+				if (!summaryOnly) {
+					// Get folder members and normalize them according to v2 constraints
+					List<FileItemSummary> folderItems = folderDAO.listItemsInFolder(folder.getExternalId(), true, null);
+					
+					Set<UUID> seenNetworkIds = new LinkedHashSet<>();
+					for (FileItemSummary item : folderItems) {
+						if (item.getType() == FileType.NETWORK) {
+							// Direct network member
+							seenNetworkIds.add(item.getUuid());
+						} else if (item.getType() == FileType.SHORTCUT) {
+							includeNetworkShortcut(item.getAttributes(), seenNetworkIds);
+						}
 					}
+					entry.setNetworks(new ArrayList<>(seenNetworkIds));
 				}
+				result.add(entry);
 			}
 		}
+		
 		return result;
 	}
 
-	
+	private void includeNetworkShortcut(Map<String, Object> attrs, Set<UUID> seenNetworkIds) {
+		if (attrs == null) {
+			return;
+		}
+
+		String targetType = (String) attrs.get("target_type");
+		if (!"NETWORK".equals(targetType)) {
+			return;
+		}
+
+		String targetStatus = (String) attrs.get("target_status");
+		if (!"ACTIVE".equals(targetStatus)) {
+			return;
+		}
+
+		UUID targetId = (UUID) attrs.get("target");
+		if (targetId != null) {
+			seenNetworkIds.add(targetId);
+		}
+	}
+
 	public int getNetworkSetCountByUserId(UUID userId) throws SQLException, NdexException {
 		
 		String sqlStr = "select count(*) from network_set  where owner_id=? and is_deleted=false";

--- a/src/main/java/org/ndexbio/rest/services/NetworkSetServiceV2.java
+++ b/src/main/java/org/ndexbio/rest/services/NetworkSetServiceV2.java
@@ -33,7 +33,6 @@ import org.ndexbio.model.exceptions.UnauthorizedOperationException;
 import org.ndexbio.model.object.NetworkSet;
 import org.ndexbio.model.object.NdexShortcut;
 import org.ndexbio.model.object.FileType;
-import org.ndexbio.model.object.NdexFolder;
 import org.ndexbio.model.object.FolderRequest;
 import org.ndexbio.rest.Configuration;
 
@@ -178,34 +177,11 @@ public class NetworkSetServiceV2 extends NdexService {
 		
 		UUID setId = UUID.fromString(networkSetIdStr);
 		
-		// Check if id exists in networkset table first
+		// All network sets are now folder-backed. NetworkSetDAO.getNetworkSet() queries folders exclusively.
 		try (NetworkSetDAO networkSetDAO = new NetworkSetDAO()) {
 			NetworkSet networkSet = networkSetDAO.getNetworkSet(setId, getLoggedInUserId(), accessKey);
 			return networkSet;
-		} catch (SQLException | ObjectNotFoundException e) {
-			// NetworkSet not found, continue to check folder
 		}
-		
-		// Check if id exists in folder table
-		try (FolderDAO folderDAO = Configuration.getInstance().getDAOFactory().getFolderDAO()) {
-			if (folderDAO.isReadable(setId, getLoggedInUserId()) || folderDAO.accessKeyIsValid(setId, accessKey)) {
-				NdexFolder folder = folderDAO.getFolder(setId, getLoggedInUserId(), accessKey);
-				
-				// Convert folder to NetworkSet format
-				NetworkSet networkSet = new NetworkSet();
-				networkSet.setExternalId(folder.getExternalId());
-				networkSet.setName(folder.getName());
-				networkSet.setCreationTime(folder.getCreationTime());
-				networkSet.setModificationTime(folder.getModificationTime());
-				networkSet.setOwnerId(getLoggedInUserId());
-				
-				return networkSet;
-			}
-		} catch (SQLException | ObjectNotFoundException e) {
-			// Folder not found
-		}
-		
-		throw new ObjectNotFoundException("Network set or folder " + setId + " not found.");
 	}
 
 	@POST

--- a/src/main/java/org/ndexbio/rest/services/UserServiceV2.java
+++ b/src/main/java/org/ndexbio/rest/services/UserServiceV2.java
@@ -35,7 +35,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -1225,19 +1224,14 @@ public class UserServiceV2 extends NdexService {
 						@DefaultValue("0") @QueryParam("limit") int limit,
 						@DefaultValue("false") @QueryParam("summary") boolean summaryOnly,
 						@DefaultValue("false") @QueryParam("showcase") boolean showcasedOnly
-						) throws SQLException, JsonParseException, JsonMappingException, IOException {
-				
+					) throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException {
 			UUID userId = UUID.fromString(userIdStr);
 					
 			try (NetworkSetDAO dao = new NetworkSetDAO ()){
 					List<NetworkSet> sets= dao.getNetworkSetsByUserId(userId, getLoggedInUserId(), offset, limit, summaryOnly, showcasedOnly);
 					return sets;
 				}
-				
-			}   
-
-	
-	// these are just prototypes not in production, 
+	}
 
 	/**************************************************************************
 	 * Authenticates a user from Google OAuth openID Connect

--- a/src/test/java/org/ndexbio/common/models/dao/postgresql/NetworkSetDAOTest.java
+++ b/src/test/java/org/ndexbio/common/models/dao/postgresql/NetworkSetDAOTest.java
@@ -1,0 +1,201 @@
+package org.ndexbio.common.models.dao.postgresql;
+
+import static org.junit.Assert.*;
+
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.ndexbio.model.object.FileItemSummary;
+import org.ndexbio.model.object.FileType;
+
+public class NetworkSetDAOTest {
+    
+    private UUID networkId1;
+    private UUID networkId2;
+    private UUID shortcutId1;
+    private UUID childFolderId;
+    
+    @Before
+    public void setUp() throws SQLException {
+        // Generate test UUIDs
+        networkId1 = UUID.randomUUID();
+        networkId2 = UUID.randomUUID();
+        shortcutId1 = UUID.randomUUID();
+        childFolderId = UUID.randomUUID();
+    }
+    
+    @Test
+    public void testGetNetworkSet_DirectNetworks() throws Exception {
+        // Create folder items with direct networks
+        List<FileItemSummary> folderItems = new ArrayList<>();
+        folderItems.add(createNetworkItem(networkId1, "Network 1"));
+        folderItems.add(createNetworkItem(networkId2, "Network 2"));
+        
+        // Extract network IDs from folder items
+        List<UUID> networkIds = extractNetworkIds(folderItems);
+
+        assertEquals(2, networkIds.size());
+        assertTrue(networkIds.contains(networkId1));
+        assertTrue(networkIds.contains(networkId2));
+    }
+    
+    @Test
+    public void testGetNetworkSet_ExcludeFolders() throws Exception {
+        List<FileItemSummary> folderItems = new ArrayList<>();
+        folderItems.add(createNetworkItem(networkId1, "Network 1"));
+        folderItems.add(createFolderItem(childFolderId, "Child Folder"));
+        folderItems.add(createNetworkItem(networkId2, "Network 2"));
+        
+        List<UUID> networkIds = extractNetworkIds(folderItems);
+
+        assertEquals(2, networkIds.size());
+        assertTrue(networkIds.contains(networkId1));
+        assertTrue(networkIds.contains(networkId2));
+        assertFalse(networkIds.contains(childFolderId));
+    }
+    
+    @Test
+    public void testGetNetworkSet_ExcludeFolderShortcuts() throws Exception {
+        List<FileItemSummary> folderItems = new ArrayList<>();
+        folderItems.add(createNetworkItem(networkId1, "Network 1"));
+        folderItems.add(createFolderTypeShortcut(shortcutId1, "Folder Shortcut", childFolderId));
+        folderItems.add(createNetworkItem(networkId2, "Network 2"));
+        
+        List<UUID> networkIds = extractNetworkIds(folderItems);
+
+        assertEquals(2, networkIds.size());
+        assertTrue(networkIds.contains(networkId1));
+        assertTrue(networkIds.contains(networkId2));
+        assertFalse(networkIds.contains(shortcutId1));
+    }
+    
+    @Test
+    public void testGetNetworkSet_NetworkShortcutsActive() throws Exception {
+        List<FileItemSummary> folderItems = new ArrayList<>();
+        folderItems.add(createNetworkItem(networkId1, "Network 1"));
+        folderItems.add(createNetworkTypeShortcut(shortcutId1, "Network Shortcut 1", networkId2, "ACTIVE"));
+        
+        List<UUID> networkIds = extractNetworkIds(folderItems);
+
+        assertEquals(2, networkIds.size());
+        assertTrue(networkIds.contains(networkId1));
+        assertTrue(networkIds.contains(networkId2));
+        assertFalse(networkIds.contains(shortcutId1)); // Shortcut UUID should not be in result
+    }
+    
+    @Test
+    public void testGetNetworkSet_NetworkShortcutsDeleted() throws Exception {
+        List<FileItemSummary> folderItems = new ArrayList<>();
+        folderItems.add(createNetworkItem(networkId1, "Network 1"));
+        folderItems.add(createNetworkTypeShortcut(shortcutId1, "Network Shortcut 1", networkId2, "DELETED"));
+        
+        List<UUID> networkIds = extractNetworkIds(folderItems);
+
+        assertEquals(1, networkIds.size());
+        assertTrue(networkIds.contains(networkId1));
+        assertFalse(networkIds.contains(shortcutId1));
+        assertFalse(networkIds.contains(networkId2)); // Target of deleted shortcut
+    }
+    
+    @Test
+    public void testGetNetworkSet_NetworkShortcutsInTrash() throws Exception {
+        List<FileItemSummary> folderItems = new ArrayList<>();
+        folderItems.add(createNetworkItem(networkId1, "Network 1"));
+        folderItems.add(createNetworkTypeShortcut(shortcutId1, "Network Shortcut 1", networkId2, "IN_TRASH"));
+        
+        List<UUID> networkIds = extractNetworkIds(folderItems);
+
+        assertEquals(1, networkIds.size());
+        assertTrue(networkIds.contains(networkId1));
+        assertFalse(networkIds.contains(shortcutId1));
+        assertFalse(networkIds.contains(networkId2));
+    }
+    
+    @Test
+    public void testGetNetworkSet_DeduplicateNetworks() throws Exception {
+        List<FileItemSummary> folderItems = new ArrayList<>();
+        folderItems.add(createNetworkItem(networkId1, "Network 1"));
+        folderItems.add(createNetworkTypeShortcut(shortcutId1, "Shortcut to Network 1", networkId1, "ACTIVE"));
+        folderItems.add(createNetworkItem(networkId2, "Network 2"));
+        
+        List<UUID> networkIds = extractNetworkIds(folderItems);
+
+        assertEquals(2, networkIds.size());
+        assertEquals(networkId1, networkIds.get(0)); // First occurrence
+        assertEquals(networkId2, networkIds.get(1));
+    }
+    
+    @Test
+    public void testGetNetworkSet_EmptyFolder() throws Exception {
+        List<FileItemSummary> folderItems = new ArrayList<>();
+        
+        List<UUID> networkIds = extractNetworkIds(folderItems);
+
+        assertEquals(0, networkIds.size());
+    }
+    
+    // ==================== Helper Methods ====================
+    
+    private FileItemSummary createNetworkItem(UUID networkId, String name) {
+        FileItemSummary item = new FileItemSummary(networkId, FileType.NETWORK, name, 
+            new Timestamp(System.currentTimeMillis()), "testuser", null);
+        return item;
+    }
+    
+    private FileItemSummary createFolderItem(UUID folderId, String name) {
+        FileItemSummary item = new FileItemSummary(folderId, FileType.FOLDER, name, 
+            new Timestamp(System.currentTimeMillis()), "testuser", null);
+        return item;
+    }
+    
+    private FileItemSummary createFolderTypeShortcut(UUID shortcutId, String name, UUID targetId) {
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put("target_type", "FOLDER");
+        attrs.put("target", targetId);
+        attrs.put("target_status", "ACTIVE");
+        FileItemSummary item = new FileItemSummary(shortcutId, FileType.SHORTCUT, name, 
+            new Timestamp(System.currentTimeMillis()), "testuser", attrs);
+        return item;
+    }
+    
+    private FileItemSummary createNetworkTypeShortcut(UUID shortcutId, String name, UUID targetId, String targetStatus) {
+        Map<String, Object> attrs = new HashMap<>();
+        attrs.put("target_type", "NETWORK");
+        attrs.put("target", targetId);
+        attrs.put("target_status", targetStatus);
+        FileItemSummary item = new FileItemSummary(shortcutId, FileType.SHORTCUT, name, 
+            new Timestamp(System.currentTimeMillis()), "testuser", attrs);
+        return item;
+    }
+    
+    private List<UUID> extractNetworkIds(List<FileItemSummary> folderItems) {
+        java.util.Set<UUID> seenNetworkIds = new java.util.LinkedHashSet<>();
+        for (FileItemSummary item : folderItems) {
+            if (item.getType() == FileType.NETWORK) {
+                seenNetworkIds.add(item.getUuid());
+            } else if (item.getType() == FileType.SHORTCUT) {
+                Map<String, Object> attrs = item.getAttributes();
+                if (attrs != null) {
+                    String targetType = (String) attrs.get("target_type");
+                    if ("NETWORK".equals(targetType)) {
+                        String targetStatus = (String) attrs.get("target_status");
+                        if ("ACTIVE".equals(targetStatus)) {
+                            UUID targetId = (UUID) attrs.get("target");
+                            if (targetId != null) {
+                                seenNetworkIds.add(targetId);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return new ArrayList<>(seenNetworkIds);
+    }
+}

--- a/src/test/java/org/ndexbio/common/models/dao/postgresql/NetworkSetDAOTest.java
+++ b/src/test/java/org/ndexbio/common/models/dao/postgresql/NetworkSetDAOTest.java
@@ -1,201 +1,342 @@
 package org.ndexbio.common.models.dao.postgresql;
 
 import static org.junit.Assert.*;
+import static org.easymock.EasyMock.*;
 
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.ndexbio.common.models.dao.FolderDAO;
+import org.ndexbio.model.exceptions.ObjectNotFoundException;
 import org.ndexbio.model.object.FileItemSummary;
 import org.ndexbio.model.object.FileType;
+import org.ndexbio.model.object.NetworkSet;
+import org.ndexbio.model.object.NdexFolder;
 
 public class NetworkSetDAOTest {
-    
+
+    private Connection mockConnection;
+    private FolderDAO mockFolderDAO;
+    private NetworkSetDAO dao;
+
+    private UUID setId;
+    private UUID ownerId;
     private UUID networkId1;
     private UUID networkId2;
-    private UUID shortcutId1;
+    private UUID networkId3;
+    private UUID shortcutId;
     private UUID childFolderId;
-    
+
     @Before
     public void setUp() throws SQLException {
-        // Generate test UUIDs
+        mockConnection = createMock(Connection.class);
+        mockFolderDAO = createMock(FolderDAO.class);
+        dao = new NetworkSetDAO(mockConnection, mockFolderDAO);
+
+        setId = UUID.randomUUID();
+        ownerId = UUID.randomUUID();
         networkId1 = UUID.randomUUID();
         networkId2 = UUID.randomUUID();
-        shortcutId1 = UUID.randomUUID();
+        networkId3 = UUID.randomUUID();
+        shortcutId = UUID.randomUUID();
         childFolderId = UUID.randomUUID();
     }
-    
+
     @Test
-    public void testGetNetworkSet_DirectNetworks() throws Exception {
-        // Create folder items with direct networks
+    public void testGetNetworkSet_IncludesDirectNetworksAndActiveNetworkShortcutTarget() throws Exception {
+        NdexFolder folder = createFolder(setId, ownerId, "set-name");
         List<FileItemSummary> folderItems = new ArrayList<>();
         folderItems.add(createNetworkItem(networkId1, "Network 1"));
+        folderItems.add(createNetworkTypeShortcut(shortcutId, "Network Shortcut", networkId2, "ACTIVE"));
         folderItems.add(createNetworkItem(networkId2, "Network 2"));
-        
-        // Extract network IDs from folder items
-        List<UUID> networkIds = extractNetworkIds(folderItems);
 
-        assertEquals(2, networkIds.size());
-        assertTrue(networkIds.contains(networkId1));
-        assertTrue(networkIds.contains(networkId2));
+        expect(mockFolderDAO.getFolder(setId, ownerId, "key")).andReturn(folder);
+        expect(mockFolderDAO.listItemsInFolder(setId, true, FileType.NETWORK)).andReturn(folderItems);
+        mockFolderDAO.close();
+        expectLastCall().once();
+
+        replay(mockFolderDAO, mockConnection);
+
+        NetworkSet result = dao.getNetworkSet(setId, ownerId, "key");
+
+        assertEquals(setId, result.getExternalId());
+        assertEquals(ownerId, result.getOwnerId());
+        assertEquals("set-name", result.getName());
+        assertEquals("set-description", result.getDescription());
+        assertEquals(2, result.getNetworks().size());
+        assertEquals(networkId1, result.getNetworks().get(0));
+        assertEquals(networkId2, result.getNetworks().get(1));
+
+        verify(mockFolderDAO, mockConnection);
     }
-    
+
     @Test
-    public void testGetNetworkSet_ExcludeFolders() throws Exception {
+    public void testGetNetworkSet_ExcludesFolderAndFolderShortcut() throws Exception {
+        NdexFolder folder = createFolder(setId, ownerId, "set-name");
         List<FileItemSummary> folderItems = new ArrayList<>();
         folderItems.add(createNetworkItem(networkId1, "Network 1"));
         folderItems.add(createFolderItem(childFolderId, "Child Folder"));
+        folderItems.add(createFolderTypeShortcut(shortcutId, "Folder Shortcut", childFolderId));
         folderItems.add(createNetworkItem(networkId2, "Network 2"));
-        
-        List<UUID> networkIds = extractNetworkIds(folderItems);
 
-        assertEquals(2, networkIds.size());
-        assertTrue(networkIds.contains(networkId1));
-        assertTrue(networkIds.contains(networkId2));
-        assertFalse(networkIds.contains(childFolderId));
+        expect(mockFolderDAO.getFolder(setId, ownerId, null)).andReturn(folder);
+        expect(mockFolderDAO.listItemsInFolder(setId, true, FileType.NETWORK)).andReturn(folderItems);
+        mockFolderDAO.close();
+        expectLastCall().once();
+
+        replay(mockFolderDAO, mockConnection);
+
+        NetworkSet result = dao.getNetworkSet(setId, ownerId, null);
+
+        assertEquals(2, result.getNetworks().size());
+        assertTrue(result.getNetworks().contains(networkId1));
+        assertTrue(result.getNetworks().contains(networkId2));
+        assertFalse(result.getNetworks().contains(childFolderId));
+        assertFalse(result.getNetworks().contains(shortcutId));
+
+        verify(mockFolderDAO, mockConnection);
     }
-    
+
     @Test
-    public void testGetNetworkSet_ExcludeFolderShortcuts() throws Exception {
+    public void testGetNetworkSet_ExcludesDeletedAndInTrashNetworkShortcuts() throws Exception {
+        NdexFolder folder = createFolder(setId, ownerId, "set-name");
         List<FileItemSummary> folderItems = new ArrayList<>();
         folderItems.add(createNetworkItem(networkId1, "Network 1"));
-        folderItems.add(createFolderTypeShortcut(shortcutId1, "Folder Shortcut", childFolderId));
+        folderItems.add(createNetworkTypeShortcut(shortcutId, "Deleted shortcut", networkId2, "DELETED"));
+        folderItems.add(createNetworkTypeShortcut(UUID.randomUUID(), "In trash shortcut", networkId3, "IN_TRASH"));
+
+        expect(mockFolderDAO.getFolder(setId, ownerId, null)).andReturn(folder);
+        expect(mockFolderDAO.listItemsInFolder(setId, true, FileType.NETWORK)).andReturn(folderItems);
+        mockFolderDAO.close();
+        expectLastCall().once();
+
+        replay(mockFolderDAO, mockConnection);
+
+        NetworkSet result = dao.getNetworkSet(setId, ownerId, null);
+
+        assertEquals(1, result.getNetworks().size());
+        assertEquals(networkId1, result.getNetworks().get(0));
+        assertFalse(result.getNetworks().contains(networkId2));
+        assertFalse(result.getNetworks().contains(networkId3));
+
+        verify(mockFolderDAO, mockConnection);
+    }
+
+    @Test
+    public void testGetNetworkSet_DeduplicatesNetworkFromDirectAndShortcut() throws Exception {
+        NdexFolder folder = createFolder(setId, ownerId, "set-name");
+        List<FileItemSummary> folderItems = new ArrayList<>();
+        folderItems.add(createNetworkItem(networkId1, "Network 1"));
+        folderItems.add(createNetworkTypeShortcut(shortcutId, "Shortcut to Network 1", networkId1, "ACTIVE"));
         folderItems.add(createNetworkItem(networkId2, "Network 2"));
-        
-        List<UUID> networkIds = extractNetworkIds(folderItems);
 
-        assertEquals(2, networkIds.size());
-        assertTrue(networkIds.contains(networkId1));
-        assertTrue(networkIds.contains(networkId2));
-        assertFalse(networkIds.contains(shortcutId1));
-    }
-    
-    @Test
-    public void testGetNetworkSet_NetworkShortcutsActive() throws Exception {
-        List<FileItemSummary> folderItems = new ArrayList<>();
-        folderItems.add(createNetworkItem(networkId1, "Network 1"));
-        folderItems.add(createNetworkTypeShortcut(shortcutId1, "Network Shortcut 1", networkId2, "ACTIVE"));
-        
-        List<UUID> networkIds = extractNetworkIds(folderItems);
+        expect(mockFolderDAO.getFolder(setId, ownerId, null)).andReturn(folder);
+        expect(mockFolderDAO.listItemsInFolder(setId, true, FileType.NETWORK)).andReturn(folderItems);
+        mockFolderDAO.close();
+        expectLastCall().once();
 
-        assertEquals(2, networkIds.size());
-        assertTrue(networkIds.contains(networkId1));
-        assertTrue(networkIds.contains(networkId2));
-        assertFalse(networkIds.contains(shortcutId1)); // Shortcut UUID should not be in result
-    }
-    
-    @Test
-    public void testGetNetworkSet_NetworkShortcutsDeleted() throws Exception {
-        List<FileItemSummary> folderItems = new ArrayList<>();
-        folderItems.add(createNetworkItem(networkId1, "Network 1"));
-        folderItems.add(createNetworkTypeShortcut(shortcutId1, "Network Shortcut 1", networkId2, "DELETED"));
-        
-        List<UUID> networkIds = extractNetworkIds(folderItems);
+        replay(mockFolderDAO, mockConnection);
 
-        assertEquals(1, networkIds.size());
-        assertTrue(networkIds.contains(networkId1));
-        assertFalse(networkIds.contains(shortcutId1));
-        assertFalse(networkIds.contains(networkId2)); // Target of deleted shortcut
-    }
-    
-    @Test
-    public void testGetNetworkSet_NetworkShortcutsInTrash() throws Exception {
-        List<FileItemSummary> folderItems = new ArrayList<>();
-        folderItems.add(createNetworkItem(networkId1, "Network 1"));
-        folderItems.add(createNetworkTypeShortcut(shortcutId1, "Network Shortcut 1", networkId2, "IN_TRASH"));
-        
-        List<UUID> networkIds = extractNetworkIds(folderItems);
+        NetworkSet result = dao.getNetworkSet(setId, ownerId, null);
 
-        assertEquals(1, networkIds.size());
-        assertTrue(networkIds.contains(networkId1));
-        assertFalse(networkIds.contains(shortcutId1));
-        assertFalse(networkIds.contains(networkId2));
-    }
-    
-    @Test
-    public void testGetNetworkSet_DeduplicateNetworks() throws Exception {
-        List<FileItemSummary> folderItems = new ArrayList<>();
-        folderItems.add(createNetworkItem(networkId1, "Network 1"));
-        folderItems.add(createNetworkTypeShortcut(shortcutId1, "Shortcut to Network 1", networkId1, "ACTIVE"));
-        folderItems.add(createNetworkItem(networkId2, "Network 2"));
-        
-        List<UUID> networkIds = extractNetworkIds(folderItems);
+        assertEquals(2, result.getNetworks().size());
+        assertEquals(networkId1, result.getNetworks().get(0));
+        assertEquals(networkId2, result.getNetworks().get(1));
 
-        assertEquals(2, networkIds.size());
-        assertEquals(networkId1, networkIds.get(0)); // First occurrence
-        assertEquals(networkId2, networkIds.get(1));
+        verify(mockFolderDAO, mockConnection);
     }
-    
+
     @Test
     public void testGetNetworkSet_EmptyFolder() throws Exception {
-        List<FileItemSummary> folderItems = new ArrayList<>();
-        
-        List<UUID> networkIds = extractNetworkIds(folderItems);
+        NdexFolder folder = createFolder(setId, ownerId, "set-name");
 
-        assertEquals(0, networkIds.size());
+        expect(mockFolderDAO.getFolder(setId, ownerId, null)).andReturn(folder);
+        expect(mockFolderDAO.listItemsInFolder(setId, true, FileType.NETWORK)).andReturn(Collections.emptyList());
+        mockFolderDAO.close();
+        expectLastCall().once();
+
+        replay(mockFolderDAO, mockConnection);
+
+        NetworkSet result = dao.getNetworkSet(setId, ownerId, null);
+
+        assertNotNull(result.getNetworks());
+        assertEquals(0, result.getNetworks().size());
+
+        verify(mockFolderDAO, mockConnection);
     }
-    
-    // ==================== Helper Methods ====================
-    
+
+    @Test(expected = ObjectNotFoundException.class)
+    public void testGetNetworkSet_PropagatesObjectNotFound() throws Exception {
+        expect(mockFolderDAO.getFolder(setId, ownerId, null)).andThrow(new ObjectNotFoundException("Folder", setId));
+        mockFolderDAO.close();
+        expectLastCall().once();
+
+        replay(mockFolderDAO, mockConnection);
+
+        try {
+            dao.getNetworkSet(setId, ownerId, null);
+        } finally {
+            verify(mockFolderDAO, mockConnection);
+        }
+    }
+
+    @Test
+    public void testGetNetworkSetsByUserId_SummaryOnlySkipsMembers() throws Exception {
+        UUID userId = ownerId;
+        NdexFolder folder1 = createFolder(UUID.randomUUID(), userId, "set-1");
+        NdexFolder folder2 = createFolder(UUID.randomUUID(), userId, "set-2");
+
+        expect(mockFolderDAO.listFoldersOfUser(userId, 2)).andReturn(List.of(folder1, folder2));
+        mockFolderDAO.close();
+        expectLastCall().once();
+
+        replay(mockFolderDAO, mockConnection);
+
+        List<NetworkSet> result = dao.getNetworkSetsByUserId(userId, userId, 0, 2, true, false);
+
+        assertEquals(2, result.size());
+        assertNotNull(result.get(0).getNetworks());
+        assertNotNull(result.get(1).getNetworks());
+        assertTrue(result.get(0).getNetworks().isEmpty());
+        assertTrue(result.get(1).getNetworks().isEmpty());
+
+        verify(mockFolderDAO, mockConnection);
+    }
+
+    @Test
+    public void testGetNetworkSetsByUserId_AppliesOffsetLimitAndNormalizesMembers() throws Exception {
+        UUID userId = ownerId;
+        NdexFolder folder1 = createFolder(UUID.randomUUID(), userId, "set-1");
+        NdexFolder folder2 = createFolder(UUID.randomUUID(), userId, "set-2");
+        NdexFolder folder3 = createFolder(UUID.randomUUID(), userId, "set-3");
+
+        List<FileItemSummary> folder2Items = new ArrayList<>();
+        folder2Items.add(createNetworkItem(networkId1, "Network 1"));
+        folder2Items.add(createNetworkTypeShortcut(shortcutId, "Shortcut to Network 2", networkId2, "ACTIVE"));
+        folder2Items.add(createNetworkTypeShortcut(UUID.randomUUID(), "Deleted shortcut", networkId3, "DELETED"));
+
+        expect(mockFolderDAO.listFoldersOfUser(userId, 2)).andReturn(List.of(folder1, folder2, folder3));
+        expect(mockFolderDAO.listItemsInFolder(folder2.getExternalId(), true, FileType.NETWORK)).andReturn(folder2Items);
+        mockFolderDAO.close();
+        expectLastCall().once();
+
+        replay(mockFolderDAO, mockConnection);
+
+        List<NetworkSet> result = dao.getNetworkSetsByUserId(userId, userId, 1, 1, false, false);
+
+        assertEquals(1, result.size());
+        NetworkSet only = result.get(0);
+        assertEquals(folder2.getExternalId(), only.getExternalId());
+        assertEquals(2, only.getNetworks().size());
+        assertEquals(networkId1, only.getNetworks().get(0));
+        assertEquals(networkId2, only.getNetworks().get(1));
+
+        verify(mockFolderDAO, mockConnection);
+    }
+
+    @Test
+    public void testGetNetworkSetsByUserId_OffsetBeyondRangeReturnsEmpty() throws Exception {
+        UUID userId = ownerId;
+        NdexFolder folder1 = createFolder(UUID.randomUUID(), userId, "set-1");
+
+        expect(mockFolderDAO.listFoldersOfUser(userId, 4)).andReturn(List.of(folder1));
+        mockFolderDAO.close();
+        expectLastCall().once();
+
+        replay(mockFolderDAO, mockConnection);
+
+        List<NetworkSet> result = dao.getNetworkSetsByUserId(userId, userId, 3, 1, false, false);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+
+        verify(mockFolderDAO, mockConnection);
+    }
+
+    @Test
+    public void testGetNetworkSetsByUserId_NonPositiveLimitUsesMaxFetch() throws Exception {
+        UUID userId = ownerId;
+        NdexFolder folder1 = createFolder(UUID.randomUUID(), userId, "set-1");
+        List<FileItemSummary> folderItems = List.of(createNetworkItem(networkId1, "Network 1"));
+
+        expect(mockFolderDAO.listFoldersOfUser(userId, Integer.MAX_VALUE)).andReturn(List.of(folder1));
+        expect(mockFolderDAO.listItemsInFolder(folder1.getExternalId(), true, FileType.NETWORK)).andReturn(folderItems);
+        mockFolderDAO.close();
+        expectLastCall().once();
+
+        replay(mockFolderDAO, mockConnection);
+
+        List<NetworkSet> result = dao.getNetworkSetsByUserId(userId, userId, 0, 0, false, true);
+
+        assertEquals(1, result.size());
+        assertEquals(1, result.get(0).getNetworks().size());
+        assertEquals(networkId1, result.get(0).getNetworks().get(0));
+
+        verify(mockFolderDAO, mockConnection);
+    }
+
+    @Test(expected = SQLException.class)
+    public void testGetNetworkSetsByUserId_PropagatesSQLExceptionFromListFolders() throws Exception {
+        UUID userId = ownerId;
+
+        expect(mockFolderDAO.listFoldersOfUser(userId, 1)).andThrow(new SQLException("listFolders failed"));
+        mockFolderDAO.close();
+        expectLastCall().once();
+
+        replay(mockFolderDAO, mockConnection);
+
+        try {
+            dao.getNetworkSetsByUserId(userId, userId, 0, 1, false, false);
+        } finally {
+            verify(mockFolderDAO, mockConnection);
+        }
+    }
+
+    private NdexFolder createFolder(UUID folderId, UUID folderOwnerId, String name) {
+        NdexFolder folder = new NdexFolder();
+        folder.setExternalId(folderId);
+        folder.setOwner_id(folderOwnerId.toString());
+        folder.setName(name);
+        folder.setDescription("set-description");
+        folder.setCreationTime(new Timestamp(System.currentTimeMillis()));
+        folder.setModificationTime(new Timestamp(System.currentTimeMillis()));
+        return folder;
+    }
+
     private FileItemSummary createNetworkItem(UUID networkId, String name) {
-        FileItemSummary item = new FileItemSummary(networkId, FileType.NETWORK, name, 
+        return new FileItemSummary(networkId, FileType.NETWORK, name,
             new Timestamp(System.currentTimeMillis()), "testuser", null);
-        return item;
     }
-    
+
     private FileItemSummary createFolderItem(UUID folderId, String name) {
-        FileItemSummary item = new FileItemSummary(folderId, FileType.FOLDER, name, 
+        return new FileItemSummary(folderId, FileType.FOLDER, name,
             new Timestamp(System.currentTimeMillis()), "testuser", null);
-        return item;
     }
-    
+
     private FileItemSummary createFolderTypeShortcut(UUID shortcutId, String name, UUID targetId) {
         Map<String, Object> attrs = new HashMap<>();
         attrs.put("target_type", "FOLDER");
         attrs.put("target", targetId);
         attrs.put("target_status", "ACTIVE");
-        FileItemSummary item = new FileItemSummary(shortcutId, FileType.SHORTCUT, name, 
+        return new FileItemSummary(shortcutId, FileType.SHORTCUT, name,
             new Timestamp(System.currentTimeMillis()), "testuser", attrs);
-        return item;
     }
-    
+
     private FileItemSummary createNetworkTypeShortcut(UUID shortcutId, String name, UUID targetId, String targetStatus) {
         Map<String, Object> attrs = new HashMap<>();
         attrs.put("target_type", "NETWORK");
         attrs.put("target", targetId);
         attrs.put("target_status", targetStatus);
-        FileItemSummary item = new FileItemSummary(shortcutId, FileType.SHORTCUT, name, 
+        return new FileItemSummary(shortcutId, FileType.SHORTCUT, name,
             new Timestamp(System.currentTimeMillis()), "testuser", attrs);
-        return item;
-    }
-    
-    private List<UUID> extractNetworkIds(List<FileItemSummary> folderItems) {
-        java.util.Set<UUID> seenNetworkIds = new java.util.LinkedHashSet<>();
-        for (FileItemSummary item : folderItems) {
-            if (item.getType() == FileType.NETWORK) {
-                seenNetworkIds.add(item.getUuid());
-            } else if (item.getType() == FileType.SHORTCUT) {
-                Map<String, Object> attrs = item.getAttributes();
-                if (attrs != null) {
-                    String targetType = (String) attrs.get("target_type");
-                    if ("NETWORK".equals(targetType)) {
-                        String targetStatus = (String) attrs.get("target_status");
-                        if ("ACTIVE".equals(targetStatus)) {
-                            UUID targetId = (UUID) attrs.get("target");
-                            if (targetId != null) {
-                                seenNetworkIds.add(targetId);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        return new ArrayList<>(seenNetworkIds);
     }
 }


### PR DESCRIPTION
Refactored to use folders and shortcuts to derive network set members instead of networkset table.

Closes: #108 