### PR TITLE
fixed visibility filtering on folders/list endpoint

### DIFF
--- a/docker/test/integration-test.sh
+++ b/docker/test/integration-test.sh
@@ -32,7 +32,7 @@ TEST_USER2="ndextest2"
 TEST_PASS2="NDExTest2!"
 TEST_EMAIL2="ndextest2@ndex-integration.local"
 
-TOTAL_API_CALLS=48
+TOTAL_API_CALLS=67
 PASSED=0
 CALL_NUM=0
 STEP_NUM=0
@@ -991,7 +991,132 @@ else
   api_fail "GET /v2/network/${V2_PRIV_UUID}/permission?type=user (owner) → HTTP ${PERM_USER_HTTP} (expected 200)"
 fi
 
+# ── STEP: Folder list/count per-child visibility (F10) ───────────────────────
+# A folder's visibility is independent of its children's. A folder the caller can
+# read must NOT leak the metadata of PRIVATE children they cannot see, and /count
+# must match /list. A valid folder access key grants the folder's full contents.
+step "Folder list/count enforces per-child visibility (F10, anonymous)"
+
+# Create a folder owned by TEST_USER; put one PUBLIC and one PRIVATE network in it.
+CALL_NUM=$((CALL_NUM+1))
+echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: POST /v3/files/folders/ (create test folder)"
+F10_FOLDER_RESP=$(curl -s -w "\n%{http_code}" -X POST \
+  -u "${TEST_USER}:${TEST_PASS}" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"F10 visibility test"}' \
+  "${BASE_URL}/v3/files/folders/")
+F10_FOLDER_HTTP=$(echo "${F10_FOLDER_RESP}" | tail -1)
+F10_FOLDER_BODY=$(echo "${F10_FOLDER_RESP}" | head -1)
+if [[ "${F10_FOLDER_HTTP}" != "201" ]]; then
+  api_fail "POST /v3/files/folders/ → HTTP ${F10_FOLDER_HTTP} (expected 201). Body: ${F10_FOLDER_BODY:0:300}"
+fi
+F10_FOLDER_ID=$(echo "${F10_FOLDER_BODY}" | grep -oiE '"uuid"[[:space:]]*:[[:space:]]*"[0-9a-f-]{36}"' | grep -oiE '[0-9a-f-]{36}' | head -1)
+if [[ -z "${F10_FOLDER_ID}" ]]; then
+  api_fail "Could not parse folder UUID from create response. Body: ${F10_FOLDER_BODY:0:300}"
+fi
+api_pass "POST /v3/files/folders/ → 201 Created (folder ${F10_FOLDER_ID})"
+
+CALL_NUM=$((CALL_NUM+1))
+echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: POST /v3/files/setvisibility (folder → PUBLIC)"
+F10_VIS_HTTP=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+  -u "${TEST_USER}:${TEST_PASS}" -H "Content-Type: application/json" \
+  -d "{\"visibility\":\"PUBLIC\",\"files\":{\"${F10_FOLDER_ID}\":\"FOLDER\"}}" \
+  "${BASE_URL}/v3/batch/files/setvisibility")
+[[ "${F10_VIS_HTTP}" == "200" || "${F10_VIS_HTTP}" == "204" ]] \
+  || api_fail "POST /v3/files/setvisibility (PUBLIC) → HTTP ${F10_VIS_HTTP}"
+api_pass "Folder set PUBLIC"
+
+CALL_NUM=$((CALL_NUM+1))
+echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: POST /v3/networks/move (public + private into folder)"
+F10_MOVE_HTTP=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+  -u "${TEST_USER}:${TEST_PASS}" -H "Content-Type: application/json" \
+  -d "{\"targetFolder\":\"${F10_FOLDER_ID}\",\"networks\":[\"${V3_PUB_UUID}\",\"${V3_PRIV_UUID}\"]}" \
+  "${BASE_URL}/v3/batch/networks/move")
+[[ "${F10_MOVE_HTTP}" == "200" || "${F10_MOVE_HTTP}" == "204" ]] \
+  || api_fail "POST /v3/networks/move → HTTP ${F10_MOVE_HTTP}"
+api_pass "Moved PUBLIC (${V3_PUB_UUID}) + PRIVATE (${V3_PRIV_UUID}) networks into folder"
+
+# ---- Phase A: PUBLIC folder — an ANONYMOUS caller sees only the public child ----
+# This step runs BEFORE the AUTHENTICATED_USER_ONLY=true step below, so the server still permits
+# anonymous access to @PermitAll endpoints — exercising the real public-server leak scenario.
+CALL_NUM=$((CALL_NUM+1))
+echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: GET .../list + /count (anon) — PRIVATE child absent, network=1"
+F10_ANON_LIST=$(curl -s "${BASE_URL}/v3/files/folders/${F10_FOLDER_ID}/list")
+F10_ANON_NET=$(curl -s "${BASE_URL}/v3/files/folders/${F10_FOLDER_ID}/count" | grep -oE '"network"[[:space:]]*:[[:space:]]*[0-9]+' | grep -oE '[0-9]+$')
+echo "${F10_ANON_LIST}" | grep -q "${V3_PRIV_UUID}" \
+  && api_fail "anon /list LEAKED private child ${V3_PRIV_UUID}. Body: ${F10_ANON_LIST:0:400}"
+{ echo "${F10_ANON_LIST}" | grep -q "${V3_PUB_UUID}" && [[ "${F10_ANON_NET}" == "1" ]]; } \
+  || api_fail "anon view wrong: net=${F10_ANON_NET}, list=${F10_ANON_LIST:0:400}"
+api_pass "anon → /list PUBLIC child only (PRIVATE absent); /count network=1"
+
+# An AUTHENTICATED non-owner must also see only the public child (created anonymously here — the
+# server is still in default mode; the AUTHENTICATED_USER_ONLY step runs later).
+CALL_NUM=$((CALL_NUM+1))
+echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: POST /v2/user (create non-owner ${TEST_USER2})"
+U2_HTTP=$(curl -s -o /dev/null -w "%{http_code}" -X POST "${BASE_URL}/v2/user" \
+  -H "Content-Type: application/json" \
+  -d "{\"userName\":\"${TEST_USER2}\",\"password\":\"${TEST_PASS2}\",\"emailAddress\":\"${TEST_EMAIL2}\",\"firstName\":\"NDEx\",\"lastName\":\"Test2\"}")
+[[ "${U2_HTTP}" == "201" || "${U2_HTTP}" == "409" ]] || api_fail "POST /v2/user (${TEST_USER2}) → HTTP ${U2_HTTP}"
+api_pass "non-owner user ${TEST_USER2} ready"
+
+CALL_NUM=$((CALL_NUM+1))
+echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: GET .../list + /count (authenticated non-owner) — PRIVATE child absent, network=1"
+F10_U2_LIST=$(curl -s -u "${TEST_USER2}:${TEST_PASS2}" "${BASE_URL}/v3/files/folders/${F10_FOLDER_ID}/list")
+F10_U2_NET=$(curl -s -u "${TEST_USER2}:${TEST_PASS2}" "${BASE_URL}/v3/files/folders/${F10_FOLDER_ID}/count" | grep -oE '"network"[[:space:]]*:[[:space:]]*[0-9]+' | grep -oE '[0-9]+$')
+echo "${F10_U2_LIST}" | grep -q "${V3_PRIV_UUID}" \
+  && api_fail "authenticated non-owner /list LEAKED private child ${V3_PRIV_UUID}. Body: ${F10_U2_LIST:0:400}"
+{ echo "${F10_U2_LIST}" | grep -q "${V3_PUB_UUID}" && [[ "${F10_U2_NET}" == "1" ]]; } \
+  || api_fail "authenticated non-owner view wrong: net=${F10_U2_NET}, list=${F10_U2_LIST:0:400}"
+api_pass "authenticated non-owner → /list PUBLIC child only (PRIVATE absent); /count network=1"
+
+CALL_NUM=$((CALL_NUM+1))
+echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: GET .../list + /count (owner) — both children, network=2"
+F10_OWNER_LIST=$(curl -s -u "${TEST_USER}:${TEST_PASS}" "${BASE_URL}/v3/files/folders/${F10_FOLDER_ID}/list")
+F10_OWNER_NET=$(curl -s -u "${TEST_USER}:${TEST_PASS}" "${BASE_URL}/v3/files/folders/${F10_FOLDER_ID}/count" | grep -oE '"network"[[:space:]]*:[[:space:]]*[0-9]+' | grep -oE '[0-9]+$')
+{ echo "${F10_OWNER_LIST}" | grep -q "${V3_PUB_UUID}" && echo "${F10_OWNER_LIST}" | grep -q "${V3_PRIV_UUID}" && [[ "${F10_OWNER_NET}" == "2" ]]; } \
+  || api_fail "owner view wrong: net=${F10_OWNER_NET}, list=${F10_OWNER_LIST:0:400}"
+api_pass "owner → /list both children; /count network=2"
+
+# ---- Phase B: PRIVATE folder + access key — key grants ALL contents ----
+CALL_NUM=$((CALL_NUM+1))
+echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: POST /v3/files/setvisibility (folder → PRIVATE)"
+F10_VIS2_HTTP=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+  -u "${TEST_USER}:${TEST_PASS}" -H "Content-Type: application/json" \
+  -d "{\"visibility\":\"PRIVATE\",\"files\":{\"${F10_FOLDER_ID}\":\"FOLDER\"}}" \
+  "${BASE_URL}/v3/batch/files/setvisibility")
+[[ "${F10_VIS2_HTTP}" == "200" || "${F10_VIS2_HTTP}" == "204" ]] \
+  || api_fail "POST /v3/files/setvisibility (PRIVATE) → HTTP ${F10_VIS2_HTTP}"
+api_pass "Folder set PRIVATE"
+
+CALL_NUM=$((CALL_NUM+1))
+echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: GET .../list + /count (anon, no key) — PRIVATE folder must be 401"
+F10_NOKEY_LIST_HTTP=$(curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/v3/files/folders/${F10_FOLDER_ID}/list")
+F10_NOKEY_COUNT_HTTP=$(curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/v3/files/folders/${F10_FOLDER_ID}/count")
+{ [[ "${F10_NOKEY_LIST_HTTP}" == "401" ]] && [[ "${F10_NOKEY_COUNT_HTTP}" == "401" ]]; } \
+  || api_fail "anon on PRIVATE folder (no key) → list=${F10_NOKEY_LIST_HTTP}, count=${F10_NOKEY_COUNT_HTTP} (expected 401/401)"
+api_pass "anon /list + /count on PRIVATE folder (no key) → 401"
+
+CALL_NUM=$((CALL_NUM+1))
+echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: POST /v3/files/sharing/share (enable folder access key)"
+F10_SHARE_BODY=$(curl -s -X POST -u "${TEST_USER}:${TEST_PASS}" -H "Content-Type: application/json" \
+  -d "{\"files\":{\"${F10_FOLDER_ID}\":\"FOLDER\"}}" \
+  "${BASE_URL}/v3/files/sharing/share")
+F10_KEY=$(echo "${F10_SHARE_BODY}" | sed -E 's/.*:[[:space:]]*"([^"]+)".*/\1/')
+[[ -n "${F10_KEY}" && "${F10_KEY}" != "${F10_SHARE_BODY}" ]] || api_fail "Could not parse access key. Body: ${F10_SHARE_BODY:0:300}"
+api_pass "Folder access key enabled"
+
+CALL_NUM=$((CALL_NUM+1))
+echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: GET .../list + /count?accesskey (anon) — ALL children, network=2"
+F10_KEY_LIST=$(curl -s "${BASE_URL}/v3/files/folders/${F10_FOLDER_ID}/list?accesskey=${F10_KEY}")
+F10_KEY_NET=$(curl -s "${BASE_URL}/v3/files/folders/${F10_FOLDER_ID}/count?accesskey=${F10_KEY}" | grep -oE '"network"[[:space:]]*:[[:space:]]*[0-9]+' | grep -oE '[0-9]+$')
+{ echo "${F10_KEY_LIST}" | grep -q "${V3_PUB_UUID}" && echo "${F10_KEY_LIST}" | grep -q "${V3_PRIV_UUID}" && [[ "${F10_KEY_NET}" == "2" ]]; } \
+  || api_fail "access-key view wrong: net=${F10_KEY_NET}, list=${F10_KEY_LIST:0:400}"
+api_pass "anon + access key → /list all children (incl. PRIVATE); /count network=2"
+
 # ── STEP: AUTHENTICATED_USER_ONLY blocks anonymous POST /v2/user ─────────────
+# NOTE: this permanently flips the server to AUTHENTICATED_USER_ONLY=true (appends to
+# ndex.properties + restarts Tomcat), so it must run AFTER any step that needs anonymous
+# access (e.g. the F10 folder-visibility step above).
 
 if [[ -z "${REMOTE_NDEX_URL}" ]]; then
   step "Verifying AUTHENTICATED_USER_ONLY=true blocks anonymous POST /v2/user"

--- a/docker/test/integration-test.sh
+++ b/docker/test/integration-test.sh
@@ -32,7 +32,7 @@ TEST_USER2="ndextest2"
 TEST_PASS2="NDExTest2!"
 TEST_EMAIL2="ndextest2@ndex-integration.local"
 
-TOTAL_API_CALLS=67
+TOTAL_API_CALLS=68
 PASSED=0
 CALL_NUM=0
 STEP_NUM=0
@@ -1077,6 +1077,25 @@ F10_OWNER_NET=$(curl -s -u "${TEST_USER}:${TEST_PASS}" "${BASE_URL}/v3/files/fol
   || api_fail "owner view wrong: net=${F10_OWNER_NET}, list=${F10_OWNER_LIST:0:400}"
 api_pass "owner → /list both children; /count network=2"
 
+# A valid access key must return ALL children even when the folder is independently readable
+# (PUBLIC) — the key takes precedence over per-child filtering.
+CALL_NUM=$((CALL_NUM+1))
+echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: POST /v3/files/sharing/share (enable folder access key)"
+F10_SHARE_BODY=$(curl -s -X POST -u "${TEST_USER}:${TEST_PASS}" -H "Content-Type: application/json" \
+  -d "{\"files\":{\"${F10_FOLDER_ID}\":\"FOLDER\"}}" \
+  "${BASE_URL}/v3/files/sharing/share")
+F10_KEY=$(echo "${F10_SHARE_BODY}" | sed -E 's/.*:[[:space:]]*"([^"]+)".*/\1/')
+[[ -n "${F10_KEY}" && "${F10_KEY}" != "${F10_SHARE_BODY}" ]] || api_fail "Could not parse access key. Body: ${F10_SHARE_BODY:0:300}"
+api_pass "Folder access key enabled"
+
+CALL_NUM=$((CALL_NUM+1))
+echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: GET .../list + /count?accesskey on PUBLIC (readable) folder (anon) — ALL children, network=2"
+F10_PUBKEY_LIST=$(curl -s "${BASE_URL}/v3/files/folders/${F10_FOLDER_ID}/list?accesskey=${F10_KEY}")
+F10_PUBKEY_NET=$(curl -s "${BASE_URL}/v3/files/folders/${F10_FOLDER_ID}/count?accesskey=${F10_KEY}" | grep -oE '"network"[[:space:]]*:[[:space:]]*[0-9]+' | grep -oE '[0-9]+$')
+{ echo "${F10_PUBKEY_LIST}" | grep -q "${V3_PUB_UUID}" && echo "${F10_PUBKEY_LIST}" | grep -q "${V3_PRIV_UUID}" && [[ "${F10_PUBKEY_NET}" == "2" ]]; } \
+  || api_fail "access-key precedence on readable folder wrong: net=${F10_PUBKEY_NET}, list=${F10_PUBKEY_LIST:0:400}"
+api_pass "anon + access key on PUBLIC folder → /list all children (incl. PRIVATE); /count network=2 (key precedence)"
+
 # ---- Phase B: PRIVATE folder + access key — key grants ALL contents ----
 CALL_NUM=$((CALL_NUM+1))
 echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: POST /v3/files/setvisibility (folder → PRIVATE)"
@@ -1096,15 +1115,8 @@ F10_NOKEY_COUNT_HTTP=$(curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/v3/fi
   || api_fail "anon on PRIVATE folder (no key) → list=${F10_NOKEY_LIST_HTTP}, count=${F10_NOKEY_COUNT_HTTP} (expected 401/401)"
 api_pass "anon /list + /count on PRIVATE folder (no key) → 401"
 
-CALL_NUM=$((CALL_NUM+1))
-echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: POST /v3/files/sharing/share (enable folder access key)"
-F10_SHARE_BODY=$(curl -s -X POST -u "${TEST_USER}:${TEST_PASS}" -H "Content-Type: application/json" \
-  -d "{\"files\":{\"${F10_FOLDER_ID}\":\"FOLDER\"}}" \
-  "${BASE_URL}/v3/files/sharing/share")
-F10_KEY=$(echo "${F10_SHARE_BODY}" | sed -E 's/.*:[[:space:]]*"([^"]+)".*/\1/')
-[[ -n "${F10_KEY}" && "${F10_KEY}" != "${F10_SHARE_BODY}" ]] || api_fail "Could not parse access key. Body: ${F10_SHARE_BODY:0:300}"
-api_pass "Folder access key enabled"
-
+# The access key was enabled in Phase A (while PUBLIC); it still grants full contents now that the
+# folder is PRIVATE.
 CALL_NUM=$((CALL_NUM+1))
 echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: GET .../list + /count?accesskey (anon) — ALL children, network=2"
 F10_KEY_LIST=$(curl -s "${BASE_URL}/v3/files/folders/${F10_FOLDER_ID}/list?accesskey=${F10_KEY}")

--- a/src/main/java/org/ndexbio/common/models/dao/FolderDAO.java
+++ b/src/main/java/org/ndexbio/common/models/dao/FolderDAO.java
@@ -43,9 +43,22 @@ public interface FolderDAO extends AutoCloseable {
 	void updateFolder(UUID folderId, String name, UUID parentId, UUID ownerId, String description) throws SQLException, JsonProcessingException, NdexException;
 	
 	FileCount getFolderChildCounts(UUID folderId) throws SQLException;
-	
+
+	/**
+	 * Like {@link #getFolderChildCounts(UUID)} but counts only children the given viewer may read.
+	 * @param viewerUserId the accessing user, or {@code null} for an anonymous caller
+	 */
+	FileCount getReadableFolderChildCounts(UUID folderId, UUID viewerUserId) throws SQLException;
+
 	List<FileItemSummary> listItemsInFolder(UUID folderId, boolean compact, FileType type) throws SQLException;
-	
+
+	/**
+	 * Like {@link #listItemsInFolder(UUID, boolean, FileType)} but returns only the immediate children
+	 * the given viewer may read (PUBLIC/UNLISTED, plus items they own or are shared on).
+	 * @param viewerUserId the accessing user, or {@code null} for an anonymous caller
+	 */
+	List<FileItemSummary> listReadableItemsInFolder(UUID folderId, boolean compact, FileType type, UUID viewerUserId) throws SQLException;
+
 	List<FileItemSummary> listRootItemsOfUser(UUID ownerId, boolean compact, FileType type) throws SQLException;
 	
 	List<NdexFolder> listFoldersOfUser(UUID ownerId, int limit) throws SQLException;

--- a/src/main/java/org/ndexbio/common/models/dao/postgresql/PostgresFolderDAO.java
+++ b/src/main/java/org/ndexbio/common/models/dao/postgresql/PostgresFolderDAO.java
@@ -459,12 +459,55 @@ public class PostgresFolderDAO extends NdexDBDAO implements FolderDAO {
 
 	    return fc;
 	}
+
+	@Override
+	public FileCount getReadableFolderChildCounts(UUID folderId, UUID viewerUserId) throws SQLException {
+	    FileCount fc = new FileCount();
+	    fc.setFolder(countReadableChildren("folder", "f", folderId,
+	            createIsReadableConditionStr(viewerUserId)));
+	    fc.setNetwork(countReadableChildren("network", "n", folderId,
+	            PostgresNetworkDAO.createIsReadableConditionStr(viewerUserId)));
+	    fc.setShortcut(countReadableChildren("shortcut", "s", folderId,
+	            PostgresShortcutDAO.createIsReadableConditionStr(viewerUserId)));
+	    return fc;
+	}
+
+	private long countReadableChildren(String table, String alias, UUID folderId, String readableClause)
+	        throws SQLException {
+	    String sql = "SELECT COUNT(*) FROM " + table + " " + alias
+	        + " WHERE " + alias + ".parent=? AND " + alias + ".is_deleted=false"
+	        + " AND (" + readableClause + ")";
+	    try (PreparedStatement pst = db.prepareStatement(sql)) {
+	        pst.setObject(1, folderId);
+	        try (ResultSet rs = pst.executeQuery()) {
+	            if (rs.next()) {
+	                return rs.getLong(1);
+	            }
+	        }
+	    }
+	    return 0L;
+	}
+
+	/** Per-entity-type readable SQL predicates (aliases f/n/s) for a given viewer. */
+	private record ChildReadClauses(String folder, String network, String shortcut) {}
+
+	private static ChildReadClauses readClausesFor(UUID viewerUserId) {
+	    return new ChildReadClauses(
+	        createIsReadableConditionStr(viewerUserId),
+	        PostgresNetworkDAO.createIsReadableConditionStr(viewerUserId),
+	        PostgresShortcutDAO.createIsReadableConditionStr(viewerUserId));
+	}
 	
 	@Override
 	public List<FileItemSummary> listItemsInFolder(UUID folderId, boolean compact, FileType type) throws SQLException {
 	    return listItemsInFolderOrHome(folderId, compact, false, type);
 	}
-	
+
+	@Override
+	public List<FileItemSummary> listReadableItemsInFolder(UUID folderId, boolean compact, FileType type, UUID viewerUserId) throws SQLException {
+	    return listItemsInFolderOrHome(folderId, compact, false, type, readClausesFor(viewerUserId));
+	}
+
 	@Override
 	public List<FileItemSummary> listRootItemsOfUser(UUID ownerId, boolean compact, FileType type) throws SQLException {
 	    return listItemsInFolderOrHome(ownerId, compact, true, type);
@@ -483,6 +526,15 @@ public class PostgresFolderDAO extends NdexDBDAO implements FolderDAO {
 	 * @throws SQLException if database access fails
 	 */
 	private List<FileItemSummary> listItemsInFolderOrHome(UUID contextId, boolean compact, boolean home, FileType type) throws SQLException {
+	    return listItemsInFolderOrHome(contextId, compact, home, type, null);
+	}
+
+	/**
+	 * @param childReadClauses when non-null, its per-type readable predicate is AND-appended to each
+	 *        child query so only children the caller may read are returned; when null, no per-child
+	 *        filtering is applied (internal/home callers).
+	 */
+	private List<FileItemSummary> listItemsInFolderOrHome(UUID contextId, boolean compact, boolean home, FileType type, ChildReadClauses childReadClauses) throws SQLException {
 	    List<FileItemSummary> results = new ArrayList<>();
 	    /* ────────────── 1) Folders ─────────────── */
 	    if (type == null || type == FileType.FOLDER) {
@@ -496,6 +548,9 @@ public class PostgresFolderDAO extends NdexDBDAO implements FolderDAO {
         folderSql.append("FROM folder f JOIN ndex_user u ON f.owneruuid = u.\"UUID\" WHERE ");
 	        folderSql.append(home ? "f.owneruuid=? AND f.parent IS NULL" : "f.parent=?");
 	        folderSql.append(" AND f.is_deleted=false");
+	        if (childReadClauses != null) {
+	            folderSql.append(" AND (").append(childReadClauses.folder()).append(")");
+	        }
 	        try (PreparedStatement pst = db.prepareStatement(folderSql.toString())) {
 	            pst.setObject(1, contextId);
 	            try (ResultSet rs = pst.executeQuery()) {
@@ -534,6 +589,9 @@ public class PostgresFolderDAO extends NdexDBDAO implements FolderDAO {
         networkSql.append("FROM network n JOIN ndex_user u ON n.owneruuid = u.\"UUID\" WHERE ");
 	        networkSql.append(home ? "n.owneruuid=? AND n.parent IS NULL" : "n.parent=?");
 	        networkSql.append(" AND n.is_deleted=false");
+	        if (childReadClauses != null) {
+	            networkSql.append(" AND (").append(childReadClauses.network()).append(")");
+	        }
 	        try (PreparedStatement pst = db.prepareStatement(networkSql.toString())) {
 	            pst.setObject(1, contextId);
 	            try (ResultSet rs = pst.executeQuery()) {
@@ -605,6 +663,9 @@ public class PostgresFolderDAO extends NdexDBDAO implements FolderDAO {
 	        + " AND s.is_deleted=false";
 	    if (type != null) {
 	        sql += " AND s.target_type=?";
+	    }
+	    if (childReadClauses != null) {
+	        sql += " AND (" + childReadClauses.shortcut() + ")";
 	    }
 	    try (PreparedStatement pst = db.prepareStatement(sql)) {
 	        pst.setObject(1, contextId);

--- a/src/main/java/org/ndexbio/rest/services/v3/files/FolderServiceV3.java
+++ b/src/main/java/org/ndexbio/rest/services/v3/files/FolderServiceV3.java
@@ -366,16 +366,17 @@ public class FolderServiceV3 extends NdexService {
 	    UUID userId = getLoggedInUserId();
 
 	    try (FolderDAO dao = Configuration.getInstance().getDAOFactory().getFolderDAO()) {
-	        boolean readable = dao.isReadable(folderUUID, userId);
-	        if (!readable && !dao.accessKeyIsValid(folderUUID, accessKey)) {
+	        // A valid access key grants the folder's full contents; otherwise the caller must be able
+	        // to read the folder and gets only the children they may see (matches /list).
+	        if (dao.accessKeyIsValid(folderUUID, accessKey)) {
+	            return dao.getFolderChildCounts(folderUUID);
+	        }
+	        if (!dao.isReadable(folderUUID, userId)) {
 	            throw new UnauthorizedOperationException(
 	                "User doesn't have read access to this folder."
 	            );
 	        }
-	        // Count only children the caller may read (matches /list); a valid access key counts all.
-	        return readable
-	                ? dao.getReadableFolderChildCounts(folderUUID, userId)
-	                : dao.getFolderChildCounts(folderUUID);
+	        return dao.getReadableFolderChildCounts(folderUUID, userId);
 	    }
 
 	}
@@ -445,15 +446,15 @@ public class FolderServiceV3 extends NdexService {
 	    UUID folderUUID = UUID.fromString(folderIdStr);
 
 	    try (FolderDAO dao = Configuration.getInstance().getDAOFactory().getFolderDAO()) {
-	        boolean readable = dao.isReadable(folderUUID, userId);
-	        if (!readable && !dao.accessKeyIsValid(folderUUID, accessKey)) {
+	        // A valid folder access key returns all contents; otherwise the caller must be able to read
+	        // the folder and gets only the children they may see.
+	        if (dao.accessKeyIsValid(folderUUID, accessKey)) {
+	            return dao.listItemsInFolder(folderUUID, compact, fileType);
+	        }
+	        if (!dao.isReadable(folderUUID, userId)) {
 	            throw new UnauthorizedOperationException("User doesn't have read access to this folder.");
 	        }
-
-	        // Filter children to what the caller may read; a valid folder access key returns all contents.
-	        return readable
-	                ? dao.listReadableItemsInFolder(folderUUID, compact, fileType, userId)
-	                : dao.listItemsInFolder(folderUUID, compact, fileType);
+	        return dao.listReadableItemsInFolder(folderUUID, compact, fileType, userId);
 	    }
 	}
 	

--- a/src/main/java/org/ndexbio/rest/services/v3/files/FolderServiceV3.java
+++ b/src/main/java/org/ndexbio/rest/services/v3/files/FolderServiceV3.java
@@ -341,7 +341,7 @@ public class FolderServiceV3 extends NdexService {
     @Operation(
             summary = "Get Item Counts Within a Folder",
             description = """
-                          Returns counts of how many networks, subfolders, and shortcuts exist directly under the specified folder.
+                          Returns counts of the networks, subfolders, and shortcuts directly under the specified folder that the caller is allowed to see (matches the /list result for the same caller). A valid folder access key counts all children.
                           
                           Path Parameters:
                           - folderid: UUID of the folder to count items in
@@ -366,15 +366,16 @@ public class FolderServiceV3 extends NdexService {
 	    UUID userId = getLoggedInUserId();
 
 	    try (FolderDAO dao = Configuration.getInstance().getDAOFactory().getFolderDAO()) {
-	        if (!dao.isReadable(folderUUID, userId) && !dao.accessKeyIsValid(folderUUID, accessKey)) {
+	        boolean readable = dao.isReadable(folderUUID, userId);
+	        if (!readable && !dao.accessKeyIsValid(folderUUID, accessKey)) {
 	            throw new UnauthorizedOperationException(
 	                "User doesn't have read access to this folder."
 	            );
 	        }
-	        FileCount result;
-	        result = dao.getFolderChildCounts(folderUUID);
-	        
-		    return result;
+	        // Count only children the caller may read (matches /list); a valid access key counts all.
+	        return readable
+	                ? dao.getReadableFolderChildCounts(folderUUID, userId)
+	                : dao.getFolderChildCounts(folderUUID);
 	    }
 
 	}
@@ -386,9 +387,9 @@ public class FolderServiceV3 extends NdexService {
 	@Operation(
 	    summary = "List items in a folder",
 	    description = """
-					Lists all items (folders, networks, shortcuts) in the specified folder.
+					Lists items (folders, networks, shortcuts) in the specified folder.
 					If *folderid* is a UUID, returns the immediate children of that folder  
-					(folders/networks/shortcuts) provided the caller is an owner or has read access or a valid accesskey.  
+					that the caller is allowed to read (PUBLIC/UNLISTED, plus items they own or are shared on); a valid folder access key returns all children.
 					If *folderid* is the literal string **"home"**, returns all top level items owned by the signed in user (parent = NULL).
 
 					Path Parameters:
@@ -444,13 +445,15 @@ public class FolderServiceV3 extends NdexService {
 	    UUID folderUUID = UUID.fromString(folderIdStr);
 
 	    try (FolderDAO dao = Configuration.getInstance().getDAOFactory().getFolderDAO()) {
-	        if (!dao.isReadable(folderUUID, userId) && !dao.accessKeyIsValid(folderUUID, accessKey)) {
+	        boolean readable = dao.isReadable(folderUUID, userId);
+	        if (!readable && !dao.accessKeyIsValid(folderUUID, accessKey)) {
 	            throw new UnauthorizedOperationException("User doesn't have read access to this folder.");
 	        }
-	        
-	        List<FileItemSummary> items;
-	        items = dao.listItemsInFolder(folderUUID, compact, fileType);
-	        return items;
+
+	        // Filter children to what the caller may read; a valid folder access key returns all contents.
+	        return readable
+	                ? dao.listReadableItemsInFolder(folderUUID, compact, fileType, userId)
+	                : dao.listItemsInFolder(folderUUID, compact, fileType);
 	    }
 	}
 	

--- a/src/test/java/org/ndexbio/rest/services/v3/files/TestFolderServiceV3.java
+++ b/src/test/java/org/ndexbio/rest/services/v3/files/TestFolderServiceV3.java
@@ -371,8 +371,8 @@ public class TestFolderServiceV3 {
 
         FolderDAO folderDAO = createMock(FolderDAO.class);
         expect(folderDAO.isReadable(folderId, userId)).andReturn(true);
-        expect(folderDAO.accessKeyIsValid(folderId, null)).andReturn(false);
-        expect(folderDAO.getFolderChildCounts(folderId)).andReturn(count);
+        // readable by the authenticated caller -> counts filtered to what they may see
+        expect(folderDAO.getReadableFolderChildCounts(folderId, userId)).andReturn(count);
         folderDAO.close();
         expectLastCall();
         replay(folderDAO);
@@ -432,8 +432,8 @@ public class TestFolderServiceV3 {
 
         FolderDAO folderDAO = createMock(FolderDAO.class);
         expect(folderDAO.isReadable(folderId, userId)).andReturn(true);
-        expect(folderDAO.accessKeyIsValid(folderId, null)).andReturn(false);
-        expect(folderDAO.listItemsInFolder(folderId, false, null)).andReturn(items);
+        // readable by the authenticated caller -> children filtered to what they may read
+        expect(folderDAO.listReadableItemsInFolder(folderId, false, null, userId)).andReturn(items);
         folderDAO.close();
         expectLastCall();
         replay(folderDAO);
@@ -453,6 +453,93 @@ public class TestFolderServiceV3 {
         assertEquals(1, result.length);
         assertEquals(FileType.NETWORK, result[0].getType());
     }
+
+    @Test
+    public void testListItemsInFolderViaAccessKeyUsesUnfiltered() throws Exception {
+        UUID folderId = UUID.randomUUID();
+
+        // Anonymous caller with a valid folder access key.
+        expect(mockHttpServletRequest.getAttribute("User")).andReturn(null).anyTimes();
+        replay(mockHttpServletRequest);
+
+        List<FileItemSummary> items = new ArrayList<>();
+        items.add(new FileItemSummary(UUID.randomUUID(), FileType.NETWORK, "Net 1"));
+
+        FolderDAO folderDAO = createMock(FolderDAO.class);
+        expect(folderDAO.isReadable(folderId, null)).andReturn(false).anyTimes();
+        expect(folderDAO.accessKeyIsValid(folderId, "k")).andReturn(true).anyTimes();
+        // access key grants the folder's full contents -> unfiltered listing
+        expect(folderDAO.listItemsInFolder(folderId, false, null)).andReturn(items);
+        folderDAO.close();
+        expectLastCall().anyTimes();
+        replay(folderDAO);
+
+        DAOFactory daoFactory = createMock(DAOFactory.class);
+        expect(daoFactory.getFolderDAO()).andReturn(folderDAO).anyTimes();
+        replay(daoFactory);
+        Configuration.getInstance().setDAOFactory(daoFactory);
+
+        MockHttpRequest request = MockHttpRequest.get("/v3/files/folders/" + folderId + "/list?accesskey=k");
+        dispatcher.invoke(request, response);
+        assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    public void testGetFolderChildCountViaAccessKeyUsesUnfiltered() throws Exception {
+        UUID folderId = UUID.randomUUID();
+
+        expect(mockHttpServletRequest.getAttribute("User")).andReturn(null).anyTimes();
+        replay(mockHttpServletRequest);
+
+        FileCount count = new FileCount();
+        count.setNetwork(2);
+
+        FolderDAO folderDAO = createMock(FolderDAO.class);
+        expect(folderDAO.isReadable(folderId, null)).andReturn(false).anyTimes();
+        expect(folderDAO.accessKeyIsValid(folderId, "k")).andReturn(true).anyTimes();
+        expect(folderDAO.getFolderChildCounts(folderId)).andReturn(count);
+        folderDAO.close();
+        expectLastCall().anyTimes();
+        replay(folderDAO);
+
+        DAOFactory daoFactory = createMock(DAOFactory.class);
+        expect(daoFactory.getFolderDAO()).andReturn(folderDAO).anyTimes();
+        replay(daoFactory);
+        Configuration.getInstance().setDAOFactory(daoFactory);
+
+        MockHttpRequest request = MockHttpRequest.get("/v3/files/folders/" + folderId + "/count?accesskey=k");
+        dispatcher.invoke(request, response);
+        assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    public void testListItemsInHomeUsesListRootItems() throws Exception {
+        UUID userId = UUID.randomUUID();
+        User user = new User();
+        user.setExternalId(userId);
+
+        expect(mockHttpServletRequest.getAttribute("User")).andReturn(user).anyTimes();
+        replay(mockHttpServletRequest);
+
+        List<FileItemSummary> items = new ArrayList<>();
+        items.add(new FileItemSummary(UUID.randomUUID(), FileType.FOLDER, "Sub"));
+
+        FolderDAO folderDAO = createMock(FolderDAO.class);
+        expect(folderDAO.listRootItemsOfUser(userId, false, null)).andReturn(items);
+        folderDAO.close();
+        expectLastCall().anyTimes();
+        replay(folderDAO);
+
+        DAOFactory daoFactory = createMock(DAOFactory.class);
+        expect(daoFactory.getFolderDAO()).andReturn(folderDAO).anyTimes();
+        replay(daoFactory);
+        Configuration.getInstance().setDAOFactory(daoFactory);
+
+        MockHttpRequest request = MockHttpRequest.get("/v3/files/folders/home/list");
+        dispatcher.invoke(request, response);
+        assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    }
+
     private static class TestFolderServiceV3NoIndex extends FolderServiceV3 {
         public TestFolderServiceV3NoIndex(HttpServletRequest request) {
             super(request);

--- a/src/test/java/org/ndexbio/rest/services/v3/files/TestFolderServiceV3.java
+++ b/src/test/java/org/ndexbio/rest/services/v3/files/TestFolderServiceV3.java
@@ -370,6 +370,7 @@ public class TestFolderServiceV3 {
         count.setShortcut(3);
 
         FolderDAO folderDAO = createMock(FolderDAO.class);
+        expect(folderDAO.accessKeyIsValid(folderId, null)).andReturn(false);
         expect(folderDAO.isReadable(folderId, userId)).andReturn(true);
         // readable by the authenticated caller -> counts filtered to what they may see
         expect(folderDAO.getReadableFolderChildCounts(folderId, userId)).andReturn(count);
@@ -431,6 +432,7 @@ public class TestFolderServiceV3 {
         items.add(new FileItemSummary(UUID.randomUUID(), FileType.NETWORK, "Net 1"));
 
         FolderDAO folderDAO = createMock(FolderDAO.class);
+        expect(folderDAO.accessKeyIsValid(folderId, null)).andReturn(false);
         expect(folderDAO.isReadable(folderId, userId)).andReturn(true);
         // readable by the authenticated caller -> children filtered to what they may read
         expect(folderDAO.listReadableItemsInFolder(folderId, false, null, userId)).andReturn(items);
@@ -466,7 +468,9 @@ public class TestFolderServiceV3 {
         items.add(new FileItemSummary(UUID.randomUUID(), FileType.NETWORK, "Net 1"));
 
         FolderDAO folderDAO = createMock(FolderDAO.class);
-        expect(folderDAO.isReadable(folderId, null)).andReturn(false).anyTimes();
+        // Folder is independently readable (e.g. PUBLIC) AND a valid access key is supplied:
+        // the key must take precedence and return the unfiltered contents.
+        expect(folderDAO.isReadable(folderId, null)).andReturn(true).anyTimes();
         expect(folderDAO.accessKeyIsValid(folderId, "k")).andReturn(true).anyTimes();
         // access key grants the folder's full contents -> unfiltered listing
         expect(folderDAO.listItemsInFolder(folderId, false, null)).andReturn(items);
@@ -495,7 +499,9 @@ public class TestFolderServiceV3 {
         count.setNetwork(2);
 
         FolderDAO folderDAO = createMock(FolderDAO.class);
-        expect(folderDAO.isReadable(folderId, null)).andReturn(false).anyTimes();
+        // Folder is independently readable (e.g. PUBLIC) AND a valid access key is supplied:
+        // the key must take precedence and return the unfiltered contents.
+        expect(folderDAO.isReadable(folderId, null)).andReturn(true).anyTimes();
         expect(folderDAO.accessKeyIsValid(folderId, "k")).andReturn(true).anyTimes();
         expect(folderDAO.getFolderChildCounts(folderId)).andReturn(count);
         folderDAO.close();


### PR DESCRIPTION
Fixed the /v3/files/folders/{folderid}/list and /v3/files/folders/{folderid}/count to correctly filter for visibility based on caller auth.

Closes #124 