### PR TITLE
keep networkset read-only api endpoints up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
-- **The NDEx network set feature has been removed.** All `/v2/networkset` endpoints now return **HTTP 501 Not Implemented**, and `GET /v2/user/{userid}/networksets` is retired. Use folders + shortcuts + folder access keys instead — see the [V3 Migration Guide](docs/V3-Migration-Guide.md). Affected endpoints:
-  - `POST /v2/networkset`, `GET|PUT|DELETE /v2/networkset/{id}`, `POST|DELETE /v2/networkset/{id}/members`, `GET|PUT /v2/networkset/{id}/accesskey`, `PUT /v2/networkset/{id}/systemproperty` → 501 (the entire `/v2/networkset` resource is retired).
+- **The NDEx network set feature has been removed**, except for two read-only endpoints re-enabled for backward-compatible reads of legacy data. All `/v2/networkset` *write* endpoints return **HTTP 501 Not Implemented**, and `GET /v2/user/{userid}/networksets` is retired. New network sets can no longer be created; use folders + shortcuts + folder access keys instead — see the [V3 Migration Guide](docs/V3-Migration-Guide.md). Endpoint status:
+  - **Re-enabled (read-only):** `GET /v2/networkset/{id}` and `GET /v2/networkset/{id}/accesskey` now serve the frozen, archived `network_set` / `network_set_member` tables directly — no v3 folder polyfill. `GET /v2/networkset/{id}` returns the archived set (members filtered to networks the caller can read, a valid access key returning all); `GET /v2/networkset/{id}/accesskey` returns the archived key to the set owner. Both are marked deprecated/archived in Swagger.
+  - **Retired → 501:** `POST /v2/networkset`, `PUT|DELETE /v2/networkset/{id}`, `POST|DELETE /v2/networkset/{id}/members`, `PUT /v2/networkset/{id}/accesskey`, `PUT /v2/networkset/{id}/systemproperty`.
   - `GET /v2/user/{userid}/networksets` → 501, and the `networkSetCount` field is removed from `GET /v2/user/{userid}/networkcount`.
   - The legacy `network_set` / `network_set_member` tables are retained as frozen/read-only; the `network_set_member → network` foreign key is dropped so the tables no longer couple to network deletion.
 - **Swagger / OpenAPI** — every removed network-set endpoint is marked `deprecated` with a documented `501` response.

--- a/docker/test/integration-test.sh
+++ b/docker/test/integration-test.sh
@@ -32,7 +32,7 @@ TEST_USER2="ndextest2"
 TEST_PASS2="NDExTest2!"
 TEST_EMAIL2="ndextest2@ndex-integration.local"
 
-TOTAL_API_CALLS=106
+TOTAL_API_CALLS=110
 PASSED=0
 CALL_NUM=0
 STEP_NUM=0
@@ -1041,19 +1041,20 @@ else
   api_fail "GET /v2/network/${V2_PRIV_UUID}/permission?type=user (owner) → HTTP ${PERM_USER_HTTP} (expected 200)"
 fi
 
-# ── STEP: NDEx network set feature removed — every /v2/networkset endpoint returns HTTP 501 ──
-step "Network set feature removed: /v2/networkset endpoints return 501"
+# ── STEP: NDEx network set WRITES retired — /v2/networkset write endpoints return HTTP 501 ──
+# The two read endpoints (GET /v2/networkset/{id} and GET /v2/networkset/{id}/accesskey) are
+# re-enabled to serve the frozen archive and are exercised in the dedicated read step below;
+# only the write endpoints remain retired to 501 here.
+step "Network set writes retired: /v2/networkset write endpoints return 501"
 
 NS_DUMMY_UUID="00000000-0000-0000-0000-000000000001"
 
-# /v2/networkset resource — all methods retired
+# /v2/networkset resource — all write methods retired
 assert_networkset_501 POST   "${BASE_URL}/v2/networkset" -H "Content-Type: application/json" -d '{}'
-assert_networkset_501 GET    "${BASE_URL}/v2/networkset/${NS_DUMMY_UUID}"
 assert_networkset_501 PUT    "${BASE_URL}/v2/networkset/${NS_DUMMY_UUID}" -H "Content-Type: application/json" -d '{}'
 assert_networkset_501 DELETE "${BASE_URL}/v2/networkset/${NS_DUMMY_UUID}"
 assert_networkset_501 POST   "${BASE_URL}/v2/networkset/${NS_DUMMY_UUID}/members" -H "Content-Type: application/json" -d '[]'
 assert_networkset_501 DELETE "${BASE_URL}/v2/networkset/${NS_DUMMY_UUID}/members" -H "Content-Type: application/json" -d '[]'
-assert_networkset_501 GET    "${BASE_URL}/v2/networkset/${NS_DUMMY_UUID}/accesskey"
 assert_networkset_501 PUT    "${BASE_URL}/v2/networkset/${NS_DUMMY_UUID}/accesskey?action=enable"
 assert_networkset_501 PUT    "${BASE_URL}/v2/networkset/${NS_DUMMY_UUID}/systemproperty" -H "Content-Type: application/json" -d '{}'
 
@@ -1437,6 +1438,95 @@ CALL_NUM=$((CALL_NUM+1))
 echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: search files visibility=PRIVATE (shortcut dropped from private-nfs)"
 poll_files_until_absent "PRIVATE" "${VM_SHORTCUT_NAME}" "${VM_S_ID}" "shortcut post-move (old core)"
 api_pass "shortcut visibility PRIVATE→PUBLIC fully reindexed: present in public-nfs, absent from private-nfs (no orphan)"
+
+# ── STEP: Re-enabled read-only /v2/networkset endpoints serve frozen archive data ──
+# The network set feature is removed (writes → 501), but two READ endpoints are re-enabled to
+# serve the frozen, archived network_set / network_set_member tables. Since no endpoint can
+# create a network set anymore, we seed one directly via psql (owned by TEST_USER, key enabled,
+# with one PUBLIC and one PRIVATE member network), then read it back. Runs BEFORE the
+# AUTHENTICATED_USER_ONLY flip below so the anonymous read path is still exercised.
+
+if [[ -z "${REMOTE_NDEX_URL}" ]]; then
+  step "Re-enabled read-only /v2/networkset endpoints (archived network_set data)"
+
+  NS_SET_ID="11111111-2222-3333-4444-555555555555"
+  NS_KEY="ns-archive-test-key"
+
+  echo "  Seeding frozen network_set '${NS_SET_ID}' (owner=${TEST_USER}, members: 1 public + 1 private)..."
+  docker exec "${CONTAINER_NAME}" bash -c "
+    DB_USER=\$(grep '^NdexDBUsername=' /apps/ndex/config/ndex.properties | cut -d= -f2-)
+    DB_PASS=\$(grep '^NdexDBDBPassword=' /apps/ndex/config/ndex.properties | cut -d= -f2-)
+    PGPASSWORD=\"\$DB_PASS\" psql -h 127.0.0.1 -p 5432 -U \"\$DB_USER\" -d ndex \
+      -c \"DELETE FROM network_set_member WHERE set_id = '${NS_SET_ID}'; \
+           DELETE FROM network_set WHERE \\\"UUID\\\" = '${NS_SET_ID}'; \
+           INSERT INTO network_set (\\\"UUID\\\", name, description, owner_id, creation_time, modification_time, is_deleted, access_key, access_key_is_on, showcased) \
+             VALUES ('${NS_SET_ID}', 'NDEx Archived Test Set', 'frozen archive read test', (SELECT \\\"UUID\\\" FROM ndex_user WHERE user_name = '${TEST_USER}' AND is_deleted = false), now(), now(), false, '${NS_KEY}', true, false); \
+           INSERT INTO network_set_member (set_id, network_id) VALUES ('${NS_SET_ID}', '${V2_PUB_UUID}'), ('${NS_SET_ID}', '${V2_PRIV_UUID}');\"
+  "
+
+  # 1) GET /v2/networkset/{id} (anon, no key): metadata + only the readable (public) member.
+  CALL_NUM=$((CALL_NUM+1))
+  echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: GET /v2/networkset/${NS_SET_ID} (anon) — public member only"
+  NS_ANON=$(curl -s -w "\n%{http_code}" "${BASE_URL}/v2/networkset/${NS_SET_ID}")
+  NS_ANON_HTTP=$(echo "${NS_ANON}" | tail -1); NS_ANON_BODY=$(echo "${NS_ANON}" | head -1)
+  [[ "${NS_ANON_HTTP}" == "200" ]] || api_fail "GET /v2/networkset (anon) → HTTP ${NS_ANON_HTTP}. Body: ${NS_ANON_BODY:0:400}"
+  echo "${NS_ANON_BODY}" | grep -q "NDEx Archived Test Set" || api_fail "anon read missing archived set name. Body: ${NS_ANON_BODY:0:400}"
+  echo "${NS_ANON_BODY}" | grep -q "${V2_PUB_UUID}" || api_fail "anon read missing PUBLIC member ${V2_PUB_UUID}. Body: ${NS_ANON_BODY:0:400}"
+  echo "${NS_ANON_BODY}" | grep -q "${V2_PRIV_UUID}" && api_fail "anon read LEAKED PRIVATE member ${V2_PRIV_UUID}. Body: ${NS_ANON_BODY:0:400}"
+  api_pass "GET /v2/networkset (anon) → 200, archived metadata + PUBLIC member only (PRIVATE filtered)"
+
+  # 2) GET /v2/networkset/{id}?accesskey=<key> (anon): a valid archived key bypasses the filter.
+  CALL_NUM=$((CALL_NUM+1))
+  echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: GET /v2/networkset/${NS_SET_ID}?accesskey (anon) — all members"
+  NS_KEYED=$(curl -s -w "\n%{http_code}" "${BASE_URL}/v2/networkset/${NS_SET_ID}?accesskey=${NS_KEY}")
+  NS_KEYED_HTTP=$(echo "${NS_KEYED}" | tail -1); NS_KEYED_BODY=$(echo "${NS_KEYED}" | head -1)
+  [[ "${NS_KEYED_HTTP}" == "200" ]] || api_fail "GET /v2/networkset?accesskey (anon) → HTTP ${NS_KEYED_HTTP}. Body: ${NS_KEYED_BODY:0:400}"
+  echo "${NS_KEYED_BODY}" | grep -q "${V2_PUB_UUID}" || api_fail "keyed read missing PUBLIC member. Body: ${NS_KEYED_BODY:0:400}"
+  echo "${NS_KEYED_BODY}" | grep -q "${V2_PRIV_UUID}" || api_fail "keyed read missing PRIVATE member (key should bypass filter). Body: ${NS_KEYED_BODY:0:400}"
+  api_pass "GET /v2/networkset?accesskey (anon) → 200, valid archived key returns ALL members"
+
+  # 3) GET /v2/networkset/{id} (owner): sees both members via own readability.
+  CALL_NUM=$((CALL_NUM+1))
+  echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: GET /v2/networkset/${NS_SET_ID} (owner) — both members"
+  NS_OWNER=$(curl -s -w "\n%{http_code}" -u "${TEST_USER}:${TEST_PASS}" "${BASE_URL}/v2/networkset/${NS_SET_ID}")
+  NS_OWNER_HTTP=$(echo "${NS_OWNER}" | tail -1); NS_OWNER_BODY=$(echo "${NS_OWNER}" | head -1)
+  [[ "${NS_OWNER_HTTP}" == "200" ]] || api_fail "GET /v2/networkset (owner) → HTTP ${NS_OWNER_HTTP}. Body: ${NS_OWNER_BODY:0:400}"
+  echo "${NS_OWNER_BODY}" | grep -q "${V2_PUB_UUID}" || api_fail "owner read missing PUBLIC member. Body: ${NS_OWNER_BODY:0:400}"
+  echo "${NS_OWNER_BODY}" | grep -q "${V2_PRIV_UUID}" || api_fail "owner read missing own PRIVATE member. Body: ${NS_OWNER_BODY:0:400}"
+  api_pass "GET /v2/networkset (owner) → 200, both members (own PRIVATE network is readable)"
+
+  # 4) GET /v2/networkset/{id}/accesskey (owner): returns the archived key.
+  CALL_NUM=$((CALL_NUM+1))
+  echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: GET /v2/networkset/${NS_SET_ID}/accesskey (owner) — key returned"
+  NS_AK=$(curl -s -w "\n%{http_code}" -u "${TEST_USER}:${TEST_PASS}" "${BASE_URL}/v2/networkset/${NS_SET_ID}/accesskey")
+  NS_AK_HTTP=$(echo "${NS_AK}" | tail -1); NS_AK_BODY=$(echo "${NS_AK}" | head -1)
+  [[ "${NS_AK_HTTP}" == "200" ]] || api_fail "GET /v2/networkset/accesskey (owner) → HTTP ${NS_AK_HTTP}. Body: ${NS_AK_BODY:0:400}"
+  echo "${NS_AK_BODY}" | grep -q "${NS_KEY}" || api_fail "accesskey read missing key '${NS_KEY}'. Body: ${NS_AK_BODY:0:400}"
+  api_pass "GET /v2/networkset/accesskey (owner) → 200, archived access key returned"
+
+  # 5) GET /v2/networkset/{id}/accesskey (non-owner): 401 (ownership required for the key).
+  CALL_NUM=$((CALL_NUM+1))
+  echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: GET /v2/networkset/${NS_SET_ID}/accesskey (non-owner ${TEST_USER2}) — 401"
+  NS_AK2_HTTP=$(curl -s -o /dev/null -w "%{http_code}" -u "${TEST_USER2}:${TEST_PASS2}" "${BASE_URL}/v2/networkset/${NS_SET_ID}/accesskey")
+  [[ "${NS_AK2_HTTP}" == "401" ]] || api_fail "GET /v2/networkset/accesskey (non-owner) → HTTP ${NS_AK2_HTTP} (expected 401)"
+  api_pass "GET /v2/networkset/accesskey (non-owner) → 401 (only the owner may read the key)"
+
+  # 6) Writes remain retired: POST /v2/networkset still returns 501.
+  CALL_NUM=$((CALL_NUM+1))
+  echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: POST /v2/networkset (auth) — still 501 (writes retired)"
+  NS_POST_HTTP=$(curl -s -o /dev/null -w "%{http_code}" -X POST -u "${TEST_USER}:${TEST_PASS}" \
+    -H "Content-Type: application/json" -d '{"name":"nope"}' "${BASE_URL}/v2/networkset")
+  [[ "${NS_POST_HTTP}" == "501" ]] || api_fail "POST /v2/networkset → HTTP ${NS_POST_HTTP} (expected 501 — writes remain removed)"
+  api_pass "POST /v2/networkset → 501 (network-set writes remain retired; only reads re-enabled)"
+
+  echo "  Cleaning up seeded network_set '${NS_SET_ID}'..."
+  docker exec "${CONTAINER_NAME}" bash -c "
+    DB_USER=\$(grep '^NdexDBUsername=' /apps/ndex/config/ndex.properties | cut -d= -f2-)
+    DB_PASS=\$(grep '^NdexDBDBPassword=' /apps/ndex/config/ndex.properties | cut -d= -f2-)
+    PGPASSWORD=\"\$DB_PASS\" psql -h 127.0.0.1 -p 5432 -U \"\$DB_USER\" -d ndex \
+      -c \"DELETE FROM network_set_member WHERE set_id = '${NS_SET_ID}'; DELETE FROM network_set WHERE \\\"UUID\\\" = '${NS_SET_ID}';\"
+  "
+fi
 
 # ── STEP: AUTHENTICATED_USER_ONLY blocks anonymous POST /v2/user ─────────────
 # NOTE: this permanently flips the server to AUTHENTICATED_USER_ONLY=true (appends to

--- a/docker/test/integration-test.sh
+++ b/docker/test/integration-test.sh
@@ -32,7 +32,7 @@ TEST_USER2="ndextest2"
 TEST_PASS2="NDExTest2!"
 TEST_EMAIL2="ndextest2@ndex-integration.local"
 
-TOTAL_API_CALLS=110
+TOTAL_API_CALLS=111
 PASSED=0
 CALL_NUM=0
 STEP_NUM=0
@@ -1510,6 +1510,14 @@ if [[ -z "${REMOTE_NDEX_URL}" ]]; then
   NS_AK2_HTTP=$(curl -s -o /dev/null -w "%{http_code}" -u "${TEST_USER2}:${TEST_PASS2}" "${BASE_URL}/v2/networkset/${NS_SET_ID}/accesskey")
   [[ "${NS_AK2_HTTP}" == "401" ]] || api_fail "GET /v2/networkset/accesskey (non-owner) → HTTP ${NS_AK2_HTTP} (expected 401)"
   api_pass "GET /v2/networkset/accesskey (non-owner) → 401 (only the owner may read the key)"
+
+  # 5b) GET /v2/networkset/{missing}/accesskey (owner): existence resolved first → 404, not 401.
+  CALL_NUM=$((CALL_NUM+1))
+  NS_MISSING_ID="99999999-9999-9999-9999-999999999999"
+  echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: GET /v2/networkset/${NS_MISSING_ID}/accesskey (owner, missing set) — 404"
+  NS_AK_MISS_HTTP=$(curl -s -o /dev/null -w "%{http_code}" -u "${TEST_USER}:${TEST_PASS}" "${BASE_URL}/v2/networkset/${NS_MISSING_ID}/accesskey")
+  [[ "${NS_AK_MISS_HTTP}" == "404" ]] || api_fail "GET /v2/networkset/accesskey (missing set) → HTTP ${NS_AK_MISS_HTTP} (expected 404)"
+  api_pass "GET /v2/networkset/accesskey (missing set) → 404 (existence resolved before ownership)"
 
   # 6) Writes remain retired: POST /v2/networkset still returns 501.
   CALL_NUM=$((CALL_NUM+1))

--- a/src/main/java/org/ndexbio/common/models/dao/postgresql/NetworkSetDAO.java
+++ b/src/main/java/org/ndexbio/common/models/dao/postgresql/NetworkSetDAO.java
@@ -82,15 +82,17 @@ public class NetworkSetDAO extends NdexDBDAO {
 					result.setShowcased(rs.getBoolean(9));
 					result.setDoi(rs.getString(10));
 				} else
-					throw new ObjectNotFoundException("Network set" + setId + " not found in db.");
+					throw new ObjectNotFoundException("Network set", setId);
 			}
 		}
 
 		boolean keyIsValid = false;
-		if (dbKeyIsOn && accessKey != null && dbAccessKey.equals(accessKey))
+		// accessKey is proven non-null here, so call equals() on it — the stored access_key column
+		// is nullable, so dbAccessKey.equals(...) could NPE.
+		if (dbKeyIsOn && accessKey != null && accessKey.equals(dbAccessKey))
 			keyIsValid = true;
 		if (!keyIsValid && accessKey != null)
-			throw new UnauthorizedOperationException("In valid network set access key.");
+			throw new UnauthorizedOperationException("Invalid network set access key.");
 
 		sqlStr = "select nm.network_id from network_set_member nm, network n where nm.set_id =? and n.\"UUID\"=nm.network_id and " +
 				(keyIsValid ? " true" : PostgresNetworkDAO.createIsReadableConditionStr(userId));
@@ -121,7 +123,7 @@ public class NetworkSetDAO extends NdexDBDAO {
 					oldKey = rs.getString(1);
 					keyIsOn = rs.getBoolean(2);
 				} else
-					throw new ObjectNotFoundException("Network", networkSetId);
+					throw new ObjectNotFoundException("Network set", networkSetId);
 
 			}
 		}

--- a/src/main/java/org/ndexbio/common/models/dao/postgresql/NetworkSetDAO.java
+++ b/src/main/java/org/ndexbio/common/models/dao/postgresql/NetworkSetDAO.java
@@ -1,0 +1,135 @@
+package org.ndexbio.common.models.dao.postgresql;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+
+import org.ndexbio.model.exceptions.ObjectNotFoundException;
+import org.ndexbio.model.exceptions.UnauthorizedOperationException;
+import org.ndexbio.model.object.NetworkSet;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Read-only DAO over the frozen, archived {@code network_set} / {@code network_set_member} tables.
+ *
+ * <p>The network set feature was removed in favor of v3 folders; the legacy tables are retained
+ * read-only. This DAO exposes only what the two re-enabled read endpoints
+ * ({@code GET /v2/networkset/{id}} and {@code GET /v2/networkset/{id}/accesskey}) need. It reads the
+ * archived network-set data directly from those tables and never reconstructs data from the v3
+ * folder/shortcut model. There are no write methods here.
+ */
+public class NetworkSetDAO extends NdexDBDAO {
+
+	public NetworkSetDAO() throws SQLException {
+		super();
+	}
+
+	/** For unit tests: inject a (mock) connection. */
+	public NetworkSetDAO(Connection connection) {
+		super(connection);
+	}
+
+	public boolean isNetworkSetOwner(UUID setId, UUID ownerId) throws SQLException {
+		String sqlStr = "select 1 from network_set where \"UUID\" = ? and owner_id = ? and is_deleted=false";
+		try (PreparedStatement p = db.prepareStatement(sqlStr)) {
+			p.setObject(1, setId);
+			p.setObject(2, ownerId);
+			try (ResultSet rs = p.executeQuery()) {
+				return rs.next();
+			}
+		}
+	}
+
+	public NetworkSet getNetworkSet(UUID setId, UUID userId, String accessKey) throws SQLException, ObjectNotFoundException, UnauthorizedOperationException, JsonParseException, JsonMappingException, IOException {
+
+		NetworkSet result = new NetworkSet();
+		String sqlStr = "select creation_time, modification_time, owner_id, name, description, access_key, access_key_is_on, other_attributes,showcased, ndexdoi from network_set  where \"UUID\"=? and is_deleted=false";
+
+		String dbAccessKey = null;
+		boolean dbKeyIsOn;
+		try (PreparedStatement p = db.prepareStatement(sqlStr)) {
+			p.setObject(1, setId);
+			try (ResultSet rs = p.executeQuery()) {
+				if (rs.next()) {
+					result.setCreationTime(rs.getTimestamp(1));
+					result.setModificationTime(rs.getTimestamp(2));
+					result.setExternalId(setId);
+					result.setOwnerId((UUID) rs.getObject(3));
+					result.setName(rs.getString(4));
+					result.setDescription(rs.getString(5));
+					dbAccessKey = rs.getString(6);
+					dbKeyIsOn = rs.getBoolean(7);
+
+					String propStr = rs.getString(8);
+
+					if (propStr != null) {
+						ObjectMapper mapper = new ObjectMapper();
+						TypeReference<HashMap<String, Object>> typeRef = new TypeReference<HashMap<String, Object>>() {/**/};
+
+						HashMap<String, Object> o = mapper.readValue(propStr, typeRef);
+						result.setProperties(o);
+					}
+
+					result.setShowcased(rs.getBoolean(9));
+					result.setDoi(rs.getString(10));
+				} else
+					throw new ObjectNotFoundException("Network set" + setId + " not found in db.");
+			}
+		}
+
+		boolean keyIsValid = false;
+		if (dbKeyIsOn && accessKey != null && dbAccessKey.equals(accessKey))
+			keyIsValid = true;
+		if (!keyIsValid && accessKey != null)
+			throw new UnauthorizedOperationException("In valid network set access key.");
+
+		sqlStr = "select nm.network_id from network_set_member nm, network n where nm.set_id =? and n.\"UUID\"=nm.network_id and " +
+				(keyIsValid ? " true" : PostgresNetworkDAO.createIsReadableConditionStr(userId));
+
+		try (PreparedStatement p = db.prepareStatement(sqlStr)) {
+			p.setObject(1, setId);
+			try (ResultSet rs = p.executeQuery()) {
+				List<UUID> networkIds = result.getNetworks();
+				while (rs.next()) {
+					networkIds.add((UUID) rs.getObject(1));
+				}
+			}
+		}
+
+		return result;
+	}
+
+	public String getNetworkSetAccessKey(UUID networkSetId) throws SQLException, ObjectNotFoundException {
+		String sqlStr = "select access_key, access_key_is_on from network_set where \"UUID\" = ? and is_deleted=false";
+
+		String oldKey = null;
+		boolean keyIsOn = false;
+
+		try (PreparedStatement p = db.prepareStatement(sqlStr)) {
+			p.setObject(1, networkSetId);
+			try (ResultSet rs = p.executeQuery()) {
+				if (rs.next()) {
+					oldKey = rs.getString(1);
+					keyIsOn = rs.getBoolean(2);
+				} else
+					throw new ObjectNotFoundException("Network", networkSetId);
+
+			}
+		}
+
+		if (keyIsOn)
+			return oldKey;
+
+		return null;
+
+	}
+}

--- a/src/main/java/org/ndexbio/rest/services/NetworkSetServiceV2.java
+++ b/src/main/java/org/ndexbio/rest/services/NetworkSetServiceV2.java
@@ -26,9 +26,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 /**
- * The NDEx network set feature has been removed. Every endpoint on this resource now returns
- * HTTP 501 (Not Implemented). The resource stays registered so clients get a 501 rather than a 404.
- * Use folders + shortcuts + folder access keys instead (see the V3 Migration Guide).
+ * The NDEx network set feature has been removed. Two read-only endpoints —
+ * {@code GET /v2/networkset/{id}} and {@code GET /v2/networkset/{id}/accesskey} — remain enabled to
+ * serve the frozen, archived {@code network_set} tables for backward-compatible reads of legacy
+ * network sets. Every other (write) endpoint on this resource returns HTTP 501 (Not Implemented).
+ * No new network sets can be created; use folders + shortcuts + folder access keys instead (see the
+ * V3 Migration Guide).
  */
 @Path("/v2/networkset")
 @Deprecated
@@ -79,6 +82,9 @@ public class NetworkSetServiceV2 extends NdexService {
 	@Path("/{networksetid}")
 	@Deprecated
 	@Operation(summary = "Get a Network Set (ARCHIVED)", description = ARCHIVED_DESC, deprecated = true)
+	@ApiResponse(responseCode = "200", description = "The archived network set")
+	@ApiResponse(responseCode = "401", description = "Unauthorized — an access key was supplied but is not valid for this network set")
+	@ApiResponse(responseCode = "404", description = "No such network set")
 	@Produces("application/json")
 	public NetworkSet getNetworkSet(@PathParam("networksetid") final String networkSetIdStr,
 			@QueryParam("accesskey") String accessKey) throws Exception {
@@ -115,21 +121,25 @@ public class NetworkSetServiceV2 extends NdexService {
 	@Path("/{networksetid}/accesskey")
 	@Deprecated
 	@Operation(summary = "Get Access key of Network Set (ARCHIVED)", description = ARCHIVED_DESC, deprecated = true)
+	@ApiResponse(responseCode = "200", description = "The access key of the archived network set")
+	@ApiResponse(responseCode = "401", description = "Unauthorized — the caller is not the owner of this network set")
+	@ApiResponse(responseCode = "404", description = "No such network set")
 	@Produces("application/json")
 	public Map<String, String> getNetworkSetAccessKey(@PathParam("networksetid") final String networkSetIdStr) throws Exception {
 		UUID networkSetId = UUID.fromString(networkSetIdStr);
 		// Archived network_set data only: the access key of a legacy network set the caller owns.
 		try (NetworkSetDAO dao = new NetworkSetDAO()) {
-			if (dao.isNetworkSetOwner(networkSetId, getLoggedInUserId())) {
-				String key = dao.getNetworkSetAccessKey(networkSetId);
-				if (key == null || key.isEmpty())
-					return null;
-				Map<String, String> result = new HashMap<>(1);
-				result.put("accessKey", key);
-				return result;
-			}
+			// Resolve existence first so a missing set surfaces as 404 (matching GET /v2/networkset/{id}),
+			// not 401. A missing row makes getNetworkSetAccessKey throw ObjectNotFoundException.
+			String key = dao.getNetworkSetAccessKey(networkSetId);
+			if (!dao.isNetworkSetOwner(networkSetId, getLoggedInUserId()))
+				throw new UnauthorizedOperationException("User is not the owner of this network set.");
+			if (key == null || key.isEmpty())
+				return null;
+			Map<String, String> result = new HashMap<>(1);
+			result.put("accessKey", key);
+			return result;
 		}
-		throw new UnauthorizedOperationException("User is not the owner of this network set.");
 	}
 
 	@PUT

--- a/src/main/java/org/ndexbio/rest/services/NetworkSetServiceV2.java
+++ b/src/main/java/org/ndexbio/rest/services/NetworkSetServiceV2.java
@@ -1,5 +1,6 @@
 package org.ndexbio.rest.services;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -17,6 +18,8 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 
+import org.ndexbio.common.models.dao.postgresql.NetworkSetDAO;
+import org.ndexbio.model.exceptions.UnauthorizedOperationException;
 import org.ndexbio.model.object.NetworkSet;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -34,6 +37,10 @@ public class NetworkSetServiceV2 extends NdexService {
 	private static final String NETWORKSETS_REMOVED = "The NDEx network set feature has been removed.";
 	private static final String REMOVED_DESC =
 			"Removed: the NDEx network set feature is no longer supported. This endpoint always returns HTTP 501 Not Implemented.";
+	private static final String ARCHIVED_DESC =
+			"Read-only access to archived, historical network-set data from the frozen network_set tables. "
+			+ "The network set feature is retired: no new network sets can be created and this data is not "
+			+ "backed by the v3 folder model. Provided only for backward-compatible reads of legacy network sets.";
 
 	public NetworkSetServiceV2(@Context HttpServletRequest httpRequest) {
 		super(httpRequest);
@@ -71,12 +78,15 @@ public class NetworkSetServiceV2 extends NdexService {
 	@PermitAll
 	@Path("/{networksetid}")
 	@Deprecated
-	@Operation(summary = "Get a Network Set (REMOVED)", description = REMOVED_DESC, deprecated = true)
-	@ApiResponse(responseCode = "501", description = "Not Implemented — the network set feature has been removed")
+	@Operation(summary = "Get a Network Set (ARCHIVED)", description = ARCHIVED_DESC, deprecated = true)
 	@Produces("application/json")
 	public NetworkSet getNetworkSet(@PathParam("networksetid") final String networkSetIdStr,
-			@QueryParam("accesskey") String accessKey) {
-		throw notImplemented(NETWORKSETS_REMOVED);
+			@QueryParam("accesskey") String accessKey) throws Exception {
+		UUID setId = UUID.fromString(networkSetIdStr);
+		// Serve only the archived network_set / network_set_member data; no v3 folder polyfill.
+		try (NetworkSetDAO dao = new NetworkSetDAO()) {
+			return dao.getNetworkSet(setId, getLoggedInUserId(), accessKey);
+		}
 	}
 
 	@POST
@@ -104,11 +114,22 @@ public class NetworkSetServiceV2 extends NdexService {
 	@GET
 	@Path("/{networksetid}/accesskey")
 	@Deprecated
-	@Operation(summary = "Get Access key of Network Set (REMOVED)", description = REMOVED_DESC, deprecated = true)
-	@ApiResponse(responseCode = "501", description = "Not Implemented — the network set feature has been removed")
+	@Operation(summary = "Get Access key of Network Set (ARCHIVED)", description = ARCHIVED_DESC, deprecated = true)
 	@Produces("application/json")
-	public Map<String, String> getNetworkSetAccessKey(@PathParam("networksetid") final String networkSetIdStr) {
-		throw notImplemented(NETWORKSETS_REMOVED);
+	public Map<String, String> getNetworkSetAccessKey(@PathParam("networksetid") final String networkSetIdStr) throws Exception {
+		UUID networkSetId = UUID.fromString(networkSetIdStr);
+		// Archived network_set data only: the access key of a legacy network set the caller owns.
+		try (NetworkSetDAO dao = new NetworkSetDAO()) {
+			if (dao.isNetworkSetOwner(networkSetId, getLoggedInUserId())) {
+				String key = dao.getNetworkSetAccessKey(networkSetId);
+				if (key == null || key.isEmpty())
+					return null;
+				Map<String, String> result = new HashMap<>(1);
+				result.put("accessKey", key);
+				return result;
+			}
+		}
+		throw new UnauthorizedOperationException("User is not the owner of this network set.");
 	}
 
 	@PUT

--- a/src/test/java/org/ndexbio/common/models/dao/postgresql/TestNetworkSetDAO.java
+++ b/src/test/java/org/ndexbio/common/models/dao/postgresql/TestNetworkSetDAO.java
@@ -168,4 +168,28 @@ public class TestNetworkSetDAO {
 		NetworkSetDAO dao = new NetworkSetDAO(conn);
 		dao.getNetworkSet(UUID.randomUUID(), UUID.randomUUID(), "wrong-key");
 	}
+
+	@Test(expected = UnauthorizedOperationException.class)
+	public void testGetNetworkSetNullStoredKeyDoesNotNPE() throws Exception {
+		Connection conn = createMock(Connection.class);
+		PreparedStatement pst = createMock(PreparedStatement.class);
+		ResultSet rs = createNiceMock(ResultSet.class);
+
+		// access_key column is nullable: key flagged on but stored key is NULL. A supplied non-null
+		// key must NOT NullPointerException on the compare — it is simply invalid, so the method
+		// throws UnauthorizedOperationException (guards the #2 regression).
+		expect(conn.prepareStatement(anyString())).andReturn(pst);
+		pst.setObject(anyInt(), anyObject());
+		expectLastCall().anyTimes();
+		expect(pst.executeQuery()).andReturn(rs);
+		expect(rs.next()).andReturn(true);
+		expect(rs.getString(6)).andReturn(null); // access_key IS NULL
+		expect(rs.getBoolean(7)).andReturn(true); // access_key_is_on = true
+		pst.close();
+		expectLastCall();
+		replay(conn, pst, rs);
+
+		NetworkSetDAO dao = new NetworkSetDAO(conn);
+		dao.getNetworkSet(UUID.randomUUID(), UUID.randomUUID(), "any-key");
+	}
 }

--- a/src/test/java/org/ndexbio/common/models/dao/postgresql/TestNetworkSetDAO.java
+++ b/src/test/java/org/ndexbio/common/models/dao/postgresql/TestNetworkSetDAO.java
@@ -1,0 +1,171 @@
+package org.ndexbio.common.models.dao.postgresql;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.UUID;
+
+import org.junit.Test;
+import org.ndexbio.model.exceptions.ObjectNotFoundException;
+import org.ndexbio.model.exceptions.UnauthorizedOperationException;
+
+/**
+ * Unit tests for the archive-only {@link NetworkSetDAO}. These verify the DAO reads exclusively from
+ * the frozen {@code network_set} / {@code network_set_member} tables (JDBC is mocked; there is no
+ * {@code FolderDAO} involved). Coverage focuses on the simple single-query methods and the cheap
+ * branch behavior of {@code getNetworkSet}; the full two-query member read is covered by the
+ * integration test against seeded rows.
+ */
+public class TestNetworkSetDAO {
+
+	// ---- isNetworkSetOwner ----
+
+	@Test
+	public void testIsNetworkSetOwnerTrueWhenRowPresent() throws SQLException {
+		assertTrue(runOwnerQuery(true));
+	}
+
+	@Test
+	public void testIsNetworkSetOwnerFalseWhenNoRow() throws SQLException {
+		assertFalse(runOwnerQuery(false));
+	}
+
+	private boolean runOwnerQuery(boolean rowPresent) throws SQLException {
+		Connection conn = createMock(Connection.class);
+		PreparedStatement pst = createMock(PreparedStatement.class);
+		ResultSet rs = createNiceMock(ResultSet.class);
+
+		expect(conn.prepareStatement(anyString())).andReturn(pst);
+		pst.setObject(anyInt(), anyObject());
+		expectLastCall().anyTimes();
+		expect(pst.executeQuery()).andReturn(rs);
+		expect(rs.next()).andReturn(rowPresent);
+		pst.close();
+		expectLastCall();
+		replay(conn, pst, rs);
+
+		NetworkSetDAO dao = new NetworkSetDAO(conn);
+		boolean result = dao.isNetworkSetOwner(UUID.randomUUID(), UUID.randomUUID());
+		verify(conn, pst);
+		return result;
+	}
+
+	// ---- getNetworkSetAccessKey ----
+
+	@Test
+	public void testGetNetworkSetAccessKeyReturnsKeyWhenEnabled() throws Exception {
+		Connection conn = createMock(Connection.class);
+		PreparedStatement pst = createMock(PreparedStatement.class);
+		ResultSet rs = createNiceMock(ResultSet.class);
+
+		expect(conn.prepareStatement(anyString())).andReturn(pst);
+		pst.setObject(anyInt(), anyObject());
+		expectLastCall().anyTimes();
+		expect(pst.executeQuery()).andReturn(rs);
+		expect(rs.next()).andReturn(true);
+		expect(rs.getString(1)).andReturn("secret-key");
+		expect(rs.getBoolean(2)).andReturn(true);
+		pst.close();
+		expectLastCall();
+		replay(conn, pst, rs);
+
+		NetworkSetDAO dao = new NetworkSetDAO(conn);
+		assertEquals("secret-key", dao.getNetworkSetAccessKey(UUID.randomUUID()));
+		verify(conn, pst);
+	}
+
+	@Test
+	public void testGetNetworkSetAccessKeyReturnsNullWhenDisabled() throws Exception {
+		Connection conn = createMock(Connection.class);
+		PreparedStatement pst = createMock(PreparedStatement.class);
+		ResultSet rs = createNiceMock(ResultSet.class);
+
+		expect(conn.prepareStatement(anyString())).andReturn(pst);
+		pst.setObject(anyInt(), anyObject());
+		expectLastCall().anyTimes();
+		expect(pst.executeQuery()).andReturn(rs);
+		expect(rs.next()).andReturn(true);
+		expect(rs.getString(1)).andReturn("secret-key");
+		expect(rs.getBoolean(2)).andReturn(false);
+		pst.close();
+		expectLastCall();
+		replay(conn, pst, rs);
+
+		NetworkSetDAO dao = new NetworkSetDAO(conn);
+		assertNull(dao.getNetworkSetAccessKey(UUID.randomUUID()));
+		verify(conn, pst);
+	}
+
+	@Test(expected = ObjectNotFoundException.class)
+	public void testGetNetworkSetAccessKeyThrowsWhenMissing() throws Exception {
+		Connection conn = createMock(Connection.class);
+		PreparedStatement pst = createMock(PreparedStatement.class);
+		ResultSet rs = createNiceMock(ResultSet.class);
+
+		expect(conn.prepareStatement(anyString())).andReturn(pst);
+		pst.setObject(anyInt(), anyObject());
+		expectLastCall().anyTimes();
+		expect(pst.executeQuery()).andReturn(rs);
+		expect(rs.next()).andReturn(false);
+		pst.close();
+		expectLastCall();
+		replay(conn, pst, rs);
+
+		NetworkSetDAO dao = new NetworkSetDAO(conn);
+		dao.getNetworkSetAccessKey(UUID.randomUUID());
+	}
+
+	// ---- getNetworkSet: cheap guard branches (single-query, no member read) ----
+
+	@Test(expected = ObjectNotFoundException.class)
+	public void testGetNetworkSetThrowsWhenSetMissing() throws Exception {
+		Connection conn = createMock(Connection.class);
+		PreparedStatement pst = createMock(PreparedStatement.class);
+		ResultSet rs = createNiceMock(ResultSet.class);
+
+		// Only the first (metadata) query runs; missing row -> ObjectNotFoundException before members.
+		expect(conn.prepareStatement(anyString())).andReturn(pst);
+		pst.setObject(anyInt(), anyObject());
+		expectLastCall().anyTimes();
+		expect(pst.executeQuery()).andReturn(rs);
+		expect(rs.next()).andReturn(false);
+		pst.close();
+		expectLastCall();
+		replay(conn, pst, rs);
+
+		NetworkSetDAO dao = new NetworkSetDAO(conn);
+		dao.getNetworkSet(UUID.randomUUID(), UUID.randomUUID(), null);
+	}
+
+	@Test(expected = UnauthorizedOperationException.class)
+	public void testGetNetworkSetThrowsOnInvalidAccessKey() throws Exception {
+		Connection conn = createMock(Connection.class);
+		PreparedStatement pst = createMock(PreparedStatement.class);
+		ResultSet rs = createNiceMock(ResultSet.class);
+
+		// Row present, key enabled with a different stored key -> supplied non-null key is invalid,
+		// so it throws before the member query (only the metadata query runs).
+		expect(conn.prepareStatement(anyString())).andReturn(pst);
+		pst.setObject(anyInt(), anyObject());
+		expectLastCall().anyTimes();
+		expect(pst.executeQuery()).andReturn(rs);
+		expect(rs.next()).andReturn(true);
+		expect(rs.getString(6)).andReturn("stored-key"); // access_key
+		expect(rs.getBoolean(7)).andReturn(true);         // access_key_is_on
+		// remaining getters (timestamps, name, description, other_attributes, showcased, doi) default
+		// via the nice mock; other_attributes (getString(8)) -> null so no JSON parsing.
+		pst.close();
+		expectLastCall();
+		replay(conn, pst, rs);
+
+		NetworkSetDAO dao = new NetworkSetDAO(conn);
+		dao.getNetworkSet(UUID.randomUUID(), UUID.randomUUID(), "wrong-key");
+	}
+}


### PR DESCRIPTION
Revert the last change from https://github.com/ndexbio/ndex-rest/pull/139 specific to obsoleting the read endpoings for networksets. Bring those endpoints back as operational for ongoing backwards compat.

Closes #133