### PR TITLE
renabled /v2/user/{userid}/networksets against networkset table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## Unreleased
+## [Unreleased]
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## Unreleased
 
 ### Breaking Changes
 
-- **The NDEx network set feature has been removed**, except for two read-only endpoints re-enabled for backward-compatible reads of legacy data. All `/v2/networkset` *write* endpoints return **HTTP 501 Not Implemented**, and `GET /v2/user/{userid}/networksets` is retired. New network sets can no longer be created; use folders + shortcuts + folder access keys instead — see the [V3 Migration Guide](docs/V3-Migration-Guide.md). Endpoint status:
-  - **Re-enabled (read-only):** `GET /v2/networkset/{id}` and `GET /v2/networkset/{id}/accesskey` now serve the frozen, archived `network_set` / `network_set_member` tables directly — no v3 folder polyfill. `GET /v2/networkset/{id}` returns the archived set (members filtered to networks the caller can read, a valid access key returning all); `GET /v2/networkset/{id}/accesskey` returns the archived key to the set owner. Both are marked deprecated/archived in Swagger.
+- **The NDEx network set feature has been removed**, except for read-only endpoints re-enabled for backward-compatible reads of legacy data. All `/v2/networkset` *write* endpoints return **HTTP 501 Not Implemented**. New network sets can no longer be created; use folders + shortcuts + folder access keys instead — see the [V3 Migration Guide](docs/V3-Migration-Guide.md). Endpoint status:
+  - **Re-enabled (read-only):** `GET /v2/networkset/{id}`, `GET /v2/networkset/{id}/accesskey`, and `GET /v2/user/{userid}/networksets` now serve the frozen, archived `network_set` / `network_set_member` tables directly — `GET /v2/networkset/{id}` returns the archived set (members filtered to networks the caller can read, a valid access key returning all); `GET /v2/networkset/{id}/accesskey` returns the archived key to the set owner; `GET /v2/user/{userid}/networksets` returns the archived sets owned by the user (members filtered to the networks the caller can read; honors `offset`/`limit`/`summary`/`showcase`). All are marked deprecated/archived in Swagger.
   - **Retired → 501:** `POST /v2/networkset`, `PUT|DELETE /v2/networkset/{id}`, `POST|DELETE /v2/networkset/{id}/members`, `PUT /v2/networkset/{id}/accesskey`, `PUT /v2/networkset/{id}/systemproperty`.
-  - `GET /v2/user/{userid}/networksets` → 501, and the `networkSetCount` field is removed from `GET /v2/user/{userid}/networkcount`.
+  - The `networkSetCount` field is removed from `GET /v2/user/{userid}/networkcount` response model.
   - The legacy `network_set` / `network_set_member` tables are retained as frozen/read-only; the `network_set_member → network` foreign key is dropped so the tables no longer couple to network deletion.
 - **Swagger / OpenAPI** — every removed network-set endpoint is marked `deprecated` with a documented `501` response.
 - **`GET /v3/networks/{networkid}/DOI` removed.** The v3 DOI-mint endpoint is deleted; it duplicated the v2 admin DOI flow (`POST /v2/admin/request` with `type=DOI`), which remains the single DOI mechanism. The endpoint existed only to serve a two-step, asynchronous DOI workflow (a DOI request emailed an admin a link — `…/DOI?key=<encrypted-network-id>&email=…` — which the admin clicked to mint). That workflow was retired in Feb 2024 ("Mint DOI immediately when user requests", UD-2788): the request handler was changed to mint synchronously in-process, and the email/link generation was commented out. Since then nothing has generated that link and nothing consumed the endpoint's `key` parameter, so the endpoint had been dead code — its removal breaks no live flow.

--- a/docker/test/integration-test.sh
+++ b/docker/test/integration-test.sh
@@ -32,7 +32,7 @@ TEST_USER2="ndextest2"
 TEST_PASS2="NDExTest2!"
 TEST_EMAIL2="ndextest2@ndex-integration.local"
 
-TOTAL_API_CALLS=116
+TOTAL_API_CALLS=119
 PASSED=0
 CALL_NUM=0
 STEP_NUM=0
@@ -1057,9 +1057,8 @@ assert_networkset_501 POST   "${BASE_URL}/v2/networkset/${NS_DUMMY_UUID}/members
 assert_networkset_501 DELETE "${BASE_URL}/v2/networkset/${NS_DUMMY_UUID}/members" -H "Content-Type: application/json" -d '[]'
 assert_networkset_501 PUT    "${BASE_URL}/v2/networkset/${NS_DUMMY_UUID}/accesskey?action=enable"
 assert_networkset_501 PUT    "${BASE_URL}/v2/networkset/${NS_DUMMY_UUID}/systemproperty" -H "Content-Type: application/json" -d '{}'
-
-# user-side network-set listing
-assert_networkset_501 GET    "${BASE_URL}/v2/user/${NS_DUMMY_UUID}/networksets"
+# Note: GET /v2/user/{userid}/networksets is NOT retired — it is a re-enabled archived read, exercised
+# in the dedicated read step below.
 
 # ── STEP: Folder list/count per-child visibility (F10) ───────────────────────
 # A folder's visibility is independent of its children's. A folder the caller can
@@ -1581,6 +1580,50 @@ if [[ -z "${REMOTE_NDEX_URL}" ]]; then
     -H "Content-Type: application/json" -d '{"name":"nope"}' "${BASE_URL}/v2/networkset")
   [[ "${NS_POST_HTTP}" == "501" ]] || api_fail "POST /v2/networkset → HTTP ${NS_POST_HTTP} (expected 501 — writes remain removed)"
   api_pass "POST /v2/networkset → 501 (network-set writes remain retired; only reads re-enabled)"
+
+  # 7) GET /v2/user/{userid}/networksets — re-enabled archived list (issue #133), served strictly from
+  #    the frozen network_set tables. Resolve the owner UUID via the @PermitAll username lookup.
+  NS_OWNER_ID=$(curl -s "${BASE_URL}/v2/user?username=${TEST_USER}" \
+    | grep -oiE '"externalId"[[:space:]]*:[[:space:]]*"[0-9a-f-]{36}"' | grep -oiE '[0-9a-f-]{36}' | head -1)
+  [[ -n "${NS_OWNER_ID}" ]] || api_fail "could not resolve ${TEST_USER} UUID from GET /v2/user?username"
+
+  # 7a) anon → 200 (no longer 501); archived set present with only the readable (public) member.
+  CALL_NUM=$((CALL_NUM+1))
+  echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: GET /v2/user/${NS_OWNER_ID}/networksets (anon) — public member only"
+  NSU_ANON=$(curl -s -w "\n%{http_code}" "${BASE_URL}/v2/user/${NS_OWNER_ID}/networksets")
+  NSU_ANON_HTTP=$(echo "${NSU_ANON}" | tail -1); NSU_ANON_BODY=$(echo "${NSU_ANON}" | head -1)
+  [[ "${NSU_ANON_HTTP}" == "200" ]] || api_fail "GET /v2/user/{id}/networksets (anon) → HTTP ${NSU_ANON_HTTP} (expected 200, not 501). Body: ${NSU_ANON_BODY:0:400}"
+  echo "${NSU_ANON_BODY}" | grep -q "${NS_SET_ID}" || api_fail "anon list missing archived set ${NS_SET_ID}. Body: ${NSU_ANON_BODY:0:400}"
+  echo "${NSU_ANON_BODY}" | grep -q "${V2_PUB_UUID}" || api_fail "anon list missing PUBLIC member ${V2_PUB_UUID}. Body: ${NSU_ANON_BODY:0:400}"
+  echo "${NSU_ANON_BODY}" | grep -q "${V2_PRIV_UUID}" && api_fail "anon list LEAKED PRIVATE member ${V2_PRIV_UUID}. Body: ${NSU_ANON_BODY:0:400}"
+  api_pass "GET /v2/user/{id}/networksets (anon) → 200, archived set + PUBLIC member only (PRIVATE filtered)"
+
+  # 7b) owner → sees both members via own readability.
+  CALL_NUM=$((CALL_NUM+1))
+  echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: GET /v2/user/${NS_OWNER_ID}/networksets (owner) — both members"
+  NSU_OWNER=$(curl -s -w "\n%{http_code}" -u "${TEST_USER}:${TEST_PASS}" "${BASE_URL}/v2/user/${NS_OWNER_ID}/networksets")
+  NSU_OWNER_HTTP=$(echo "${NSU_OWNER}" | tail -1); NSU_OWNER_BODY=$(echo "${NSU_OWNER}" | head -1)
+  [[ "${NSU_OWNER_HTTP}" == "200" ]] || api_fail "GET /v2/user/{id}/networksets (owner) → HTTP ${NSU_OWNER_HTTP}. Body: ${NSU_OWNER_BODY:0:400}"
+  { echo "${NSU_OWNER_BODY}" | grep -q "${V2_PUB_UUID}" && echo "${NSU_OWNER_BODY}" | grep -q "${V2_PRIV_UUID}"; } \
+    || api_fail "owner list missing a member (expected both public + private). Body: ${NSU_OWNER_BODY:0:400}"
+  api_pass "GET /v2/user/{id}/networksets (owner) → 200, both members (own PRIVATE network readable)"
+
+  # 7c) owner + summary=true → set header present, member network ids omitted.
+  CALL_NUM=$((CALL_NUM+1))
+  echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: GET /v2/user/${NS_OWNER_ID}/networksets?summary=true (owner) — headers only"
+  NSU_SUM=$(curl -s -u "${TEST_USER}:${TEST_PASS}" "${BASE_URL}/v2/user/${NS_OWNER_ID}/networksets?summary=true")
+  echo "${NSU_SUM}" | grep -q "${NS_SET_ID}" || api_fail "summary list missing archived set ${NS_SET_ID}. Body: ${NSU_SUM:0:400}"
+  { echo "${NSU_SUM}" | grep -q "${V2_PUB_UUID}" || echo "${NSU_SUM}" | grep -q "${V2_PRIV_UUID}"; } \
+    && api_fail "summary=true should omit member network ids. Body: ${NSU_SUM:0:400}"
+  api_pass "GET /v2/user/{id}/networksets?summary=true → set header present, members omitted"
+
+  # 7d) owner + showcase=true → seeded set has showcased=false, so it is filtered out.
+  CALL_NUM=$((CALL_NUM+1))
+  echo "  API call ${CALL_NUM}/${TOTAL_API_CALLS}: GET /v2/user/${NS_OWNER_ID}/networksets?showcase=true (owner) — non-showcased set absent"
+  NSU_SHOW=$(curl -s -u "${TEST_USER}:${TEST_PASS}" "${BASE_URL}/v2/user/${NS_OWNER_ID}/networksets?showcase=true")
+  echo "${NSU_SHOW}" | grep -q "${NS_SET_ID}" \
+    && api_fail "showcase=true must exclude the non-showcased set ${NS_SET_ID}. Body: ${NSU_SHOW:0:400}"
+  api_pass "GET /v2/user/{id}/networksets?showcase=true → non-showcased set excluded (showcase filter)"
 
   echo "  Cleaning up seeded network_set '${NS_SET_ID}'..."
   docker exec "${CONTAINER_NAME}" bash -c "

--- a/src/main/java/org/ndexbio/common/models/dao/postgresql/NetworkSetDAO.java
+++ b/src/main/java/org/ndexbio/common/models/dao/postgresql/NetworkSetDAO.java
@@ -5,6 +5,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
@@ -94,20 +95,92 @@ public class NetworkSetDAO extends NdexDBDAO {
 		if (!keyIsValid && accessKey != null)
 			throw new UnauthorizedOperationException("Invalid network set access key.");
 
-		sqlStr = "select nm.network_id from network_set_member nm, network n where nm.set_id =? and n.\"UUID\"=nm.network_id and " +
-				(keyIsValid ? " true" : PostgresNetworkDAO.createIsReadableConditionStr(userId));
+		loadReadableMembers(result, setId, userId, keyIsValid);
+
+		return result;
+	}
+
+	/**
+	 * Lists the archived network sets owned by {@code ownerId} from the frozen {@code network_set} table
+	 * (never the v3 folder model). Members of each set are filtered to the networks {@code signedInUserId}
+	 * may read (same visibility rule as {@link #getNetworkSet}); there is no access key on this endpoint.
+	 *
+	 * @param offset       row offset for paging; ignored unless {@code limit > 0}
+	 * @param limit        max sets to return; {@code <= 0} means no limit
+	 * @param summaryOnly  when true, set headers are returned without loading their member networks
+	 * @param showcasedOnly when true, restrict to sets with {@code showcased = true}
+	 * @return the (possibly empty) list of the owner's non-deleted archived network sets
+	 */
+	public List<NetworkSet> getNetworkSetsByUserId(UUID ownerId, UUID signedInUserId, int offset, int limit,
+			boolean summaryOnly, boolean showcasedOnly)
+			throws SQLException, JsonParseException, JsonMappingException, IOException {
+
+		List<NetworkSet> result = new ArrayList<>();
+
+		StringBuilder sqlStr = new StringBuilder(
+				"select \"UUID\", creation_time, modification_time, owner_id, name, description, "
+				+ "other_attributes, showcased, ndexdoi from network_set where owner_id=? and is_deleted=false");
+		if (showcasedOnly)
+			sqlStr.append(" and showcased=true");
+		sqlStr.append(" order by creation_time");
+		// offset/limit are ints (not caller strings), so inlining them is injection-safe.
+		if (limit > 0)
+			sqlStr.append(" limit ").append(limit).append(" offset ").append(Math.max(offset, 0));
+
+		try (PreparedStatement p = db.prepareStatement(sqlStr.toString())) {
+			p.setObject(1, ownerId);
+			try (ResultSet rs = p.executeQuery()) {
+				ObjectMapper mapper = new ObjectMapper();
+				TypeReference<HashMap<String, Object>> typeRef = new TypeReference<HashMap<String, Object>>() {/**/};
+				while (rs.next()) {
+					NetworkSet set = new NetworkSet();
+					set.setExternalId((UUID) rs.getObject(1));
+					set.setCreationTime(rs.getTimestamp(2));
+					set.setModificationTime(rs.getTimestamp(3));
+					set.setOwnerId((UUID) rs.getObject(4));
+					set.setName(rs.getString(5));
+					set.setDescription(rs.getString(6));
+					String propStr = rs.getString(7);
+					if (propStr != null)
+						set.setProperties(mapper.readValue(propStr, typeRef));
+					set.setShowcased(rs.getBoolean(8));
+					set.setDoi(rs.getString(9));
+					result.add(set);
+				}
+			}
+		}
+
+		// Members are loaded in a second pass, after the header statement above is closed (one active
+		// statement per connection). No access key on this endpoint, so members follow readability.
+		if (!summaryOnly) {
+			for (NetworkSet set : result) {
+				loadReadableMembers(set, set.getExternalId(), signedInUserId, false);
+			}
+		}
+
+		return result;
+	}
+
+	/**
+	 * Appends the readable member network ids of {@code setId} to {@code set}'s network list, reading only
+	 * the frozen {@code network_set_member} / {@code network} tables. When {@code keyIsValid} is true a
+	 * valid access key was presented and all members are returned; otherwise members are restricted to the
+	 * networks {@code signedInUserId} may read.
+	 */
+	private void loadReadableMembers(NetworkSet set, UUID setId, UUID signedInUserId, boolean keyIsValid)
+			throws SQLException {
+		String sqlStr = "select nm.network_id from network_set_member nm, network n where nm.set_id =? and n.\"UUID\"=nm.network_id and " +
+				(keyIsValid ? " true" : PostgresNetworkDAO.createIsReadableConditionStr(signedInUserId));
 
 		try (PreparedStatement p = db.prepareStatement(sqlStr)) {
 			p.setObject(1, setId);
 			try (ResultSet rs = p.executeQuery()) {
-				List<UUID> networkIds = result.getNetworks();
+				List<UUID> networkIds = set.getNetworks();
 				while (rs.next()) {
 					networkIds.add((UUID) rs.getObject(1));
 				}
 			}
 		}
-
-		return result;
 	}
 
 	public String getNetworkSetAccessKey(UUID networkSetId) throws SQLException, ObjectNotFoundException {

--- a/src/main/java/org/ndexbio/common/models/dao/postgresql/NetworkSetDAO.java
+++ b/src/main/java/org/ndexbio/common/models/dao/postgresql/NetworkSetDAO.java
@@ -169,7 +169,7 @@ public class NetworkSetDAO extends NdexDBDAO {
 	 */
 	private void loadReadableMembers(NetworkSet set, UUID setId, UUID signedInUserId, boolean keyIsValid)
 			throws SQLException {
-		String sqlStr = "select nm.network_id from network_set_member nm, network n where nm.set_id =? and n.\"UUID\"=nm.network_id and " +
+		String sqlStr = "select nm.network_id from network_set_member nm, network n where nm.set_id =? and n.\"UUID\"=nm.network_id and n.is_deleted=false and " +
 				(keyIsValid ? " true" : PostgresNetworkDAO.createIsReadableConditionStr(signedInUserId));
 
 		try (PreparedStatement p = db.prepareStatement(sqlStr)) {

--- a/src/main/java/org/ndexbio/rest/services/UserServiceV2.java
+++ b/src/main/java/org/ndexbio/rest/services/UserServiceV2.java
@@ -59,6 +59,7 @@ import jakarta.ws.rs.core.Response;
 
 import org.ndexbio.common.models.dao.FolderDAO;
 import org.ndexbio.common.models.dao.NetworkDAO;
+import org.ndexbio.common.models.dao.postgresql.NetworkSetDAO;
 import org.ndexbio.common.models.dao.postgresql.PostgresNetworkDAO;
 import org.ndexbio.common.models.dao.postgresql.PostgresShortcutDAO;
 import org.ndexbio.common.models.dao.postgresql.RequestDAO;
@@ -103,7 +104,12 @@ import jakarta.ws.rs.Consumes;
 
 @Path("/v2/user")
 public class UserServiceV2 extends NdexService {
-	
+
+	private static final String ARCHIVED_DESC =
+			"Read-only access to archived, historical network-set data from the frozen network_set tables. "
+			+ "The network set feature is retired: no new network sets can be created and this data is not "
+			+ "backed by the v3 folder model. Provided only for backward-compatible reads of legacy network sets.";
+
 
 	/**************************************************************************
 	 * Injects the HTTP request into the base class to be used by
@@ -1050,8 +1056,8 @@ public class UserServiceV2 extends NdexService {
 	   	@GET
 		@Path("/{userid}/networksets")
 		@Deprecated
-		@Operation(summary = "Get All Network Sets owned by a user (REMOVED)", description = "Removed: the NDEx network set feature is no longer supported. This endpoint always returns HTTP 501 Not Implemented.", deprecated = true)
-		@ApiResponse(responseCode = "501", description = "Not Implemented — the network set feature has been removed")
+		@Operation(summary = "Get All Network Sets owned by a user (ARCHIVED)", description = ARCHIVED_DESC, deprecated = true)
+		@ApiResponse(responseCode = "200", description = "The archived network sets owned by the user")
 		@Produces("application/json")
 		@PermitAll
 		public  List<NetworkSet> getNetworksetsByUserId(
@@ -1060,8 +1066,12 @@ public class UserServiceV2 extends NdexService {
 						@DefaultValue("0") @QueryParam("limit") int limit,
 						@DefaultValue("false") @QueryParam("summary") boolean summaryOnly,
 						@DefaultValue("false") @QueryParam("showcase") boolean showcasedOnly
-					) {
-			throw notImplemented("The NDEx network set feature has been removed.");
+					) throws Exception {
+			UUID ownerId = UUID.fromString(userIdStr);
+			// Serve only the archived network_set / network_set_member data; no v3 folder polyfill.
+			try (NetworkSetDAO dao = new NetworkSetDAO()) {
+				return dao.getNetworkSetsByUserId(ownerId, getLoggedInUserId(), offset, limit, summaryOnly, showcasedOnly);
+			}
 	}
 
 	/**************************************************************************

--- a/src/test/java/org/ndexbio/common/models/dao/postgresql/TestNetworkSetDAO.java
+++ b/src/test/java/org/ndexbio/common/models/dao/postgresql/TestNetworkSetDAO.java
@@ -273,4 +273,31 @@ public class TestNetworkSetDAO {
 
 		assertEquals(1, sets.size());
 	}
+
+	@Test
+	public void testMemberQueryExcludesDeletedNetworks() throws Exception {
+		Connection conn = createMock(Connection.class);
+		PreparedStatement pst = createNiceMock(PreparedStatement.class);
+		ResultSet rs = createNiceMock(ResultSet.class);
+
+		// One header row, summaryOnly=false -> the member query runs. Capture every SQL statement so we
+		// can assert the member read filters out soft-deleted networks (dangling members guard, #145).
+		Capture<String> sqlCap = newCapture(org.easymock.CaptureType.ALL);
+		expect(conn.prepareStatement(capture(sqlCap))).andReturn(pst).anyTimes();
+		expect(pst.executeQuery()).andReturn(rs).anyTimes();
+		// header query: one row then done; member query: no rows.
+		expect(rs.next()).andReturn(true).andReturn(false).andReturn(false);
+		replay(conn, pst, rs);
+
+		NetworkSetDAO dao = new NetworkSetDAO(conn);
+		dao.getNetworkSetsByUserId(UUID.randomUUID(), UUID.randomUUID(), 0, 0, false, false);
+		verify(conn);
+
+		String memberSql = sqlCap.getValues().stream()
+				.filter(s -> s.contains("network_set_member"))
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("member query was not issued"));
+		assertTrue("member query must exclude soft-deleted networks: " + memberSql,
+				memberSql.contains("n.is_deleted=false"));
+	}
 }

--- a/src/test/java/org/ndexbio/common/models/dao/postgresql/TestNetworkSetDAO.java
+++ b/src/test/java/org/ndexbio/common/models/dao/postgresql/TestNetworkSetDAO.java
@@ -10,11 +10,14 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.UUID;
 
+import org.easymock.Capture;
 import org.junit.Test;
 import org.ndexbio.model.exceptions.ObjectNotFoundException;
 import org.ndexbio.model.exceptions.UnauthorizedOperationException;
+import org.ndexbio.model.object.NetworkSet;
 
 /**
  * Unit tests for the archive-only {@link NetworkSetDAO}. These verify the DAO reads exclusively from
@@ -191,5 +194,83 @@ public class TestNetworkSetDAO {
 
 		NetworkSetDAO dao = new NetworkSetDAO(conn);
 		dao.getNetworkSet(UUID.randomUUID(), UUID.randomUUID(), "any-key");
+	}
+
+	// ---- getNetworkSetsByUserId (owner-scoped archive list) ----
+
+	@Test
+	public void testGetNetworkSetsByUserIdEmptyWhenNoRows() throws Exception {
+		Connection conn = createMock(Connection.class);
+		PreparedStatement pst = createMock(PreparedStatement.class);
+		ResultSet rs = createNiceMock(ResultSet.class);
+
+		// Exactly ONE prepareStatement: header query only (no rows -> no per-set member query).
+		Capture<String> sqlCap = newCapture();
+		expect(conn.prepareStatement(capture(sqlCap))).andReturn(pst);
+		pst.setObject(anyInt(), anyObject());
+		expectLastCall().anyTimes();
+		expect(pst.executeQuery()).andReturn(rs);
+		expect(rs.next()).andReturn(false);
+		pst.close();
+		expectLastCall();
+		replay(conn, pst, rs);
+
+		NetworkSetDAO dao = new NetworkSetDAO(conn);
+		List<NetworkSet> sets = dao.getNetworkSetsByUserId(UUID.randomUUID(), UUID.randomUUID(), 0, 0, false, false);
+		verify(conn, pst);
+
+		assertTrue(sets.isEmpty());
+		String sql = sqlCap.getValue();
+		assertTrue("owner-scoped header query", sql.contains("owner_id=?"));
+		assertTrue("frozen non-deleted rows only", sql.contains("is_deleted=false"));
+		assertTrue("reads the frozen network_set table", sql.contains("from network_set"));
+		assertFalse("no showcase filter by default", sql.contains("showcased=true"));
+	}
+
+	@Test
+	public void testGetNetworkSetsByUserIdShowcasedOnlyAddsFilter() throws Exception {
+		Connection conn = createMock(Connection.class);
+		PreparedStatement pst = createMock(PreparedStatement.class);
+		ResultSet rs = createNiceMock(ResultSet.class);
+
+		Capture<String> sqlCap = newCapture();
+		expect(conn.prepareStatement(capture(sqlCap))).andReturn(pst);
+		pst.setObject(anyInt(), anyObject());
+		expectLastCall().anyTimes();
+		expect(pst.executeQuery()).andReturn(rs);
+		expect(rs.next()).andReturn(false);
+		pst.close();
+		expectLastCall();
+		replay(conn, pst, rs);
+
+		NetworkSetDAO dao = new NetworkSetDAO(conn);
+		dao.getNetworkSetsByUserId(UUID.randomUUID(), UUID.randomUUID(), 0, 0, false, true);
+		verify(conn, pst);
+
+		assertTrue("showcasedOnly adds the showcased filter", sqlCap.getValue().contains("showcased=true"));
+	}
+
+	@Test
+	public void testGetNetworkSetsByUserIdSummaryOnlySkipsMemberQuery() throws Exception {
+		Connection conn = createMock(Connection.class);
+		PreparedStatement pst = createMock(PreparedStatement.class);
+		ResultSet rs = createNiceMock(ResultSet.class);
+
+		// One header row present. With summaryOnly=true the member query must NOT run, so the strict
+		// conn mock expects prepareStatement exactly once — a second call (member read) fails verify().
+		expect(conn.prepareStatement(anyString())).andReturn(pst);
+		pst.setObject(anyInt(), anyObject());
+		expectLastCall().anyTimes();
+		expect(pst.executeQuery()).andReturn(rs);
+		expect(rs.next()).andReturn(true).andReturn(false);
+		pst.close();
+		expectLastCall();
+		replay(conn, pst, rs);
+
+		NetworkSetDAO dao = new NetworkSetDAO(conn);
+		List<NetworkSet> sets = dao.getNetworkSetsByUserId(UUID.randomUUID(), UUID.randomUUID(), 0, 0, true, false);
+		verify(conn, pst);
+
+		assertEquals(1, sets.size());
 	}
 }


### PR DESCRIPTION
Allow /v2/user/{userid}/networksets but only for the frozen networkset table data to provide some minimal backwards compat after v3 migration to folders.