### PR TITLE
#114: lower search results sort order for edgeless networks

### DIFF
--- a/docker/test/fixtures/ranking/edged-rank-probe.cx2
+++ b/docker/test/fixtures/ranking/edged-rank-probe.cx2
@@ -1,0 +1,7 @@
+[{"CXVersion":"2.0","hasFragments":false},
+{"metaData":[{"name":"attributeDeclarations","elementCount":1},{"name":"networkAttributes","elementCount":1},{"name":"nodes","elementCount":3},{"name":"edges","elementCount":2}]},
+{"attributeDeclarations":[{"nodes":{"name":{"a":"n","d":"string"}},"networkAttributes":{"name":{"d":"string"},"description":{"d":"string"}},"edges":{"interaction":{"a":"i","d":"string"}}}]},
+{"networkAttributes":[{"name":"EdgelessRankProbe Edged Network","description":"EdgelessRankProbe ranking fixture that contains edges."}]},
+{"nodes":[{"id":0,"v":{"n":"EdgelessRankProbe geneA"}},{"id":1,"v":{"n":"EdgelessRankProbe geneB"}},{"id":2,"v":{"n":"EdgelessRankProbe geneC"}}]},
+{"edges":[{"id":0,"s":0,"t":1,"v":{"i":"interacts with"}},{"id":1,"s":1,"t":2,"v":{"i":"interacts with"}}]},
+{"status":[{"error":"","success":true}]}]

--- a/docker/test/fixtures/ranking/edgeless-rank-probe.cx2
+++ b/docker/test/fixtures/ranking/edgeless-rank-probe.cx2
@@ -1,0 +1,6 @@
+[{"CXVersion":"2.0","hasFragments":false},
+{"metaData":[{"name":"attributeDeclarations","elementCount":1},{"name":"networkAttributes","elementCount":1},{"name":"nodes","elementCount":3}]},
+{"attributeDeclarations":[{"nodes":{"name":{"a":"n","d":"string"}},"networkAttributes":{"name":{"d":"string"},"description":{"d":"string"}}}]},
+{"networkAttributes":[{"name":"EdgelessRankProbe EdgelessRankProbe Edgeless Network","description":"EdgelessRankProbe EdgelessRankProbe EdgelessRankProbe ranking fixture with no edges and a deliberately stronger text match so that only the edge penalty can demote it."}]},
+{"nodes":[{"id":0,"v":{"n":"EdgelessRankProbe EdgelessRankProbe geneA"}},{"id":1,"v":{"n":"EdgelessRankProbe EdgelessRankProbe geneB"}},{"id":2,"v":{"n":"EdgelessRankProbe EdgelessRankProbe geneC"}}]},
+{"status":[{"error":"","success":true}]}]

--- a/docker/test/integration-test.sh
+++ b/docker/test/integration-test.sh
@@ -31,7 +31,7 @@ TEST_USER2="ndextest2"
 TEST_PASS2="NDExTest2!"
 TEST_EMAIL2="ndextest2@ndex-integration.local"
 
-TOTAL_API_CALLS=43
+TOTAL_API_CALLS=46
 PASSED=0
 CALL_NUM=0
 STEP_NUM=0
@@ -575,6 +575,95 @@ while true; do
   echo "  Waiting for public-nfs Solr index... (${ELAPSED}s)"
 done
 api_pass "POST /v3/search/files → 200 OK, BindingDB UUID found in results (CX2 public-nfs confirmed)"
+
+# ── STEP: Edgeless network search ranking (issue #116) ───────────────────────
+# Upload two networks that share the unique token "EdgelessRankProbe" — one WITH
+# edges, one edgeless (0 edges, but a deliberately STRONGER text match). Without
+# the edgeCount demotion boost the edgeless network would rank first on text
+# relevance; the boost must push the edged network above it.
+
+step "Verifying edgeless networks are demoted in search ranking (issue #116)"
+
+RANK_DIR="${FIXTURES_DIR}/ranking"
+RANK_EDGED_UUID=""
+RANK_EDGELESS_UUID=""
+
+for RANK_FILE in "${RANK_DIR}/edged-rank-probe.cx2" "${RANK_DIR}/edgeless-rank-probe.cx2"; do
+  RANK_LABEL="$(basename "${RANK_FILE}")"
+  CALL_NUM=$((CALL_NUM+1))
+  echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: POST /v3/networks?visibility=PUBLIC  [${RANK_LABEL}]"
+
+  RANK_UPLOAD=$(curl -s -w "\n%{http_code}" -X POST \
+    -u "${TEST_USER}:${TEST_PASS}" \
+    -H "Content-Type: application/json" \
+    --data-binary "@${RANK_FILE}" \
+    "${BASE_URL}/v3/networks?visibility=PUBLIC")
+  RANK_HTTP=$(echo "${RANK_UPLOAD}" | tail -1)
+  RANK_BODY=$(echo "${RANK_UPLOAD}" | head -1)
+
+  if [[ "${RANK_HTTP}" != "201" ]]; then
+    api_fail "POST /v3/networks → HTTP ${RANK_HTTP} for '${RANK_LABEL}'. Body: ${RANK_BODY:0:300}"
+  fi
+  RANK_UUID=$(echo "${RANK_BODY}" | grep -o '"uuid":"[^"]*"' | head -1 | cut -d'"' -f4)
+  if [[ "${RANK_LABEL}" == "edged-rank-probe.cx2" ]]; then
+    RANK_EDGED_UUID="${RANK_UUID}"
+  else
+    RANK_EDGELESS_UUID="${RANK_UUID}"
+  fi
+  api_pass "POST /v3/networks → 201 Created (UUID: ${RANK_UUID}, ${RANK_LABEL})"
+done
+
+# Wait until both rank-probe networks finish processing.
+for UUID in "${RANK_EDGED_UUID}" "${RANK_EDGELESS_UUID}"; do
+  ELAPSED=0
+  while true; do
+    SUMMARY_BODY=$(curl -s -u "${TEST_USER}:${TEST_PASS}" "${BASE_URL}/v3/networks/${UUID}/summary")
+    if echo "${SUMMARY_BODY}" | grep -q '"completed":true'; then
+      break
+    fi
+    if [[ ${ELAPSED} -ge ${LOAD_TIMEOUT} ]]; then
+      api_fail "rank-probe network ${UUID} did not complete within ${LOAD_TIMEOUT}s. Last: ${SUMMARY_BODY:0:300}"
+    fi
+    sleep 5; (( ELAPSED += 5 )) || true
+    echo "  Waiting for rank-probe network ${UUID}... (${ELAPSED}s)"
+  done
+done
+
+CALL_NUM=$((CALL_NUM+1))
+echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: POST /v3/search/files?visibility=PUBLIC (searchString=EdgelessRankProbe)"
+
+# Poll until both networks are indexed, then assert the edged network ranks first.
+ELAPSED=0
+while true; do
+  RANK_SEARCH=$(curl -s -w "\n%{http_code}" -X POST \
+    -u "${TEST_USER}:${TEST_PASS}" \
+    -H "Content-Type: application/json" \
+    -d '{"searchString":"EdgelessRankProbe"}' \
+    "${BASE_URL}/v3/search/files?visibility=PUBLIC&start=0&size=10")
+  RANK_SEARCH_HTTP=$(echo "${RANK_SEARCH}" | tail -1)
+  RANK_SEARCH_BODY=$(echo "${RANK_SEARCH}" | head -1)
+  if [[ "${RANK_SEARCH_HTTP}" != "200" ]]; then
+    api_fail "POST /v3/search/files (EdgelessRankProbe) → HTTP ${RANK_SEARCH_HTTP}. Body: ${RANK_SEARCH_BODY:0:300}"
+  fi
+  # Ordered list of result UUIDs (rank order is preserved by the search provider).
+  RANK_ORDER=$(echo "${RANK_SEARCH_BODY}" | grep -oE '"uuid":"[^"]*"' | cut -d'"' -f4)
+  EDGED_POS=$(echo "${RANK_ORDER}" | grep -n "^${RANK_EDGED_UUID}$" | head -1 | cut -d: -f1)
+  EDGELESS_POS=$(echo "${RANK_ORDER}" | grep -n "^${RANK_EDGELESS_UUID}$" | head -1 | cut -d: -f1)
+  if [[ -n "${EDGED_POS}" && -n "${EDGELESS_POS}" ]]; then
+    break
+  fi
+  if [[ ${ELAPSED} -ge ${LOAD_TIMEOUT} ]]; then
+    api_fail "Both rank-probe networks not found in search within ${LOAD_TIMEOUT}s. Body: ${RANK_SEARCH_BODY:0:500}"
+  fi
+  sleep 3; (( ELAPSED += 3 )) || true
+  echo "  Waiting for rank-probe networks to index... (${ELAPSED}s)"
+done
+
+if [[ ${EDGED_POS} -lt ${EDGELESS_POS} ]]; then
+  api_pass "Edged network (pos ${EDGED_POS}) ranks above edgeless network (pos ${EDGELESS_POS}) — edgeless demotion confirmed"
+else
+  api_fail "Edgeless network (pos ${EDGELESS_POS}) ranked at/above edged network (pos ${EDGED_POS}) — edgeCount boost not applied"
+fi
 
 # ── STEP: Neighborhood query — SSL context fix (local container only) ─────────
 

--- a/docker/test/integration-test.sh
+++ b/docker/test/integration-test.sh
@@ -13,7 +13,7 @@
 #   v3 CX2 retrieve → private network access control → public anonymous access →
 #   v2 Solr search → v3 Solr search → v2 neighborhood query (SSL context)
 #
-# Exits 0 if all 29 API calls pass, exits 1 on the first failure.
+# Exits 0 if all API calls pass, exits 1 on the first failure.
 # Deps: docker, make, curl (no python, no jq, no uv)
 
 set -euo pipefail

--- a/docker/test/integration-test.sh
+++ b/docker/test/integration-test.sh
@@ -646,9 +646,11 @@ while true; do
     api_fail "POST /v3/search/files (EdgelessRankProbe) → HTTP ${RANK_SEARCH_HTTP}. Body: ${RANK_SEARCH_BODY:0:300}"
   fi
   # Ordered list of result UUIDs (rank order is preserved by the search provider).
-  RANK_ORDER=$(echo "${RANK_SEARCH_BODY}" | grep -oE '"uuid":"[^"]*"' | cut -d'"' -f4)
-  EDGED_POS=$(echo "${RANK_ORDER}" | grep -n "^${RANK_EDGED_UUID}$" | head -1 | cut -d: -f1)
-  EDGELESS_POS=$(echo "${RANK_ORDER}" | grep -n "^${RANK_EDGELESS_UUID}$" | head -1 | cut -d: -f1)
+  # `|| true` keeps a "no match yet" grep (exit 1) from tripping `set -e`/pipefail
+  # while the just-uploaded networks are still being indexed.
+  RANK_ORDER=$(echo "${RANK_SEARCH_BODY}" | grep -oE '"uuid":"[^"]*"' | cut -d'"' -f4 || true)
+  EDGED_POS=$(echo "${RANK_ORDER}" | grep -n "^${RANK_EDGED_UUID}$" | head -1 | cut -d: -f1 || true)
+  EDGELESS_POS=$(echo "${RANK_ORDER}" | grep -n "^${RANK_EDGELESS_UUID}$" | head -1 | cut -d: -f1 || true)
   if [[ -n "${EDGED_POS}" && -n "${EDGELESS_POS}" ]]; then
     break
   fi

--- a/src/main/java/org/ndexbio/common/models/search/NFSSearchProvider.java
+++ b/src/main/java/org/ndexbio/common/models/search/NFSSearchProvider.java
@@ -7,6 +7,7 @@ import org.ndexbio.common.models.dao.DAOFactory;
 import org.ndexbio.common.models.dao.FolderDAO;
 import org.ndexbio.common.models.dao.NetworkDAO;
 import org.ndexbio.common.models.dao.ShortcutDAO;
+import org.ndexbio.common.solr.GlobalNetworkIndexManager;
 import org.ndexbio.common.solr.NFSIndexManager;
 import org.ndexbio.common.solr.SolrClientWrapper;
 import org.ndexbio.model.exceptions.NdexException;
@@ -248,6 +249,13 @@ public class NFSSearchProvider implements SearchProvider {
             return "uuid^20 name^10 description^5 labels^6 owner^2 " +
                    "networkType^4 organism^3 disease^3 tissue^3 author^2 methods " +
                    "nodeName represents alias rights^0.6 rightsHolder^0.6";
+        }
+
+        @Override
+        protected String getBoostFunction() {
+            // Demote edgeless networks; non-network file types have no edgeCount
+            // field and are left unaffected by the def() guard.
+            return edgePenaltyBoost(GlobalNetworkIndexManager.EDGELESS_PENALTY);
         }
 
     }

--- a/src/main/java/org/ndexbio/common/solr/GlobalNetworkIndexManager.java
+++ b/src/main/java/org/ndexbio/common/solr/GlobalNetworkIndexManager.java
@@ -29,6 +29,13 @@ import java.util.*;
 public class GlobalNetworkIndexManager extends NFSIndexManager<NetworkSummary> {
     private static final org.slf4j.Logger log = LoggerFactory.getLogger(GlobalNetworkIndexManager.class);
 
+    /**
+     * Score multiplier applied to edgeless networks (edgeCount == 0) so they rank
+     * below networks with edges. 0.01 = ~100x demotion; raise toward 0.1 for a
+     * softer penalty.
+     */
+    public static final double EDGELESS_PENALTY = 0.01;
+
     // user required indexing fields. hardcoded for now. Will turn them into configurable list in 1.4.
     public static final Set<String> otherAttributes =
             new HashSet<>(Arrays.asList("objectCategory", "organism",
@@ -107,6 +114,12 @@ public class GlobalNetworkIndexManager extends NFSIndexManager<NetworkSummary> {
         // Networks use scoring boost
         return "( " + super.preprocessSearchTerms(searchTerms) +
                 " ) AND _val_:\"div(" + NDEX_SCORE + ",10)\"";
+    }
+
+    @Override
+    protected String getBoostFunction() {
+        // Demote edgeless networks to the bottom of the ranking.
+        return edgePenaltyBoost(EDGELESS_PENALTY);
     }
 
     /**

--- a/src/main/java/org/ndexbio/common/solr/NFSIndexManager.java
+++ b/src/main/java/org/ndexbio/common/solr/NFSIndexManager.java
@@ -366,6 +366,12 @@ public abstract class NFSIndexManager<T> implements AutoCloseable {
         solrQuery.set("defType", "edismax");
         solrQuery.set("qf", getQueryFields());
 
+        // Optional multiplicative boost (e.g. to demote edgeless networks)
+        String boostFunction = getBoostFunction();
+        if (boostFunction != null) {
+            solrQuery.set("boost", boostFunction);
+        }
+
         // Pagination
         if (offset >= 0) {
             solrQuery.setStart(offset);
@@ -378,6 +384,27 @@ public abstract class NFSIndexManager<T> implements AutoCloseable {
 
         // Apply filters
         solrQuery.setFilterQueries(resultFilter);
+    }
+
+    /**
+     * Optional edismax multiplicative boost function applied to the query score.
+     * Returns null by default (no boost). Subclasses override to demote or promote
+     * documents (e.g. GlobalNetworkIndexManager demotes edgeless networks).
+     */
+    protected String getBoostFunction() {
+        return null;
+    }
+
+    /**
+     * Builds a multiplicative boost function that demotes edgeless documents
+     * (edgeCount == 0) by the given penalty while leaving all other documents
+     * unchanged. Documents lacking an edgeCount field default to 1 (no penalty),
+     * so non-network types are never affected.
+     *
+     * @param penalty the multiplier applied to edgeless documents (e.g. 0.01)
+     */
+    protected String edgePenaltyBoost(double penalty) {
+        return "map(def(" + EDGE_COUNT + ",1),0,0," + penalty + ",1)";
     }
 
     /**

--- a/src/test/java/org/ndexbio/common/models/search/TestNFSSearchProvider.java
+++ b/src/test/java/org/ndexbio/common/models/search/TestNFSSearchProvider.java
@@ -1,0 +1,71 @@
+package org.ndexbio.common.models.search;
+
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrDocumentList;
+import org.easymock.Capture;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.ndexbio.common.solr.SolrClientWrapper;
+import org.ndexbio.model.object.SimpleFileQuery;
+import org.ndexbio.model.object.network.VisibilityType;
+import org.ndexbio.rest.Configuration;
+
+import java.lang.reflect.Field;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for NFSSearchProvider's Solr query configuration.
+ * Verifies the edgeless-network demotion boost (issue #116) is applied to the
+ * unified file-search path via the mocked SolrClientWrapper. No live Solr required.
+ */
+public class TestNFSSearchProvider {
+
+    private static Configuration savedInstance;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        Configuration mockConfig = createMock(Configuration.class);
+        expect(mockConfig.getSolrURL()).andReturn("http://localhost:8983/solr").anyTimes();
+        replay(mockConfig);
+
+        Field instanceField = Configuration.class.getDeclaredField("INSTANCE");
+        instanceField.setAccessible(true);
+        savedInstance = (Configuration) instanceField.get(null);
+        instanceField.set(null, mockConfig);
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        Configuration.setInstance(savedInstance);
+    }
+
+    @Test
+    public void testSearchFiles_AppliesEdgelessBoost() throws Exception {
+        // Empty result set so no DAO post-processing is triggered.
+        SolrDocumentList emptyResults = new SolrDocumentList();
+        emptyResults.setNumFound(0);
+
+        QueryResponse mockResponse = createMock(QueryResponse.class);
+        expect(mockResponse.getResults()).andReturn(emptyResults);
+        replay(mockResponse);
+
+        SolrClientWrapper mockWrapper = createMock(SolrClientWrapper.class);
+        Capture<SolrQuery> queryCapture = Capture.newInstance();
+        expect(mockWrapper.query(anyString(), capture(queryCapture))).andReturn(mockResponse);
+        replay(mockWrapper);
+
+        NFSSearchProvider provider = new NFSSearchProvider(mockWrapper, 100);
+
+        SimpleFileQuery query = new SimpleFileQuery();
+        query.setSearchString("cancer");
+
+        provider.searchFiles(query, VisibilityType.PUBLIC, null, 0, 10);
+
+        verify(mockWrapper);
+        assertEquals("map(def(edgeCount,1),0,0,0.01,1)", queryCapture.getValue().get("boost"));
+    }
+}

--- a/src/test/java/org/ndexbio/common/solr/TestFolderIndexManager.java
+++ b/src/test/java/org/ndexbio/common/solr/TestFolderIndexManager.java
@@ -1040,6 +1040,25 @@ public class TestFolderIndexManager {
     }
 
     // ========================================================================
+    // BOOST FUNCTION - NON-NETWORK MANAGERS ARE NOT PENALIZED (issue #116)
+    // ========================================================================
+
+    @Test
+    public void testGetBoostFunction_DefaultsToNull() {
+        manager = createManagerWithMock();
+        // Folders (and other non-network types) inherit the base no-op boost.
+        assertNull(manager.getBoostFunction());
+    }
+
+    @Test
+    public void testConfigureQuery_NoBoostForFolders() {
+        manager = createManagerWithMock();
+        SolrQuery q = new SolrQuery();
+        manager.configureQuery(q, "test", "filter", 10, 0);
+        assertNull(q.get("boost"));
+    }
+
+    // ========================================================================
     // INTEGRATION TESTS (Require local Solr - @Ignore by default)
     // Single manager instance since visibility is now per-operation
     // ========================================================================

--- a/src/test/java/org/ndexbio/common/solr/TestGlobalNetworkIndexManager.java
+++ b/src/test/java/org/ndexbio/common/solr/TestGlobalNetworkIndexManager.java
@@ -932,6 +932,55 @@ public class TestGlobalNetworkIndexManager {
     }
 
     // ========================================================================
+    // EDGELESS NETWORK DEMOTION (edgeCount boost) - issue #116
+    // ========================================================================
+
+    @Test
+    public void testGetBoostFunction_ReturnsEdgePenalty() {
+        manager = createManagerWithMock();
+        assertEquals("map(def(edgeCount,1),0,0,0.01,1)", manager.getBoostFunction());
+    }
+
+    @Test
+    public void testConfigureQuery_SetsEdgelessBoost() {
+        manager = createManagerWithMock();
+        SolrQuery q = new SolrQuery();
+        manager.configureQuery(q, "cancer", "filter", 10, 0);
+        // edgeCount==0 maps to 0.01 (heavy demotion); everything else stays at 1.
+        assertEquals("map(def(edgeCount,1),0,0,0.01,1)", q.get("boost"));
+    }
+
+    @Test
+    public void testConfigureQuery_BoostAppliedWithEdismax() {
+        manager = createManagerWithMock();
+        SolrQuery q = new SolrQuery();
+        manager.configureQuery(q, "cancer", "filter", 10, 0);
+        // edismax must be the parser for the multiplicative boost param to apply.
+        assertEquals("edismax", q.get("defType"));
+        assertNotNull(q.get("boost"));
+    }
+
+    @Test
+    public void testEdgelessPenaltyValue() {
+        assertEquals(0.01, GlobalNetworkIndexManager.EDGELESS_PENALTY, 0.0);
+    }
+
+    @Test
+    public void testEdgePenaltyBoost_BuildsFunction() {
+        manager = createManagerWithMock();
+        // The helper encodes any penalty into the same map/def shape.
+        assertEquals("map(def(edgeCount,1),0,0,0.1,1)", manager.edgePenaltyBoost(0.1));
+    }
+
+    @Test
+    public void testEdgePenaltyBoost_GuardsMissingEdgeCount() {
+        manager = createManagerWithMock();
+        // def(edgeCount,1) means a doc lacking edgeCount defaults to 1 (no penalty),
+        // never the 0->penalty bucket.
+        assertTrue(manager.edgePenaltyBoost(0.01).contains("def(edgeCount,1)"));
+    }
+
+    // ========================================================================
     // PREPROCESS SEARCH TERMS - NETWORK SPECIFIC (ndexScore boost)
     // ========================================================================
 


### PR DESCRIPTION
Networks with zero edges ("edgeless" networks) currently rank equally with networks that have edges in Solr search results, so an empty network can outrank one with real content based on text semantics alone. I

Solution - edgeless networks are pushed to the bottom of result lists by applying a lower rank factor.
 
Closes #116 