### PR TITLE
#133: reneabled shortcuts in access key support, backwards compat needed

### DIFF
--- a/docker/test/integration-test.sh
+++ b/docker/test/integration-test.sh
@@ -32,7 +32,7 @@ TEST_USER2="ndextest2"
 TEST_PASS2="NDExTest2!"
 TEST_EMAIL2="ndextest2@ndex-integration.local"
 
-TOTAL_API_CALLS=111
+TOTAL_API_CALLS=116
 PASSED=0
 CALL_NUM=0
 STEP_NUM=0
@@ -1195,10 +1195,12 @@ F10_KEY_NET=$(curl -s "${BASE_URL}/v3/files/folders/${F10_FOLDER_ID}/count?acces
   || api_fail "access-key view wrong: net=${F10_KEY_NET}, list=${F10_KEY_LIST:0:400}"
 api_pass "anon + access key → /list all children (incl. PRIVATE); /count network=2"
 
-# ── STEP: Access key follows the folder hierarchy + shortcut carve-out (G11, #133) ──
-# A network is reachable by an ANCESTOR folder's access key (accrual up the folder chain), and a
-# key-authorized /list|/count EXCLUDES shortcut children (access keys don't traverse shortcuts).
-step "Access key: ancestor-folder accrual for networks + shortcut exclusion (G11)"
+# ── STEP: Access key follows the folder hierarchy + same-owner shortcut resolution (G11, #133/#137) ──
+# A network is reachable by an ANCESTOR folder's access key (accrual up the folder chain), AND — for
+# backwards compatibility with the v3 networkset migration — by a SAME-OWNER NETWORK shortcut that lives
+# in a keyed folder even though the target network sits elsewhere (e.g. Home). Such shortcuts are also
+# surfaced in the key-authorized /list and /count views.
+step "Access key: ancestor-folder accrual + same-owner shortcut resolution (G11, #133/#137)"
 
 # Nest the PRIVATE network one level deeper: a subfolder under the (keyed) F10 folder. The network's
 # key access must now be resolved via the GRANDPARENT folder's key.
@@ -1239,30 +1241,83 @@ G11_NOKEY_HTTP=$(curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/v3/networks
   || api_fail "anon no-key on PRIVATE network summary → HTTP ${G11_NOKEY_HTTP} (expected 401)"
 api_pass "anon + no key → GET private network summary 401 (negative control)"
 
-# Shortcut exclusion: put a shortcut in the keyed folder; the key view (/list, /count) must omit it,
-# while the owner (no key) still sees it.
+# Same-owner NETWORK shortcut resolution (#133/#137): put a shortcut in the keyed folder pointing at a
+# PRIVATE network that lives in Home — reachable by this key ONLY through the shortcut. The target is
+# owned by TEST_USER (same owner as the folder), satisfying the same-owner guard. The key must now
+# (Change 3) surface the shortcut in the key /list + /count, and (Changes 1 & 2) grant anonymous read to
+# the target network via GET, search, and batch summary.
 CALL_NUM=$((CALL_NUM+1))
-echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: POST /v3/files/shortcuts/ (shortcut in keyed folder → public network)"
+echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: POST /v3/files/shortcuts/ (shortcut in keyed folder → private Home network)"
 G11_SC_RESP=$(curl -s -w "\n%{http_code}" -X POST -u "${TEST_USER}:${TEST_PASS}" \
   -H "Content-Type: application/json" \
-  -d "{\"name\":\"G11 shortcut\",\"parent\":\"${F10_FOLDER_ID}\",\"target\":\"${V3_PUB_UUID}\",\"targetType\":\"NETWORK\"}" \
+  -d "{\"name\":\"G11 shortcut\",\"parent\":\"${F10_FOLDER_ID}\",\"target\":\"${V2_PRIV_UUID}\",\"targetType\":\"NETWORK\"}" \
   "${BASE_URL}/v3/files/shortcuts/")
 G11_SC_HTTP=$(echo "${G11_SC_RESP}" | tail -1); G11_SC_BODY=$(echo "${G11_SC_RESP}" | head -1)
 [[ "${G11_SC_HTTP}" == "201" ]] || api_fail "create shortcut → HTTP ${G11_SC_HTTP}. Body: ${G11_SC_BODY:0:300}"
 G11_SC_ID=$(echo "${G11_SC_BODY}" | grep -oiE '"uuid"[[:space:]]*:[[:space:]]*"[0-9a-f-]{36}"' | grep -oiE '[0-9a-f-]{36}' | head -1)
 [[ -n "${G11_SC_ID}" ]] || api_fail "no uuid in create-shortcut response. Body: ${G11_SC_BODY:0:300}"
-api_pass "shortcut ${G11_SC_ID} created in keyed folder"
+api_pass "shortcut ${G11_SC_ID} created in keyed folder → private network ${V2_PRIV_UUID}"
 
+# Change 3: key-authorized /list + /count now INCLUDE the same-owner NETWORK shortcut.
 CALL_NUM=$((CALL_NUM+1))
-echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: GET .../list + /count?accesskey (anon) — shortcut EXCLUDED, shortcut count 0"
+echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: GET .../list + /count?accesskey (anon) — shortcut INCLUDED, shortcut count >=1"
 G11_KEY_LIST=$(curl -s "${BASE_URL}/v3/files/folders/${F10_FOLDER_ID}/list?accesskey=${F10_KEY}")
 G11_KEY_SC=$(curl -s "${BASE_URL}/v3/files/folders/${F10_FOLDER_ID}/count?accesskey=${F10_KEY}" | grep -oE '"shortcut"[[:space:]]*:[[:space:]]*[0-9]+' | grep -oE '[0-9]+$')
 echo "${G11_KEY_LIST}" | grep -q "${G11_SC_ID}" \
-  && api_fail "key /list LEAKED shortcut ${G11_SC_ID}. Body: ${G11_KEY_LIST:0:400}"
-[[ "${G11_KEY_SC}" == "0" ]] \
-  || api_fail "key /count shortcut expected 0, got ${G11_KEY_SC}"
-api_pass "anon + key → /list omits shortcut; /count shortcut=0 (access keys don't traverse shortcuts)"
+  || api_fail "key /list should include same-owner shortcut ${G11_SC_ID}. Body: ${G11_KEY_LIST:0:400}"
+[[ "${G11_KEY_SC:-0}" -ge 1 ]] \
+  || api_fail "key /count shortcut expected >=1, got ${G11_KEY_SC}"
+api_pass "anon + key → /list includes same-owner NETWORK shortcut; /count shortcut>=1 (Change 3, #133/#137)"
 
+# Change 1 (GET): the key grants anonymous read to the shortcut's target network (was 401 before the fix).
+CALL_NUM=$((CALL_NUM+1))
+echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: GET /v3/networks/{shortcut-target}?accesskey (anon, expect 200)"
+G11_SCGET_HTTP=$(curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/v3/networks/${V2_PRIV_UUID}?accesskey=${F10_KEY}")
+[[ "${G11_SCGET_HTTP}" == "200" ]] \
+  || api_fail "anon + key via shortcut → GET network HTTP ${G11_SCGET_HTTP} (expected 200)"
+api_pass "anon + key → GET private network via same-owner shortcut 200 (Change 1, #133/#137)"
+
+# Negative controls: no key and a wrong key must stay 401 (the shortcut alone grants nothing).
+CALL_NUM=$((CALL_NUM+1))
+echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: GET /v3/networks/{shortcut-target} (anon no-key / wrong-key, expect 401)"
+G11_SCNO_HTTP=$(curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/v3/networks/${V2_PRIV_UUID}")
+G11_SCWRONG_HTTP=$(curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/v3/networks/${V2_PRIV_UUID}?accesskey=not-a-real-key")
+{ [[ "${G11_SCNO_HTTP}" == "401" ]] && [[ "${G11_SCWRONG_HTTP}" == "401" ]]; } \
+  || api_fail "shortcut-target negative controls wrong: no-key=${G11_SCNO_HTTP}, wrong-key=${G11_SCWRONG_HTTP} (expected 401/401)"
+api_pass "anon no-key / wrong-key → GET shortcut-target network 401 (negative controls)"
+
+# Change 1 (search): the same accessKeyIsValid path backs the per-network search endpoints (stub proxied).
+CALL_NUM=$((CALL_NUM+1))
+echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: POST /v3/search/networks/{shortcut-target}/query?accesskey (anon, expect 200)"
+G11_SCQ_HTTP=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+  -H "Content-Type: application/json" -d '{"searchString":"EGFR","searchDepth":1}' \
+  "${BASE_URL}/v3/search/networks/${V2_PRIV_UUID}/query?accesskey=${F10_KEY}")
+[[ "${G11_SCQ_HTTP}" == "200" ]] \
+  || api_fail "anon + key via shortcut → search query HTTP ${G11_SCQ_HTTP} (expected 200)"
+api_pass "anon + key → POST search query on shortcut-target network 200 (Change 1, #133/#137)"
+
+# Change 2 (batch summary): one call spanning a REAL network (V3_PRIV, reached via the ancestor folder
+# key) and a SHORTCUT network (V2_PRIV, reached via the same-owner shortcut) — both must be returned.
+CALL_NUM=$((CALL_NUM+1))
+echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: POST /v3/batch/networks/summary?accesskey (anon) — real + shortcut network both present"
+G11_BATCH=$(curl -s -X POST -H "Content-Type: application/json" \
+  -d "[\"${V3_PRIV_UUID}\",\"${V2_PRIV_UUID}\"]" \
+  "${BASE_URL}/v3/batch/networks/summary?accesskey=${F10_KEY}")
+{ echo "${G11_BATCH}" | grep -q "${V3_PRIV_UUID}" && echo "${G11_BATCH}" | grep -q "${V2_PRIV_UUID}"; } \
+  || api_fail "batch summary + key should include real (${V3_PRIV_UUID}) and shortcut (${V2_PRIV_UUID}) networks. Body: ${G11_BATCH:0:400}"
+api_pass "anon + key → batch summary returns both the ancestor-key network and the shortcut-key network (Change 2)"
+
+# Negative: batch summary WITHOUT a key returns neither private network to an anonymous caller.
+CALL_NUM=$((CALL_NUM+1))
+echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: POST /v3/batch/networks/summary (anon, no key) — neither private network present"
+G11_BATCH_NOKEY=$(curl -s -X POST -H "Content-Type: application/json" \
+  -d "[\"${V3_PRIV_UUID}\",\"${V2_PRIV_UUID}\"]" \
+  "${BASE_URL}/v3/batch/networks/summary")
+{ echo "${G11_BATCH_NOKEY}" | grep -q "${V3_PRIV_UUID}" || echo "${G11_BATCH_NOKEY}" | grep -q "${V2_PRIV_UUID}"; } \
+  && api_fail "batch summary without key LEAKED a private network. Body: ${G11_BATCH_NOKEY:0:400}"
+api_pass "anon + no key → batch summary omits both private networks (negative control)"
+
+# The owner (no key) still sees the shortcut in the identity-based view (no-key path unchanged).
 CALL_NUM=$((CALL_NUM+1))
 echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: GET .../list (owner, no key) — shortcut PRESENT (no-key path unchanged)"
 G11_OWNER_LIST=$(curl -s -u "${TEST_USER}:${TEST_PASS}" "${BASE_URL}/v3/files/folders/${F10_FOLDER_ID}/list")

--- a/docs/specifications/FOLDER_SHORTCUT_SPECIFICATION.md
+++ b/docs/specifications/FOLDER_SHORTCUT_SPECIFICATION.md
@@ -107,7 +107,7 @@ anonymous, **binary READ grant** (there is no write-granting access key), issued
   Shortcut inherits its *target's* permission, not its container's) and the Google Drive model, where
   folder sharing does not flow through a shortcut to a file elsewhere. **Exception (backwards
   compatibility, issue #133/#137):** for a **Network** target, a key **is** valid when a *same-owner*
-  (Shortcut owner = target Network owner) live `NETWORK` Shortcut pointing at it lives in a Folder whose
+  (Shortcut owner = target Network owner) live `NETWORK` Shortcut pointing at it resides in a Folder whose
   ancestry carries the matching enabled key. This restores access keys stranded by the v3 networkset
   migration, which converted keyed networksets into keyed Folders full of Shortcuts to member Networks
   that stayed in their owner's Home folder. The same-owner guard prevents a keyed Folder from granting

--- a/docs/specifications/FOLDER_SHORTCUT_SPECIFICATION.md
+++ b/docs/specifications/FOLDER_SHORTCUT_SPECIFICATION.md
@@ -102,18 +102,23 @@ anonymous, **binary READ grant** (there is no write-granting access key), issued
   Folder if it matches the enabled key of that item's own record (for a Network, its own access key)
   or of **any** ancestor Folder, walking `parent` up to the root. There is no "nearest parent
   overrides" rule — because a key is only ever `read`, there is nothing to override.
-* **Shortcut carve-out:** an access key does **not** propagate through a Shortcut to the Shortcut's
-  target. A key on a Folder that *contains* a Shortcut does not grant access to the Shortcut's target
-  Network/Folder (which lives elsewhere with its own access controls). This matches how permissions
-  treat Shortcuts (a Shortcut inherits its *target's* permission, not its container's) and the Google
-  Drive model, where folder sharing does not flow through a shortcut to a file elsewhere. Shortcuts
-  are therefore never traversed during access-key validation.
+* **Shortcut traversal (same-owner NETWORK carve-out):** in general an access key does **not**
+  propagate through a Shortcut to the Shortcut's target — matching how permissions treat Shortcuts (a
+  Shortcut inherits its *target's* permission, not its container's) and the Google Drive model, where
+  folder sharing does not flow through a shortcut to a file elsewhere. **Exception (backwards
+  compatibility, issue #133/#137):** for a **Network** target, a key **is** valid when a *same-owner*
+  (Shortcut owner = target Network owner) live `NETWORK` Shortcut pointing at it lives in a Folder whose
+  ancestry carries the matching enabled key. This restores access keys stranded by the v3 networkset
+  migration, which converted keyed networksets into keyed Folders full of Shortcuts to member Networks
+  that stayed in their owner's Home folder. The same-owner guard prevents a keyed Folder from granting
+  anonymous read to a Network its owner does not own. `FOLDER`-target Shortcuts are still not traversed.
 * Consistent with the above, `GET /v3/files/folders/{folderid}/list` and `/count`, when a request
-  **presents a valid access key**, return only the key-accessible children — folders and networks;
-  **Shortcut children are excluded**. When a request provides a valid access key, this key-accessible
-  result is returned regardless of the caller's identity; when no valid key is provided, the caller
-  gets their identity-based view (owners and users with direct `read`/`write` see the full listing,
-  including Shortcuts).
+  **presents a valid access key**, return the key-accessible children — folders, networks, and
+  **same-owner `NETWORK` Shortcuts** whose target networks the key now unlocks (other Shortcut children
+  are excluded). When a request provides a valid access key, this key-accessible result is returned
+  regardless of the caller's identity; when no valid key is provided, the caller gets their
+  identity-based view (owners and users with direct `read`/`write` see the full listing, including all
+  Shortcuts).
 
 This behavior is implemented once in `AccessKeyResolver`
 (`org.ndexbio.common.models.dao.AccessKeyResolver`), shared by the network and folder DAOs.

--- a/src/main/java/org/ndexbio/common/models/dao/AccessKeyResolver.java
+++ b/src/main/java/org/ndexbio/common/models/dao/AccessKeyResolver.java
@@ -13,8 +13,15 @@ import java.util.UUID;
  * exactly like folder permissions (see the "Access key propagation through folders" section of
  * {@code docs/specifications/FOLDER_SHORTCUT_SPECIFICATION.md}). A key is valid for a subject when it
  * matches the enabled {@code access_key} of the subject itself (network's own key) or of <em>any</em>
- * ancestor folder (full-chain accrual / OR semantics — no "nearest parent" override). Shortcuts are
- * intentionally not traversed (issue #133; edge case tracked as #137).</p>
+ * ancestor folder (full-chain accrual / OR semantics — no "nearest parent" override).</p>
+ *
+ * <p>For networks the chain is additionally seeded by <em>shortcuts</em>: a key is valid for a network
+ * when a same-owner (shortcut owner = network owner) live {@code NETWORK} shortcut pointing at it lives
+ * in a folder whose ancestry carries the matching enabled key. This restores access keys stranded by
+ * the v3 networkset migration, which turned keyed networksets into keyed folders full of shortcuts
+ * (issue #133; the previously-deferred #137 edge case). The same-owner guard mirrors
+ * {@code DbMigrationTool}'s cross-owner skip and prevents a keyed folder from granting anonymous read
+ * to a network its owner does not own.</p>
  *
  * <p>This is the single source of truth for access-key validation, shared by
  * {@code PostgresNetworkDAO} and {@code PostgresFolderDAO}.</p>
@@ -28,16 +35,18 @@ public interface AccessKeyResolver {
 	boolean isFolderKeyValid(UUID folderId, String accessKey) throws SQLException;
 
 	/**
-	 * @return true if {@code accessKey} matches the network's own enabled access key, or an enabled
-	 *         access key on any ancestor folder of the network (walking {@code network.parent} to the
-	 *         root). Returns false for a null/empty key.
+	 * @return true if {@code accessKey} matches the network's own enabled access key, an enabled access
+	 *         key on any ancestor folder of the network (walking {@code network.parent} to the root), or
+	 *         an enabled key on the ancestry of a folder that holds a same-owner {@code NETWORK} shortcut
+	 *         pointing at the network. Returns false for a null/empty key.
 	 */
 	boolean isNetworkKeyValid(UUID networkId, String accessKey) throws SQLException;
 
 	/**
 	 * Batch form of {@link #isNetworkKeyValid}: given a candidate set of network ids, return the subset
-	 * for which {@code accessKey} is valid (own key or ancestor-folder chain). Evaluated in a single
-	 * query. Returns an empty set for a null/empty key or empty input.
+	 * for which {@code accessKey} is valid (own key, ancestor-folder chain, or a same-owner {@code NETWORK}
+	 * shortcut's folder chain). Evaluated in a single query. Returns an empty set for a null/empty key or
+	 * empty input.
 	 */
 	Set<UUID> filterNetworksByKey(Collection<UUID> networkIds, String accessKey) throws SQLException;
 }

--- a/src/main/java/org/ndexbio/common/models/dao/FolderDAO.java
+++ b/src/main/java/org/ndexbio/common/models/dao/FolderDAO.java
@@ -52,8 +52,8 @@ public interface FolderDAO extends AutoCloseable {
 
 	/**
 	 * Like {@link #getFolderChildCounts(UUID)} but for a request that provided a valid access key for
-	 * this folder: counts the children the key validates (folders + networks; shortcuts excluded,
-	 * since access keys do not traverse shortcuts).
+	 * this folder: counts the children the key validates (folders + networks, plus same-owner NETWORK
+	 * shortcuts whose target networks the key now unlocks — issue #133/#137).
 	 */
 	FileCount getFolderChildCountsKeyFiltered(UUID folderId) throws SQLException;
 
@@ -68,8 +68,8 @@ public interface FolderDAO extends AutoCloseable {
 
 	/**
 	 * Like {@link #listItemsInFolder(UUID, boolean, FileType)} but for a request that provided a valid
-	 * access key for this folder: returns the immediate children the key validates (folders +
-	 * networks; shortcuts excluded, since access keys do not traverse shortcuts).
+	 * access key for this folder: returns the immediate children the key validates (folders + networks,
+	 * plus same-owner NETWORK shortcuts whose target networks the key now unlocks — issue #133/#137).
 	 */
 	List<FileItemSummary> listItemsInFolderKeyFiltered(UUID folderId, boolean compact, FileType type) throws SQLException;
 

--- a/src/main/java/org/ndexbio/common/models/dao/postgresql/PostgresAccessKeyResolver.java
+++ b/src/main/java/org/ndexbio/common/models/dao/postgresql/PostgresAccessKeyResolver.java
@@ -17,8 +17,11 @@ import org.ndexbio.common.models.dao.AccessKeyResolver;
  * <p>Validity is computed live with an upward recursive CTE over {@code folder.parent}, mirroring the
  * downward propagation of folder permissions but for the binary READ grant that an access key
  * represents. See the "Access key propagation through folders" section of
- * {@code docs/specifications/FOLDER_SHORTCUT_SPECIFICATION.md}. Shortcuts are not traversed
- * (issue #133; #137 tracks a known edge case).</p>
+ * {@code docs/specifications/FOLDER_SHORTCUT_SPECIFICATION.md}. For networks the CTE seed also includes
+ * the parent folders of same-owner live {@code NETWORK} shortcuts pointing at the network, so a key
+ * stranded on a migrated networkset folder (full of shortcuts) still grants read to its target networks
+ * (issue #133; the previously-deferred #137 edge case). The same-owner guard mirrors
+ * {@code DbMigrationTool}'s cross-owner skip.</p>
  *
  * <p>This collaborator shares the JDBC {@link Connection} of the DAO that owns it (constructor
  * injection, same seam as {@code NdexDBDAO}), so tests can supply a mock connection — or a mock of
@@ -62,12 +65,21 @@ public class PostgresAccessKeyResolver implements AccessKeyResolver {
 		if (accessKey == null || accessKey.isEmpty())
 			return false;
 
-		// The network's own key, OR any live ancestor folder starting from network.parent.
+		// The network's own key, OR any live ancestor folder starting from either the network's own
+		// parent OR the parent folder of a same-owner live NETWORK shortcut pointing at this network.
+		// The shortcut seed restores access keys that the v3 networkset migration left stranded on a
+		// folder full of shortcuts (issue #133; the previously-deferred #137 edge case). The same-owner
+		// guard (shortcut.owneruuid = network.owneruuid) mirrors DbMigrationTool's cross-owner skip and
+		// prevents a keyed folder from granting anonymous read to a network its owner does not own.
 		String sql = "WITH RECURSIVE chain AS ("
 				+ "  SELECT f.\"UUID\", f.parent, f.access_key_is_on, f.access_key"
 				+ "    FROM folder f"
-				+ "   WHERE f.\"UUID\" = (SELECT parent FROM network WHERE \"UUID\" = ?)"
-				+ "     AND f.is_deleted = false"
+				+ "   WHERE f.is_deleted = false"
+				+ "     AND ( f.\"UUID\" = (SELECT parent FROM network WHERE \"UUID\" = ?)"
+				+ "           OR f.\"UUID\" IN ("
+				+ "                SELECT s.parent FROM shortcut s"
+				+ "                 WHERE s.target = ? AND s.target_type = 'NETWORK' AND s.is_deleted = false"
+				+ "                   AND s.owneruuid = (SELECT owneruuid FROM network WHERE \"UUID\" = ?) ) )"
 				+ "  UNION"
 				+ "  SELECT pf.\"UUID\", pf.parent, pf.access_key_is_on, pf.access_key"
 				+ "    FROM folder pf JOIN chain c ON pf.\"UUID\" = c.parent"
@@ -81,8 +93,10 @@ public class PostgresAccessKeyResolver implements AccessKeyResolver {
 		try (PreparedStatement p = db.prepareStatement(sql)) {
 			p.setObject(1, networkId);
 			p.setObject(2, networkId);
-			p.setString(3, accessKey);
-			p.setString(4, accessKey);
+			p.setObject(3, networkId);
+			p.setObject(4, networkId);
+			p.setString(5, accessKey);
+			p.setString(6, accessKey);
 			try (ResultSet rs = p.executeQuery()) {
 				return rs.next();
 			}
@@ -103,14 +117,26 @@ public class PostgresAccessKeyResolver implements AccessKeyResolver {
 			idList.append('\'').append(id.toString()).append('\'');
 		}
 
-		// One query: map each candidate to its parent-folder chain (carrying the originating network id),
-		// then union networks matched by their own key with networks matched by an ancestor folder's key.
+		// One query: map each candidate to the parent folders that could carry its key — its own parent
+		// folder AND the parent folder of any same-owner live NETWORK shortcut pointing at it (seed_folders)
+		// — walk those folder chains up (chain), then union networks matched by their own key with networks
+		// matched by an ancestor folder's key. The shortcut seed is the batch twin of isNetworkKeyValid's
+		// shortcut resolution (issue #133/#137); the same-owner guard (sc.owneruuid = n.owneruuid) blocks
+		// cross-owner escalation.
 		String sql = "WITH RECURSIVE seed AS ("
-				+ "  SELECT n.\"UUID\" AS net_id, n.parent AS folder_id FROM network n"
+				+ "  SELECT n.\"UUID\" AS net_id, n.parent AS folder_id, n.owneruuid AS net_owner FROM network n"
 				+ "   WHERE n.\"UUID\" IN (" + idList + ")"
+				+ "), seed_folders AS ("
+				+ "  SELECT net_id, folder_id FROM seed WHERE folder_id IS NOT NULL"
+				+ "  UNION"
+				+ "  SELECT sd.net_id, sc.parent"
+				+ "    FROM seed sd JOIN shortcut sc"
+				+ "      ON sc.target = sd.net_id AND sc.target_type = 'NETWORK'"
+				+ "     AND sc.is_deleted = false AND sc.owneruuid = sd.net_owner"
+				+ "   WHERE sc.parent IS NOT NULL"
 				+ "), chain AS ("
-				+ "  SELECT s.net_id, f.parent, f.access_key_is_on, f.access_key"
-				+ "    FROM seed s JOIN folder f ON f.\"UUID\" = s.folder_id AND f.is_deleted = false"
+				+ "  SELECT sf.net_id, f.parent, f.access_key_is_on, f.access_key"
+				+ "    FROM seed_folders sf JOIN folder f ON f.\"UUID\" = sf.folder_id AND f.is_deleted = false"
 				+ "  UNION"
 				+ "  SELECT c.net_id, pf.parent, pf.access_key_is_on, pf.access_key"
 				+ "    FROM folder pf JOIN chain c ON pf.\"UUID\" = c.parent"

--- a/src/main/java/org/ndexbio/common/models/dao/postgresql/PostgresFolderDAO.java
+++ b/src/main/java/org/ndexbio/common/models/dao/postgresql/PostgresFolderDAO.java
@@ -516,23 +516,37 @@ public class PostgresFolderDAO extends NdexDBDAO implements FolderDAO {
 	    return listItemsInFolderOrHome(folderId, compact, false, type, readClausesFor(viewerUserId));
 	}
 
+	/**
+	 * Shortcut read predicate (alias {@code s}) for the key-accessible view: keep same-owner NETWORK
+	 * shortcuts, so a validated folder key surfaces the shortcuts whose target networks it now unlocks
+	 * (issue #133/#137). Must be self-contained: this same string is injected both into the listing
+	 * query (which LEFT JOINs {@code network n}) and into countReadableChildren (a bare
+	 * {@code SELECT COUNT(*) FROM shortcut s} with no network join), so it uses its own EXISTS subquery
+	 * alias {@code tn} rather than relying on the listing's {@code n}. The same-owner guard mirrors the
+	 * resolver's shortcut resolution.
+	 */
+	private static final String KEY_ACCESSIBLE_SHORTCUT_CLAUSE =
+	        "s.target_type = 'NETWORK' AND EXISTS (SELECT 1 FROM network tn"
+	        + " WHERE tn.\"UUID\" = s.target AND tn.owneruuid = s.owneruuid AND tn.is_deleted = false)";
+
 	@Override
 	public List<FileItemSummary> listItemsInFolderKeyFiltered(UUID folderId, boolean compact, FileType type) throws SQLException {
-	    // The key-accessible children of a folder whose access key validated. A validated folder key
-	    // is valid for every folder/network descendant but never for a shortcut, so per-child validity
-	    // reduces to: keep folders + networks, drop shortcuts. Expressed as constant per-type clauses
-	    // (no key inlined into SQL). Keeps results consistent with a direct network/folder key fetch.
+	    // The key-accessible children of a folder whose access key validated. A validated folder key is
+	    // valid for every folder/network descendant, and for same-owner NETWORK shortcuts whose target
+	    // networks it now unlocks (issue #133/#137). Expressed as constant per-type clauses (no key
+	    // inlined into SQL). Keeps results consistent with a direct network key fetch.
 	    return listItemsInFolderOrHome(folderId, compact, false, type,
-	            new ChildReadClauses("true", "true", "false"));
+	            new ChildReadClauses("true", "true", KEY_ACCESSIBLE_SHORTCUT_CLAUSE));
 	}
 
 	@Override
 	public FileCount getFolderChildCountsKeyFiltered(UUID folderId) throws SQLException {
-	    // Same reduction as listItemsInFolderKeyFiltered: folders/networks counted, shortcuts excluded.
+	    // Same reduction as listItemsInFolderKeyFiltered: folders/networks counted, plus same-owner
+	    // NETWORK shortcuts.
 	    FileCount fc = new FileCount();
 	    fc.setFolder(countReadableChildren("folder", "f", folderId, "true"));
 	    fc.setNetwork(countReadableChildren("network", "n", folderId, "true"));
-	    fc.setShortcut(0L);
+	    fc.setShortcut(countReadableChildren("shortcut", "s", folderId, KEY_ACCESSIBLE_SHORTCUT_CLAUSE));
 	    return fc;
 	}
 

--- a/src/main/java/org/ndexbio/rest/services/BatchServiceV2.java
+++ b/src/main/java/org/ndexbio/rest/services/BatchServiceV2.java
@@ -141,7 +141,7 @@ public class BatchServiceV2 extends NdexService {
 	@PermitAll
 	@POST
 	@Path("/network/summary")
-	@Operation(summary = "Get Network Summaries By UUIDs", description = "Return a JSON array of network summary objects selected by the POSTed JSON array of Network UUIDs. When `accesskey` is provided, networks it unlocks (via the network's own key or an ancestor folder's key) are returned in addition to those the caller can already read.")
+	@Operation(summary = "Get Network Summaries By UUIDs", description = "Return a JSON array of network summary objects selected by the POSTed JSON array of Network UUIDs. When `accesskey` is provided, networks it unlocks (via the network's own key, an ancestor folder's key, or a same-owner shortcut to the network in a keyed folder) are returned in addition to those the caller can already read.")
 	@Produces("application/json")
 	@Consumes("application/json")
 	public List<NetworkSummary> getNetworkSummaries(

--- a/src/main/java/org/ndexbio/rest/services/NetworkServiceV2.java
+++ b/src/main/java/org/ndexbio/rest/services/NetworkServiceV2.java
@@ -163,7 +163,7 @@ public class NetworkServiceV2 extends NdexService {
 	@PermitAll
 	@GET
 	@Path("/{networkid}/provenance")
-	@Operation(summary = "Get Network Provenance", description = "Returns the Provenance aspect of the network specified by networkid. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself or on any ancestor folder in its folder hierarchy.")
+	@Operation(summary = "Get Network Provenance", description = "Returns the Provenance aspect of the network specified by networkid. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself, on any ancestor folder in its folder hierarchy, or on a folder holding a same-owner shortcut to the network.")
 	@Produces("application/json")
 
 	public ProvenanceEntity getProvenance(
@@ -337,7 +337,7 @@ public class NetworkServiceV2 extends NdexService {
 	@PermitAll
 	@GET
 	@Path("/{networkid}/summary")
-	@Operation(summary = "Get a Network Summary", description = "Retrieves a NetworkSummary JSON object based on the network specified by networkId. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself or on any ancestor folder in its folder hierarchy.")
+	@Operation(summary = "Get a Network Summary", description = "Retrieves a NetworkSummary JSON object based on the network specified by networkId. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself, on any ancestor folder in its folder hierarchy, or on a folder holding a same-owner shortcut to the network.")
 	@Produces("application/json")
 	
 	public NetworkSummary getNetworkSummary(
@@ -366,7 +366,7 @@ public class NetworkServiceV2 extends NdexService {
 	@PermitAll
 	@GET
 	@Path("/{networkid}/aspect")
-	@Operation(summary = "Get Network CX Metadata Collection", description = "Returns the CX metadata collection of the network specified by networkid. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself or on any ancestor folder in its folder hierarchy.")
+	@Operation(summary = "Get Network CX Metadata Collection", description = "Returns the CX metadata collection of the network specified by networkid. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself, on any ancestor folder in its folder hierarchy, or on a folder holding a same-owner shortcut to the network.")
 
 	public Response getNetworkCXMetadataCollection(	@PathParam("networkid") final String networkId,
 			@QueryParam("accesskey") String accessKey)
@@ -491,7 +491,7 @@ public class NetworkServiceV2 extends NdexService {
 	@PermitAll
 	@GET
 	@Path("/{networkid}")
-	@Operation(summary = "Get Complete Network in CX format", description = "Returns the specified network as CX. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself or on any ancestor folder in its folder hierarchy.")
+	@Operation(summary = "Get Complete Network in CX format", description = "Returns the specified network as CX. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself, on any ancestor folder in its folder hierarchy, or on a folder holding a same-owner shortcut to the network.")
 	public Response getCompleteNetworkAsCX(	@PathParam("networkid") final String networkId,
 			@QueryParam("download") boolean isDownload,
 			@QueryParam("accesskey") String accessKey,
@@ -548,7 +548,7 @@ public class NetworkServiceV2 extends NdexService {
 	@PermitAll
 	@GET
 	@Path("/{networkid}/sample")
-	@Operation(summary = "Get Network Sample", description = "Returns a sample subnetwork of the network specified by networkid. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself or on any ancestor folder in its folder hierarchy.")
+	@Operation(summary = "Get Network Sample", description = "Returns a sample subnetwork of the network specified by networkid. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself, on any ancestor folder in its folder hierarchy, or on a folder holding a same-owner shortcut to the network.")
 
 	public Response getSampleNetworkAsCX(	@PathParam("networkid") final String networkIdStr ,
 			@QueryParam("accesskey") String accessKey)

--- a/src/main/java/org/ndexbio/rest/services/SearchServiceV2.java
+++ b/src/main/java/org/ndexbio/rest/services/SearchServiceV2.java
@@ -222,7 +222,7 @@ public class SearchServiceV2 extends NdexService {
 	@PermitAll
 	@POST
 	@Path("/network/{networkId}/nodes")
-	@Operation(summary = "Query Network Nodes", description = "Search for nodes within a specific network using a query string. Returns a list of matching nodes with their properties. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself or on any ancestor folder in its folder hierarchy.")
+	@Operation(summary = "Query Network Nodes", description = "Search for nodes within a specific network using a query string. Returns a list of matching nodes with their properties. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself, on any ancestor folder in its folder hierarchy, or on a folder holding a same-owner shortcut to the network.")
 	@Produces("application/json")
    
 	public SolrDocumentList queryNetworkNodes(
@@ -279,7 +279,7 @@ public class SearchServiceV2 extends NdexService {
 	@PermitAll
 	@POST
 	@Path("/network/{networkId}/query")
-	@Operation(summary = "Query Network", description = "Returns a CX network that is a 'neighborhood' subnetwork of the network specified by networkid. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself or on any ancestor folder in its folder hierarchy.")
+	@Operation(summary = "Query Network", description = "Returns a CX network that is a 'neighborhood' subnetwork of the network specified by networkid. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself, on any ancestor folder in its folder hierarchy, or on a folder holding a same-owner shortcut to the network.")
 	@Produces("application/json")
 
 	public Response queryNetworkAsCX(
@@ -480,7 +480,7 @@ public class SearchServiceV2 extends NdexService {
 	@PermitAll
 	@POST
 	@Path("/network/{networkId}/interconnectquery")
-	@Operation(summary = "Interconnect Query", description = "Returns a CX network that is a 'neighborhood' subnetwork where all the paths must start and end at one of the query nodes in the network specified by networkid. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself or on any ancestor folder in its folder hierarchy.")
+	@Operation(summary = "Interconnect Query", description = "Returns a CX network that is a 'neighborhood' subnetwork where all the paths must start and end at one of the query nodes in the network specified by networkid. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself, on any ancestor folder in its folder hierarchy, or on a folder holding a same-owner shortcut to the network.")
 	@Produces("application/json")
 
 	public Response interconnectQuery(
@@ -563,7 +563,7 @@ public class SearchServiceV2 extends NdexService {
 	@PermitAll
 	@POST
 	@Path("/network/{networkId}/advancedquery")
-	@Operation(summary = "Advanced Query", description = "This method retrieves a filtered subnetwork of the network specified by ‘networkId’ based on a POSTed JSON query object. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself or on any ancestor folder in its folder hierarchy.")
+	@Operation(summary = "Advanced Query", description = "This method retrieves a filtered subnetwork of the network specified by ‘networkId’ based on a POSTed JSON query object. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself, on any ancestor folder in its folder hierarchy, or on a folder holding a same-owner shortcut to the network.")
 	@Produces("application/json")
    
 	public Response advancedQuery(

--- a/src/main/java/org/ndexbio/rest/services/v3/BatchService.java
+++ b/src/main/java/org/ndexbio/rest/services/v3/BatchService.java
@@ -112,7 +112,7 @@ public class BatchService extends NdexService {
 	@PermitAll
 	@POST
 	@Path("/networks/summary")
-	@Operation(summary = "Get Network Summaries By UUIDs (V3)", description = "Returns a JSON array of NetworkSummaryV3 objects selected by the POSTed JSON array of Network UUIDs. Supports different summary formats. When `accesskey` is provided, networks it unlocks (via the network's own key or an ancestor folder's key) are returned in addition to those the caller can already read.")
+	@Operation(summary = "Get Network Summaries By UUIDs (V3)", description = "Returns a JSON array of NetworkSummaryV3 objects selected by the POSTed JSON array of Network UUIDs. Supports different summary formats. When `accesskey` is provided, networks it unlocks (via the network's own key, an ancestor folder's key, or a same-owner shortcut to the network in a keyed folder) are returned in addition to those the caller can already read.")
 	@Produces("application/json")
 	public List<NetworkSummaryV3> getNetworkSummaries(
 			@QueryParam("accesskey") String accessKey,

--- a/src/main/java/org/ndexbio/rest/services/v3/NetworkServiceV3.java
+++ b/src/main/java/org/ndexbio/rest/services/v3/NetworkServiceV3.java
@@ -105,7 +105,7 @@ public class NetworkServiceV3  extends NdexService {
 	@PermitAll
 	@GET
 	@Path("/{networkid}")
-	@Operation(summary = "Get Network in CX2 format", description = "Returns the specified network in CX2 format. This is performed as a monolithic operation, so it is typically advisable for applications to first use the getNetworkSummary method to check the node and edge counts for a network before retrieving the network. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself or on any ancestor folder in its folder hierarchy.")
+	@Operation(summary = "Get Network in CX2 format", description = "Returns the specified network in CX2 format. This is performed as a monolithic operation, so it is typically advisable for applications to first use the getNetworkSummary method to check the node and edge counts for a network before retrieving the network. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself, on any ancestor folder in its folder hierarchy, or on a folder holding a same-owner shortcut to the network.")
 
 	public Response getCX2Network(	@PathParam("networkid") final String networkId,
 			@QueryParam("download") boolean isDownload,
@@ -165,7 +165,7 @@ public class NetworkServiceV3  extends NdexService {
 	@GET
 	@Path("/{networkid}/aspects")
 	@Produces("application/json")
-	@Operation(summary = "Get Network CX2 Aspect Metadata", description = "Returns the CX2 aspect metadata for the network specified by networkid. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself or on any ancestor folder in its folder hierarchy.")
+	@Operation(summary = "Get Network CX2 Aspect Metadata", description = "Returns the CX2 aspect metadata for the network specified by networkid. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself, on any ancestor folder in its folder hierarchy, or on a folder holding a same-owner shortcut to the network.")
 	public List<CxMetadata>  getCX2Metadata(	@PathParam("networkid") final String networkId,
 			@QueryParam("accesskey") String accessKey)
 			throws Exception {
@@ -184,7 +184,7 @@ public class NetworkServiceV3  extends NdexService {
 	@PermitAll
 	@GET
 	@Path("/{networkid}/aspects/edges")
-	@Operation(summary = "Get Network Edges (CX2)", description = "Returns the edge aspect of the network specified by networkid in CX2 format. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself or on any ancestor folder in its folder hierarchy.")
+	@Operation(summary = "Get Network Edges (CX2)", description = "Returns the edge aspect of the network specified by networkid in CX2 format. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself, on any ancestor folder in its folder hierarchy, or on a folder holding a same-owner shortcut to the network.")
 	public Response getEdges (
 			@PathParam("networkid") final String networkId,
 			@DefaultValue("first") @QueryParam("method") String method,
@@ -245,7 +245,7 @@ public class NetworkServiceV3  extends NdexService {
 	@PermitAll
 	@GET
 	@Path("/{networkid}/aspects/{aspectname}")
-	@Operation(summary = "Get a Network Aspect (CX2)", description = "Returns the elements of the specified aspect from the network specified by networkid in CX2 format. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself or on any ancestor folder in its folder hierarchy.")
+	@Operation(summary = "Get a Network Aspect (CX2)", description = "Returns the elements of the specified aspect from the network specified by networkid in CX2 format. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself, on any ancestor folder in its folder hierarchy, or on a folder holding a same-owner shortcut to the network.")
 	public Response getAspectElements(	@PathParam("networkid") final String networkId,
 			@PathParam("aspectname") final String aspectName,
 			@DefaultValue("-1") @QueryParam("size") int limit,
@@ -665,7 +665,7 @@ public class NetworkServiceV3  extends NdexService {
 		@PermitAll
 		@GET
 		@Path("/{networkid}/export")
-		@Operation(summary = "Export nodes or edges in TSV format", description = "Returns the nodes or edges of this network specified by networkid in TSV format. Content type of the response is text/tab-separated-values. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself or on any ancestor folder in its folder hierarchy.")
+		@Operation(summary = "Export nodes or edges in TSV format", description = "Returns the nodes or edges of this network specified by networkid in TSV format. Content type of the response is text/tab-separated-values. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself, on any ancestor folder in its folder hierarchy, or on a folder holding a same-owner shortcut to the network.")
 
 		public Response exportTSVText( 
 				@PathParam("networkid") final String networkId,
@@ -758,7 +758,7 @@ public class NetworkServiceV3  extends NdexService {
 		@PermitAll
 		@GET
 		@Path("/{networkid}/summary")
-		@Operation(summary = "Get a Network Summary", description = "Retrieves a NetworkSummary JSON object based on the network specified by networkId. A NetworkSummary object is a subset of a network object. It is used to convey basic information about a network in this API. NOTE: If value of 'completed' is False this result may not contain all attributes below (name, description, version might be missing, nodeCount and edgeCount will be zero, properties will be empty, etc…) If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself or on any ancestor folder in its folder hierarchy.")
+		@Operation(summary = "Get a Network Summary", description = "Retrieves a NetworkSummary JSON object based on the network specified by networkId. A NetworkSummary object is a subset of a network object. It is used to convey basic information about a network in this API. NOTE: If value of 'completed' is False this result may not contain all attributes below (name, description, version might be missing, nodeCount and edgeCount will be zero, properties will be empty, etc…) If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself, on any ancestor folder in its folder hierarchy, or on a folder holding a same-owner shortcut to the network.")
 		@Produces("application/json")
 		
 		public NetworkSummaryV3 getNetworkSummaryV3(

--- a/src/main/java/org/ndexbio/rest/services/v3/SearchServiceV3.java
+++ b/src/main/java/org/ndexbio/rest/services/v3/SearchServiceV3.java
@@ -96,7 +96,7 @@ public class SearchServiceV3 extends NdexService  {
 	@POST
 	@Path("/networks/{networkId}/edges")
 	//@Produces("application/json")
-	@Operation(summary = "Get Network Edges (CX2)", description = "Returns a filtered set of edges from the network specified by networkId in CX2 format. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself or on any ancestor folder in its folder hierarchy.")
+	@Operation(summary = "Get Network Edges (CX2)", description = "Returns a filtered set of edges from the network specified by networkId in CX2 format. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself, on any ancestor folder in its folder hierarchy, or on a folder holding a same-owner shortcut to the network.")
 	public Response getEdges(	@PathParam("networkId") final String networkId,
 				@DefaultValue("-1") @QueryParam("size") int limit,
 				@DefaultValue("desc") @QueryParam("order") String order,
@@ -156,7 +156,7 @@ public class SearchServiceV3 extends NdexService  {
 	@POST
 	@Path("/networks/{networkId}/query")
 	@Produces("application/json")
-	@Operation(summary = "Query Network (CX2)", description = "Returns a CX2 'neighborhood' subnetwork of the network specified by networkId. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself or on any ancestor folder in its folder hierarchy.")
+	@Operation(summary = "Query Network (CX2)", description = "Returns a CX2 'neighborhood' subnetwork of the network specified by networkId. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself, on any ancestor folder in its folder hierarchy, or on a folder holding a same-owner shortcut to the network.")
 	public Response queryNetworkAsCX(
 			@PathParam("networkId") final String networkIdStr,
 			@QueryParam("accesskey") String accessKey,
@@ -240,7 +240,7 @@ public class SearchServiceV3 extends NdexService  {
 	@POST
 	@Path("/networks/{networkId}/interconnectquery")
 	@Produces("application/json")
-	@Operation(summary = "Interconnect Query (CX2)", description = "Returns a CX2 'neighborhood' subnetwork where all paths start and end at one of the query nodes in the network specified by networkId. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself or on any ancestor folder in its folder hierarchy.")
+	@Operation(summary = "Interconnect Query (CX2)", description = "Returns a CX2 'neighborhood' subnetwork where all paths start and end at one of the query nodes in the network specified by networkId. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself, on any ancestor folder in its folder hierarchy, or on a folder holding a same-owner shortcut to the network.")
 	public Response interconnectQuery(
 			@PathParam("networkId") final String networkIdStr,
 			@QueryParam("accesskey") String accessKey,
@@ -334,7 +334,7 @@ public class SearchServiceV3 extends NdexService  {
 	@POST
 	@Path("/networks/{networkId}/nodes")
 	@Produces("application/json")
-	@Operation(summary = "Get Node Attributes", description = "Returns node attributes for matching nodes in the network specified by networkId. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself or on any ancestor folder in its folder hierarchy.")
+	@Operation(summary = "Get Node Attributes", description = "Returns node attributes for matching nodes in the network specified by networkId. If the network is not public, an optional `accesskey` grants anonymous read access when it matches an enabled access key on the network itself, on any ancestor folder in its folder hierarchy, or on a folder holding a same-owner shortcut to the network.")
 	public Response getNodeAttributes (@PathParam("networkId") final String networkIdStr,
 			@QueryParam("accesskey") String accessKey,
 			final CXObjectFilter filterObject) throws SQLException, IOException, NdexException {

--- a/src/main/java/org/ndexbio/rest/services/v3/files/FileServiceV3.java
+++ b/src/main/java/org/ndexbio/rest/services/v3/files/FileServiceV3.java
@@ -299,7 +299,7 @@ public class FileServiceV3 extends NdexService {
             description = """
                           Makes a copy of the supplied object.
 
-                          When copying a network source you don't otherwise have read access to, an optional `accesskey` query parameter authorizes the read when it matches an enabled access key on that network or any ancestor folder in its folder hierarchy. Access keys do not authorize copying a shortcut source.
+                          When copying a network source you don't otherwise have read access to, an optional `accesskey` query parameter authorizes the read when it matches an enabled access key on that network, any ancestor folder in its folder hierarchy, or a folder holding a same-owner shortcut to it. Access keys do not authorize copying a shortcut source.
 
                           Copying folders is not supported – suggest creating a shortcut instead.
 

--- a/src/main/java/org/ndexbio/rest/services/v3/files/FolderServiceV3.java
+++ b/src/main/java/org/ndexbio/rest/services/v3/files/FolderServiceV3.java
@@ -348,7 +348,7 @@ public class FolderServiceV3 extends NdexService {
     @Operation(
             summary = "Get Item Counts Within a Folder",
             description = """
-                          Returns counts of the networks, subfolders, and shortcuts directly under the specified folder that the caller is allowed to see (matches the /list result for the same caller). When a valid folder access key is provided on the request, the counts cover the key-accessible children — folders and networks; shortcuts are excluded, since access keys do not traverse shortcuts.
+                          Returns counts of the networks, subfolders, and shortcuts directly under the specified folder that the caller is allowed to see (matches the /list result for the same caller). When a valid folder access key is provided on the request, the counts cover the key-accessible children — folders, networks, and same-owner NETWORK shortcuts whose target networks the key now unlocks.
                           
                           Path Parameters:
                           - folderid: UUID of the folder to count items in
@@ -374,7 +374,7 @@ public class FolderServiceV3 extends NdexService {
 
 	    try (FolderDAO dao = Configuration.getInstance().getDAOFactory().getFolderDAO()) {
 	        // If the request provides a valid access key, return the key-accessible child counts —
-	        // folders and networks; shortcuts excluded (access keys do not traverse shortcuts). If no
+	        // folders, networks, and same-owner NETWORK shortcuts whose targets the key unlocks. If no
 	        // valid key is present, the caller must be able to read the folder and gets the counts of
 	        // the children they may see (matches /list).
 	        if (dao.accessKeyIsValid(folderUUID, accessKey)) {
@@ -399,7 +399,7 @@ public class FolderServiceV3 extends NdexService {
 	    description = """
 					Lists items (folders, networks, shortcuts) in the specified folder.
 					If *folderid* is a UUID, returns the immediate children of that folder  
-					that the caller is allowed to read (PUBLIC/UNLISTED, plus items they own or are shared on); when a valid folder access key is provided on the request, the response contains the key-accessible children — folders and networks; shortcuts are excluded, since access keys do not traverse shortcuts.
+					that the caller is allowed to read (PUBLIC/UNLISTED, plus items they own or are shared on); when a valid folder access key is provided on the request, the response contains the key-accessible children — folders, networks, and same-owner NETWORK shortcuts whose target networks the key now unlocks.
 					If *folderid* is the literal string **"home"**, returns all top level items owned by the signed in user (parent = NULL).
 
 					Path Parameters:
@@ -456,7 +456,7 @@ public class FolderServiceV3 extends NdexService {
 
 	    try (FolderDAO dao = Configuration.getInstance().getDAOFactory().getFolderDAO()) {
 	        // If the request provides a valid access key, return the key-accessible children —
-	        // folders and networks; shortcuts excluded (access keys do not traverse shortcuts). If no
+	        // folders, networks, and same-owner NETWORK shortcuts whose targets the key unlocks. If no
 	        // valid key is present, the caller must be able to read the folder and gets only the
 	        // children they may see.
 	        if (dao.accessKeyIsValid(folderUUID, accessKey)) {

--- a/src/test/java/org/ndexbio/common/models/dao/postgresql/TestPostgresAccessKeyResolver.java
+++ b/src/test/java/org/ndexbio/common/models/dao/postgresql/TestPostgresAccessKeyResolver.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.UUID;
 
+import org.easymock.Capture;
 import org.junit.Test;
 
 public class TestPostgresAccessKeyResolver {
@@ -121,6 +122,79 @@ public class TestPostgresAccessKeyResolver {
         assertTrue(granted.contains(b));
         assertFalse(granted.contains(c));
         verify(conn, pst, rs);
+    }
+
+    /**
+     * The isNetworkKeyValid query must seed the folder chain from same-owner NETWORK shortcuts pointing
+     * at the network (issue #133/#137), so a key stranded on a migrated networkset folder still resolves.
+     * The mock can't exercise real rows, so assert the emitted SQL carries the shortcut seed and the
+     * same-owner guard, and that all four UUID binds are set (index shifted from 2 to 4).
+     */
+    @Test
+    public void testNetworkKeyQuerySeedsFromSameOwnerShortcut() throws SQLException {
+        Connection conn = createMock(Connection.class);
+        PreparedStatement pst = createMock(PreparedStatement.class);
+        ResultSet rs = createMock(ResultSet.class);
+
+        Capture<String> sqlCap = newCapture();
+        expect(conn.prepareStatement(capture(sqlCap))).andReturn(pst);
+        Capture<Integer> objIdx = newCapture(org.easymock.CaptureType.ALL);
+        pst.setObject(captureInt(objIdx), anyObject());
+        expectLastCall().anyTimes();
+        pst.setString(anyInt(), anyString());
+        expectLastCall().anyTimes();
+        expect(pst.executeQuery()).andReturn(rs);
+        expect(rs.next()).andReturn(false);
+        rs.close();
+        expectLastCall();
+        pst.close();
+        expectLastCall();
+        replay(conn, pst, rs);
+
+        PostgresAccessKeyResolver r = new PostgresAccessKeyResolver(conn);
+        r.isNetworkKeyValid(UUID.randomUUID(), "k");
+        verify(conn, pst, rs);
+
+        String sql = sqlCap.getValue();
+        assertTrue("query must join shortcut table", sql.contains("shortcut s"));
+        assertTrue("query must restrict to NETWORK shortcuts", sql.contains("s.target_type = 'NETWORK'"));
+        assertTrue("query must apply the same-owner guard",
+                sql.contains("s.owneruuid = (SELECT owneruuid FROM network"));
+        assertEquals("four UUID binds expected (network parent, shortcut target, owner, own-key)",
+                4, objIdx.getValues().size());
+    }
+
+    /**
+     * filterNetworksByKey is the batch twin: its seed_folders CTE must union each network's own parent
+     * folder with the parent folders of its same-owner NETWORK shortcuts.
+     */
+    @Test
+    public void testFilterNetworksByKeyQuerySeedsFromSameOwnerShortcut() throws SQLException {
+        Connection conn = createMock(Connection.class);
+        PreparedStatement pst = createMock(PreparedStatement.class);
+        ResultSet rs = createMock(ResultSet.class);
+
+        Capture<String> sqlCap = newCapture();
+        expect(conn.prepareStatement(capture(sqlCap))).andReturn(pst);
+        pst.setString(anyInt(), anyString());
+        expectLastCall().anyTimes();
+        expect(pst.executeQuery()).andReturn(rs);
+        expect(rs.next()).andReturn(false);
+        rs.close();
+        expectLastCall();
+        pst.close();
+        expectLastCall();
+        replay(conn, pst, rs);
+
+        PostgresAccessKeyResolver r = new PostgresAccessKeyResolver(conn);
+        r.filterNetworksByKey(Arrays.asList(UUID.randomUUID()), "k");
+        verify(conn, pst, rs);
+
+        String sql = sqlCap.getValue();
+        assertTrue("query must define seed_folders CTE", sql.contains("seed_folders"));
+        assertTrue("query must join shortcut table", sql.contains("shortcut sc"));
+        assertTrue("query must restrict to NETWORK shortcuts", sql.contains("sc.target_type = 'NETWORK'"));
+        assertTrue("query must apply the same-owner guard", sql.contains("sc.owneruuid = sd.net_owner"));
     }
 
     @Test


### PR DESCRIPTION
I tried creating a notification email list for owners that had migrated networksets into folders with shortcuts to networks that had multiple shortcuts on those netowrks, as that prevented auto migrating their shortcuts direct to networks in folders to enable access key inheritance. it was about 90 people which have folders with shortcuts that couldn't be converted direclty to networks and there is not clean/simple way to explain to them how manually fix their shortcut references. 

So, instead have walked back the change to elide shortcuts from access key propagation and instead include that so it will allow this remnant in the v3 networkset migration.