### PR TITLE
reindexing loops should log WARN for any issue per network indexed

### DIFF
--- a/src/main/java/org/ndexbio/common/persistence/CX2NetworkLoader.java
+++ b/src/main/java/org/ndexbio/common/persistence/CX2NetworkLoader.java
@@ -247,7 +247,7 @@ public class CX2NetworkLoader implements AutoCloseable {
 				boolean needIndividualIndex = this.nodeIdTracker.getDefinedElementSize() >= SingleNetworkSolrIdxManager.AUTOCREATE_THRESHHOLD;
 				
 				// clear individual index
-				try (SingleNetworkSolrIdxManager idx2 = new SingleNetworkSolrIdxManager(networkId.toString())) {
+				try (SingleNetworkSolrIdxManager idx2 = Configuration.getInstance().getSolrObjectFactory().getSingleNetworkSolrIdxManager(networkId.toString())) {
 					idx2.dropIndex();
 				}
 				if (needIndividualIndex)

--- a/src/main/java/org/ndexbio/common/persistence/CXNetworkAspectsUpdater.java
+++ b/src/main/java/org/ndexbio/common/persistence/CXNetworkAspectsUpdater.java
@@ -107,7 +107,7 @@ public class CXNetworkAspectsUpdater extends CXNetworkLoader {
 				throw new NdexException("DB error when setting unlock flag: " + e.getMessage(), e);
 			}
 
-			try (SingleNetworkSolrIdxManager idx2 = new SingleNetworkSolrIdxManager(getNetworkId().toString())) {
+			try (SingleNetworkSolrIdxManager idx2 = Configuration.getInstance().getSolrObjectFactory().getSingleNetworkSolrIdxManager(getNetworkId().toString())) {
 				idx2.dropIndex();
 			}
 			NetworkIndexLevel indexLevel = dao.getIndexLevel(networkUUID);

--- a/src/main/java/org/ndexbio/common/persistence/CXNetworkLoader.java
+++ b/src/main/java/org/ndexbio/common/persistence/CXNetworkLoader.java
@@ -349,7 +349,7 @@ public class CXNetworkLoader implements AutoCloseable {
 				boolean needIndividualIndex = this.nodeIdTracker.getDefinedElementSize() >= SingleNetworkSolrIdxManager.AUTOCREATE_THRESHHOLD;
 				
 				//clear the individual index 
-				try (SingleNetworkSolrIdxManager idx2 = new SingleNetworkSolrIdxManager(networkId.toString())) {
+				try (SingleNetworkSolrIdxManager idx2 = Configuration.getInstance().getSolrObjectFactory().getSingleNetworkSolrIdxManager(networkId.toString())) {
 					idx2.dropIndex();
 				}
 

--- a/src/main/java/org/ndexbio/common/solr/Cx2NodeIndexService.java
+++ b/src/main/java/org/ndexbio/common/solr/Cx2NodeIndexService.java
@@ -1,0 +1,27 @@
+package org.ndexbio.common.solr;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.ndexbio.model.exceptions.NdexException;
+
+/**
+ * Reads a network's CX2 aspect files and produces the entries that make up its
+ * per-network Solr node index.
+ */
+public interface Cx2NodeIndexService {
+
+	/**
+	 * Builds one {@link NodeIndexEntry} per indexable node in {@code networkId}, keyed by node id.
+	 *
+	 * <p>Returns an empty map only when the network genuinely declares no indexable node
+	 * attributes. Any inability to <em>read</em> the network's aspect files is an error and
+	 * throws — callers must be able to tell "this network has nothing to index" apart from
+	 * "this network's data could not be read".
+	 *
+	 * @param networkId network UUID, which is also its aspect directory name
+	 * @throws NdexException if the attribute declarations cannot be read
+	 * @throws IOException   if an aspect file exists but cannot be parsed
+	 */
+	Map<Long, NodeIndexEntry> loadNodeIndexEntries(String networkId) throws NdexException, IOException;
+}

--- a/src/main/java/org/ndexbio/common/solr/Cx2NodeIndexServiceImpl.java
+++ b/src/main/java/org/ndexbio/common/solr/Cx2NodeIndexServiceImpl.java
@@ -1,0 +1,276 @@
+package org.ndexbio.common.solr;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.ndexbio.common.persistence.CX2NetworkLoader;
+import org.ndexbio.cx2.aspect.element.core.CxAttributeDeclaration;
+import org.ndexbio.cx2.aspect.element.core.CxNode;
+import org.ndexbio.cx2.aspect.element.core.DeclarationEntry;
+import org.ndexbio.cxio.aspects.datamodels.ATTRIBUTE_DATA_TYPE;
+import org.ndexbio.model.cx.FunctionTermElement;
+import org.ndexbio.model.exceptions.NdexException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Builds node index entries from the CX2 aspect files under
+ * {@code <ndexRoot>/data/<networkId>/aspects_cx2/}.
+ *
+ * <p>The ndex root is supplied at construction rather than read from global configuration so
+ * that this reader can be exercised against any directory.
+ */
+public class Cx2NodeIndexServiceImpl implements Cx2NodeIndexService {
+
+	private static final Logger logger = LoggerFactory.getLogger(Cx2NodeIndexServiceImpl.class);
+
+	private final String ndexRoot;
+
+	public Cx2NodeIndexServiceImpl(final String ndexRoot) {
+		this.ndexRoot = ndexRoot;
+	}
+
+	@Override
+	public Map<Long, NodeIndexEntry> loadNodeIndexEntries(String networkId)
+			throws NdexException, IOException {
+
+		Map<Long, NodeIndexEntry> result = new TreeMap<>();
+
+		String pathPrefix = ndexRoot + "/data/" + networkId + "/"
+				+ CX2NetworkLoader.cx2AspectDirName + "/";
+
+		ObjectMapper om = new ObjectMapper();
+
+		// Create the attribute name mapping table from the attribute declarations.
+		//
+		// canRead() is false both when the file is absent and when it (or its directory) cannot
+		// be read by this process. Those are very different situations - a permission problem
+		// used to be silently indistinguishable from an empty network, which let a reindex
+		// running as the wrong user quietly produce empty indexes - so fail here and say which
+		// one it was.
+		File aspectDir = new File(pathPrefix);
+		File declFile = new File(pathPrefix + CxAttributeDeclaration.ASPECT_NAME);
+		if (!declFile.canRead()) {
+			throw new NdexException(describeUnreadableDecl(aspectDir, declFile, networkId));
+		}
+
+		CxAttributeDeclaration[] declarations = om.readValue(declFile, CxAttributeDeclaration[].class);
+
+		if (declarations.length == 0
+				|| !declarations[0].getDeclarations().containsKey(CxNode.ASPECT_NAME)) {
+			logger.warn("Network {} declares no {} aspect in {} - node index will be empty.",
+					networkId, CxNode.ASPECT_NAME, declFile.getAbsolutePath());
+			return result;
+		}
+
+		Map<String, DeclarationEntry> nodeAttributeDecls =
+				declarations[0].getAttributesInAspect(CxNode.ASPECT_NAME);
+		if (nodeAttributeDecls.size() == 0) {
+			logger.warn("Network {} declares no node attributes in {} - node index will be empty.",
+					networkId, declFile.getAbsolutePath());
+			return result;
+		}
+
+		//key is lowercased attribute name that we need to index,
+		//value is the actual attribute name in the node. This is for doing a case-insensitive lookup of attribute value.
+		Map<String, Map.Entry<String, DeclarationEntry>> attributeNameMapping = new HashMap<>();
+		for (Map.Entry<String, DeclarationEntry> entry : nodeAttributeDecls.entrySet()) {
+			ATTRIBUTE_DATA_TYPE dType = entry.getValue().getDataType();
+			String attrName = entry.getKey();
+
+			if (dType == null || dType == ATTRIBUTE_DATA_TYPE.STRING
+					|| dType == ATTRIBUTE_DATA_TYPE.LIST_OF_STRING) {
+				if (attrName.equalsIgnoreCase(NodeIndexFields.ALIAS)) {
+					attributeNameMapping.put(NodeIndexFields.ALIAS, entry);
+				} else if (attrName.equalsIgnoreCase(NodeIndexFields.TYPE)) {
+					attributeNameMapping.put(NodeIndexFields.TYPE, entry);
+				} else if (attrName.equalsIgnoreCase(NodeIndexFields.MEMBER)) {
+					attributeNameMapping.put(NodeIndexFields.MEMBER, entry);
+				} else {
+					attributeNameMapping.put(attrName, entry);
+				}
+			}
+		}
+
+		addNodeAspectEntries(pathPrefix, om, nodeAttributeDecls, attributeNameMapping, result);
+		addFunctionTermEntries(pathPrefix, result);
+
+		return result;
+	}
+
+	/**
+	 * Explains why {@code declFile} could not be read. {@code File.canRead()} collapses
+	 * "missing" and "no permission" into a single false, so probe both the file and its
+	 * directory and name the OS user, which is what identifies a permission problem.
+	 */
+	private String describeUnreadableDecl(File aspectDir, File declFile, String networkId) {
+		String user = System.getProperty("user.name");
+
+		if (!aspectDir.exists()) {
+			return "Cannot index network " + networkId + ": CX2 aspect directory is missing - "
+					+ aspectDir.getAbsolutePath();
+		}
+		if (!aspectDir.canRead()) {
+			return "Cannot index network " + networkId + ": CX2 aspect directory is not readable by user '"
+					+ user + "' - " + aspectDir.getAbsolutePath();
+		}
+		if (declFile.exists()) {
+			return "Cannot index network " + networkId + ": " + CxAttributeDeclaration.ASPECT_NAME
+					+ " is present but not readable by user '" + user + "' - " + declFile.getAbsolutePath();
+		}
+		return "Cannot index network " + networkId + ": " + CxAttributeDeclaration.ASPECT_NAME
+				+ " is missing - " + declFile.getAbsolutePath();
+	}
+
+	private void addNodeAspectEntries(String pathPrefix, ObjectMapper om,
+			Map<String, DeclarationEntry> nodeAttributeDecls,
+			Map<String, Map.Entry<String, DeclarationEntry>> attributeNameMapping,
+			Map<Long, NodeIndexEntry> result) throws IOException {
+
+		try (FileInputStream inputStream = new FileInputStream(pathPrefix + CxNode.ASPECT_NAME)) {
+
+			Iterator<CxNode> it = om.readerFor(CxNode.class).readValues(inputStream);
+
+			while (it.hasNext()) {
+				CxNode node = it.next();
+
+				node.extendToFullNode(nodeAttributeDecls);
+
+				NodeIndexEntry e = null;
+				String name = NodeIndexFields.getSingleIndexableTermFromNode(CxNode.NAME, node,
+						attributeNameMapping);
+				if (name != null) {
+					e = new NodeIndexEntry(node.getId(), name);
+				}
+				List<String> represents = NodeIndexFields.getSplitableTerms(CxNode.REPRESENTS, node,
+						attributeNameMapping);
+				if (represents.size() > 0) {
+					if (e == null)
+						e = new NodeIndexEntry(node.getId(), null);
+					e.setRepresents(represents);
+				}
+
+				// process alias
+				List<String> aliases = NodeIndexFields.getSplitableTerms(NodeIndexFields.ALIAS, node,
+						attributeNameMapping);
+				if (aliases.size() > 0) {
+					if (e == null)
+						e = new NodeIndexEntry(node.getId(), null);
+					e.setAliases(aliases);
+				}
+
+				//process members
+				boolean proteinMembersFound = false;
+				Map.Entry<String, DeclarationEntry> typeAttrName =
+						attributeNameMapping.get(NodeIndexFields.TYPE);
+				if (typeAttrName != null) {
+					ATTRIBUTE_DATA_TYPE t = typeAttrName.getValue().getDataType();
+					if (t == null || t == ATTRIBUTE_DATA_TYPE.STRING) {
+						String nodeType = (String) node.getAttributes().get(typeAttrName.getKey());
+						if (nodeType != null && (nodeType.equalsIgnoreCase(NodeIndexFields.PROTEINFAMILY)
+								|| nodeType.equalsIgnoreCase(NodeIndexFields.COMPLEX))) {
+							List<String> memberGenes = NodeIndexFields.getSplitableTerms(
+									NodeIndexFields.MEMBER, node, attributeNameMapping);
+							if (e == null)
+								e = new NodeIndexEntry(node.getId(), null);
+							e.getRepresents().addAll(memberGenes);
+							proteinMembersFound = true;
+						}
+					}
+				}
+
+				e = addRemainingAttributes(node, attributeNameMapping, proteinMembersFound, e);
+
+				if (e != null)
+					result.put(node.getId(), e);
+			}
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private NodeIndexEntry addRemainingAttributes(CxNode node,
+			Map<String, Map.Entry<String, DeclarationEntry>> attributeNameMapping,
+			boolean proteinMembersFound, NodeIndexEntry entry) {
+
+		NodeIndexEntry e = entry;
+
+		for (Map.Entry<String, Map.Entry<String, DeclarationEntry>> attrDecl
+				: attributeNameMapping.entrySet()) {
+			String attrName = attrDecl.getKey();
+			if (attrName.equals(CxNode.NAME) || attrName.equals(CxNode.REPRESENTS)
+					|| attrName.equals(NodeIndexFields.ALIAS))
+				continue;
+			if (proteinMembersFound && attrName.equals(NodeIndexFields.MEMBER))
+				continue;
+
+			// process the value
+			Map.Entry<String, DeclarationEntry> decl = attrDecl.getValue();
+			Object attrValue = node.getAttributes().get(decl.getKey());
+			ATTRIBUTE_DATA_TYPE dType = decl.getValue().getDataType();
+			if (dType == null || dType == ATTRIBUTE_DATA_TYPE.STRING) {
+				if (attrValue != null) {
+					String s = (String) attrValue;
+					if (s.length() > 1) {
+						if (e == null)
+							e = new NodeIndexEntry(node.getId(), null);
+						e.addText(s);
+					}
+				}
+			} else { // list of strings
+				List<String> ls = (List<String>) attrValue;
+				if (ls != null) {
+					for (String str : ls) {
+						if (str != null && str.length() > 1) {
+							if (e == null)
+								e = new NodeIndexEntry(node.getId(), null);
+							e.addText(str);
+						}
+					}
+				}
+			}
+		}
+
+		return e;
+	}
+
+	private void addFunctionTermEntries(String pathPrefix, Map<Long, NodeIndexEntry> result)
+			throws IOException {
+
+		java.nio.file.Path functionTermAspect = Paths.get(pathPrefix + FunctionTermElement.ASPECT_NAME);
+
+		if (!Files.exists(functionTermAspect)) {
+			return;
+		}
+
+		try (FileInputStream inputStream =
+				new FileInputStream(pathPrefix + FunctionTermElement.ASPECT_NAME)) {
+
+			Iterator<FunctionTermElement> it =
+					new ObjectMapper().readerFor(FunctionTermElement.class).readValues(inputStream);
+
+			while (it.hasNext()) {
+				FunctionTermElement functionTerm = it.next();
+				List<String> terms =
+						NetworkGlobalIndexManager.getIndexableStringsFromFunctionTerm(functionTerm);
+				if (terms.size() > 0) {
+					NodeIndexEntry e = result.get(functionTerm.getNodeID());
+					if (e == null) { // need to add a new entry
+						e = new NodeIndexEntry(functionTerm.getNodeID(), null);
+						result.put(functionTerm.getNodeID(), e);
+					}
+					e.setRepresents(terms);
+				}
+			}
+		}
+	}
+}

--- a/src/main/java/org/ndexbio/common/solr/GlobalNetworkIndexManager.java
+++ b/src/main/java/org/ndexbio/common/solr/GlobalNetworkIndexManager.java
@@ -156,21 +156,21 @@ public class GlobalNetworkIndexManager extends NFSIndexManager<NetworkSummary> {
             }
         }
 
-        if ( attributeNameMapping.get(SingleNetworkSolrIdxManager.ALIAS)!=null) {
+        if ( attributeNameMapping.get(NodeIndexFields.ALIAS)!=null) {
 
-            for (String v : SingleNetworkSolrIdxManager.getSplitableTerms(SingleNetworkSolrIdxManager.ALIAS, node,
+            for (String v : NodeIndexFields.getSplitableTerms(NodeIndexFields.ALIAS, node,
                     attributeNameMapping) ){
                 doc.addField(ALIASES, v);
             }
 
         }
 
-        String nodeType = SingleNetworkSolrIdxManager.getSingleIndexableTermFromNode(SingleNetworkSolrIdxManager.TYPE,
+        String nodeType = NodeIndexFields.getSingleIndexableTermFromNode(NodeIndexFields.TYPE,
                 node, attributeNameMapping);
 
-        if ( nodeType != null && (nodeType.equalsIgnoreCase(SingleNetworkSolrIdxManager.PROTEINFAMILY) ||
-                nodeType.equalsIgnoreCase(SingleNetworkSolrIdxManager.COMPLEX) )) {
-            List<String> memberGenes = SingleNetworkSolrIdxManager.getSplitableTerms (SingleNetworkSolrIdxManager.MEMBER,
+        if ( nodeType != null && (nodeType.equalsIgnoreCase(NodeIndexFields.PROTEINFAMILY) ||
+                nodeType.equalsIgnoreCase(NodeIndexFields.COMPLEX) )) {
+            List<String> memberGenes = NodeIndexFields.getSplitableTerms (NodeIndexFields.MEMBER,
                     node, attributeNameMapping);
             for ( String memberIdStr : memberGenes) {
                 for ( String indexableString : getIndexableString(memberIdStr) ){

--- a/src/main/java/org/ndexbio/common/solr/NetworkGlobalIndexManager.java
+++ b/src/main/java/org/ndexbio/common/solr/NetworkGlobalIndexManager.java
@@ -266,21 +266,21 @@ public class NetworkGlobalIndexManager implements AutoCloseable{
 			}
 		}
 	
-		if ( attributeNameMapping.get(SingleNetworkSolrIdxManager.ALIAS)!=null) {
+		if ( attributeNameMapping.get(NodeIndexFields.ALIAS)!=null) {
 			
-			for (String v : SingleNetworkSolrIdxManager.getSplitableTerms(SingleNetworkSolrIdxManager.ALIAS, node,
+			for (String v : NodeIndexFields.getSplitableTerms(NodeIndexFields.ALIAS, node,
 					attributeNameMapping) ){
 				doc.addField(ALIASES, v);
 			}
 			
 		} 
 		
-		String nodeType = SingleNetworkSolrIdxManager.getSingleIndexableTermFromNode(SingleNetworkSolrIdxManager.TYPE,
+		String nodeType = NodeIndexFields.getSingleIndexableTermFromNode(NodeIndexFields.TYPE,
 				node, attributeNameMapping);
 		
-		if ( nodeType != null && (nodeType.equalsIgnoreCase(SingleNetworkSolrIdxManager.PROTEINFAMILY) || 
-    			nodeType.equalsIgnoreCase(SingleNetworkSolrIdxManager.COMPLEX) )) {
-    		List<String> memberGenes = SingleNetworkSolrIdxManager.getSplitableTerms (SingleNetworkSolrIdxManager.MEMBER,
+		if ( nodeType != null && (nodeType.equalsIgnoreCase(NodeIndexFields.PROTEINFAMILY) || 
+    			nodeType.equalsIgnoreCase(NodeIndexFields.COMPLEX) )) {
+    		List<String> memberGenes = NodeIndexFields.getSplitableTerms (NodeIndexFields.MEMBER,
     				node, attributeNameMapping);
     		for ( String memberIdStr : memberGenes) {
 				for ( String indexableString : getIndexableString(memberIdStr) ){

--- a/src/main/java/org/ndexbio/common/solr/NodeIndexFields.java
+++ b/src/main/java/org/ndexbio/common/solr/NodeIndexFields.java
@@ -1,0 +1,94 @@
+package org.ndexbio.common.solr;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.ndexbio.cx2.aspect.element.core.CxNode;
+import org.ndexbio.cx2.aspect.element.core.DeclarationEntry;
+import org.ndexbio.cxio.aspects.datamodels.ATTRIBUTE_DATA_TYPE;
+
+/**
+ * CX2 node attribute names that participate in node indexing, plus the shared
+ * accessors that pull indexable terms out of a {@link CxNode} using a network's
+ * attribute declarations.
+ *
+ * <p>These were previously static members of {@link SingleNetworkSolrIdxManager}. They
+ * are consumed both by the per-network node index and by the global network index, so
+ * they live here to avoid the two managers depending on each other.
+ */
+public final class NodeIndexFields {
+
+	public static final String TYPE = "type";
+	public static final String COMPLEX = "complex";
+	public static final String PROTEINFAMILY = "proteinfamily";
+	public static final String MEMBER = "member";
+	public static final String ALIAS = "alias";
+
+	private NodeIndexFields() {
+		// constants and shared accessors only
+	}
+
+	/**
+	 * Returns the single string value of {@code attrName} on {@code node}, or {@code null}
+	 * when the attribute is not declared, not a string, or absent from the node.
+	 *
+	 * @param attrName             lower-cased attribute name to look up
+	 * @param node                 node to read, already expanded to a full node
+	 * @param attributeNameMapping lower-cased attribute name to its actual name and declaration
+	 */
+	static String getSingleIndexableTermFromNode(String attrName, CxNode node,
+			Map<String, Map.Entry<String, DeclarationEntry>> attributeNameMapping) {
+
+		Map.Entry<String, DeclarationEntry> entry = attributeNameMapping.get(attrName);
+
+		if (entry != null) {
+			String actualAttrName = entry.getKey();
+			ATTRIBUTE_DATA_TYPE t = entry.getValue().getDataType();
+			if (t == null || t == ATTRIBUTE_DATA_TYPE.STRING) {
+				return (String) node.getAttributes().get(actualAttrName);
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns every indexable term for {@code attrName} on {@code node}, splitting each raw
+	 * value into its indexable parts. Handles both string and list-of-string attributes;
+	 * returns an empty list when the attribute is not declared or absent.
+	 *
+	 * @param attrName             lower-cased attribute name to look up
+	 * @param node                 node to read, already expanded to a full node
+	 * @param attributeNameMapping lower-cased attribute name to its actual name and declaration
+	 */
+	@SuppressWarnings("unchecked")
+	static List<String> getSplitableTerms(String attrName, CxNode node,
+			Map<String, Map.Entry<String, DeclarationEntry>> attributeNameMapping) {
+
+		List<String> result = new ArrayList<>();
+
+		Map.Entry<String, DeclarationEntry> entry = attributeNameMapping.get(attrName);
+
+		if (entry != null) {
+			String actualAttrName = entry.getKey();
+			ATTRIBUTE_DATA_TYPE t = entry.getValue().getDataType();
+
+			if (t == null || t == ATTRIBUTE_DATA_TYPE.STRING) {
+				String v = (String) node.getAttributes().get(actualAttrName);
+				if (v != null) {
+					result.addAll(NetworkGlobalIndexManager.getIndexableString(v));
+				}
+			} else if (t == ATTRIBUTE_DATA_TYPE.LIST_OF_STRING) {
+				List<String> vl = (List<String>) node.getAttributes().get(actualAttrName);
+				if (vl != null) {
+					for (String v : vl) {
+						result.addAll(NetworkGlobalIndexManager.getIndexableString(v));
+					}
+				}
+			}
+		}
+
+		return result;
+	}
+}

--- a/src/main/java/org/ndexbio/common/solr/SingleNetworkSolrIdxManager.java
+++ b/src/main/java/org/ndexbio/common/solr/SingleNetworkSolrIdxManager.java
@@ -30,634 +30,254 @@
  */
 package org.ndexbio.common.solr;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 
 import org.apache.solr.client.solrj.SolrQuery;
-import org.apache.solr.client.solrj.SolrRequest.METHOD;
 import org.apache.solr.client.solrj.SolrServerException;
-import org.apache.solr.client.solrj.impl.BaseHttpSolrClient;
-import org.apache.solr.client.solrj.impl.HttpSolrClient;
-import org.apache.solr.client.solrj.request.ConfigSetAdminRequest;
-import org.apache.solr.client.solrj.request.CoreAdminRequest;
-import org.apache.solr.client.solrj.response.ConfigSetAdminResponse;
-import org.apache.solr.client.solrj.response.CoreAdminResponse;
-import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.SolrInputDocument;
-import org.apache.solr.common.util.NamedList;
-import org.ndexbio.common.persistence.CX2NetworkLoader;
-import org.ndexbio.cx2.aspect.element.core.CxAttributeDeclaration;
 import org.ndexbio.cx2.aspect.element.core.CxNode;
-import org.ndexbio.cx2.aspect.element.core.DeclarationEntry;
-import org.ndexbio.cxio.aspects.datamodels.ATTRIBUTE_DATA_TYPE;
-import org.ndexbio.cxio.aspects.datamodels.NodeAttributesElement;
-
-import org.ndexbio.model.cx.FunctionTermElement;
 import org.ndexbio.model.exceptions.NdexException;
 import org.ndexbio.model.tools.SearchUtilities;
-import org.ndexbio.rest.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+/**
+ * Manages the per-network Solr core that backs node queries on a single network.
+ *
+ * <p>Every index-creating method returns the number of documents that actually landed in
+ * Solr, verified by querying the core after the commit. Callers pass the node count the
+ * database reports so that a rebuild which produces no documents for a network that has
+ * nodes fails loudly instead of leaving an empty core behind reporting success.
+ */
+public class SingleNetworkSolrIdxManager implements AutoCloseable {
 
-public class SingleNetworkSolrIdxManager implements AutoCloseable{
+	private static final Logger logger = LoggerFactory.getLogger(SingleNetworkSolrIdxManager.class);
 
-	private String solrUrl;
-	
-	private String collectionName; 
-	private HttpSolrClient client;
-	
-	static private final  int batchSize = NodeIndexDocumentBuilder.DEFAULT_BATCH_SIZE;
-	
+	private final String collectionName;
+	private final SolrClientWrapper client;
+	private final Cx2NodeIndexService nodeIndexService;
+
+	static private final int batchSize = NodeIndexDocumentBuilder.DEFAULT_BATCH_SIZE;
+
 	//NDEx will auto create index for networks with node count larger than this value
 	// other wise it will delay the creation until the first time this network is queried.
-	static public final int AUTOCREATE_THRESHHOLD= 100;
-	
-	private int counter ; 
-	private Collection<SolrInputDocument> docs ;
-	
+	static public final int AUTOCREATE_THRESHHOLD = 100;
+
+	private static final String NODE_CONFIG_SET = "ndex-nodes";
+	private static final String NODE_CONFIG_SET_TEMPLATE = "ndex-nodes-template";
+
+	/**
+	 * Guards core creation so two concurrent queries on the same unindexed network don't both
+	 * try to create its core. Striped rather than one lock per network: bounded in size, and
+	 * unrelated networks no longer serialize behind a single global lock.
+	 */
+	private static final int CORE_CREATION_STRIPES = 64;
+	private static final Object[] CORE_CREATION_LOCKS = newLockStripes();
+
+	private int counter;
+	private Collection<SolrInputDocument> docs;
+
 	public static final String ID = "id";
-	public  static final String TYPE = "type";
-	public  static final String COMPLEX = "complex";
-	public  static final String PROTEINFAMILY = "proteinfamily";
-	public  static final String MEMBER= "member";
-	
+
 	private static final String NAME = "nodeName";
-	public static final String ALIAS= "alias";
 	public static final String TEXT = "text";
-		
-	public SingleNetworkSolrIdxManager(String networkUUID) {
-		collectionName = networkUUID;
-		solrUrl = Configuration.getInstance().getSolrURL();
-		client = new HttpSolrClient.Builder(solrUrl).build();
+
+	private static Object[] newLockStripes() {
+		Object[] stripes = new Object[CORE_CREATION_STRIPES];
+		for (int i = 0; i < stripes.length; i++) {
+			stripes[i] = new Object();
+		}
+		return stripes;
 	}
-	
-	public SolrDocumentList getNodeIdsByQuery(String query, int limit) throws SolrServerException, IOException, NdexException {
-				
-		client.setBaseURL(solrUrl+ "/" + collectionName);
+
+	public SingleNetworkSolrIdxManager(String networkId, SolrClientWrapper client,
+			Cx2NodeIndexService nodeIndexService) {
+		this.collectionName = networkId;
+		this.client = client;
+		this.nodeIndexService = nodeIndexService;
+	}
+
+	public SolrDocumentList getNodeIdsByQuery(String query, int limit)
+			throws SolrServerException, IOException, NdexException {
 
 		SolrQuery solrQuery = new SolrQuery();
-		
+
 		solrQuery.setQuery(SearchUtilities.preprocessSearchTerm(query)).setFields(ID);
-    	solrQuery.set("defType", "edismax");
-		solrQuery.set("qf", NAME + " " + CxNode.REPRESENTS + " " + ALIAS + " " + TEXT);
+		solrQuery.set("defType", "edismax");
+		solrQuery.set("qf", NAME + " " + CxNode.REPRESENTS + " " + NodeIndexFields.ALIAS + " " + TEXT);
 		solrQuery.setStart(0);
-		if (limit >0)
+		if (limit > 0)
 			solrQuery.setRows(limit);
-		else 
+		else
 			solrQuery.setRows(30000000);
-		
-		try {
-			QueryResponse rsp = client.query(solrQuery, METHOD.POST);
-			SolrDocumentList dds = rsp.getResults();
-			return dds;
-		} catch (BaseHttpSolrClient.RemoteSolrException e) {
-			throw NetworkGlobalIndexManager.convertException(e, collectionName);
+
+		return client.query(collectionName, solrQuery).getResults();
+	}
+
+	/**
+	 * Makes sure this network's query core exists, creating and populating it when the network
+	 * is small enough to index on demand.
+	 *
+	 * <p>Any failure while building the index propagates unchanged: the reason a rebuild could
+	 * not read a network's aspect files is the whole diagnostic, so it must not be replaced by
+	 * a generic message here.
+	 *
+	 * @param expectedNodeCount node count the database reports for this network
+	 * @throws NdexException when the core is absent and cannot be created now
+	 */
+	public void ensureReady(int expectedNodeCount)
+			throws SolrServerException, IOException, NdexException {
+
+		if (client.coreExists(collectionName)) {
+			return;
+		}
+
+		if (expectedNodeCount >= AUTOCREATE_THRESHHOLD) {
+			throw new NdexException(
+					"NDEx server hasn't finished creating index on this network yet. Please try again later");
+		}
+
+		synchronized (coreCreationLock()) {
+			// another thread may have created it while we waited
+			if (client.coreExists(collectionName)) {
+				return;
+			}
+			createDefaultIndex(expectedNodeCount);
 		}
 	}
-	
-	public boolean isReady (boolean autoCreate) throws SolrServerException, IOException, NdexException {
-		return coreIsReady(this, autoCreate);
+
+	private Object coreCreationLock() {
+		int stripe = Math.abs(collectionName.hashCode() % CORE_CREATION_STRIPES);
+		return CORE_CREATION_LOCKS[stripe];
 	}
-	private static synchronized boolean coreIsReady(SingleNetworkSolrIdxManager mgr, boolean autoCreate) throws SolrServerException, IOException, NdexException {
-		CoreAdminResponse rp = CoreAdminRequest.getStatus(mgr.getNetworkId(), mgr.getClient());
-		//	CoreStatus r = CoreAdminRequest.getCoreStatus(mgr.getNetworkId(), mgr.getClient());
-		//int d = rp.getStatus();
-		NamedList<NamedList<Object>> o1 = rp.getCoreStatus();
-		//System.out.println(o1);
-		NamedList<Object> o11 = o1.get(mgr.getNetworkId());
-		//System.out.println(o11);
-		
-		//NamedList<Object> o2 = rp.getResponse();
-		//System.out.println(o2);
-		if ( o11.size() !=0)
-			return true;
-		if ( autoCreate) {
-			mgr.createDefaultIndex();
-			return true;
+
+	/**
+	 * Creates this network's query core and populates it.
+	 *
+	 * @param extraIndexFields extra node attributes to index; when null the shared
+	 *                         {@value #NODE_CONFIG_SET} configSet is used
+	 * @param expectedNodeCount node count the database reports for this network
+	 * @return number of documents committed to Solr
+	 */
+	public int createIndex(Set<String> extraIndexFields, int expectedNodeCount)
+			throws SolrServerException, IOException, NdexException {
+
+		if (extraIndexFields == null) {
+			return createDefaultIndex(expectedNodeCount);
 		}
-		return false;
-	}
-	
-	
-	
-	public void createIndex(Set<String> extraIndexFields) throws SolrServerException, IOException, NdexException {
-		
-		if ( extraIndexFields == null) {
-			 createDefaultIndex();
-			 return;
-		}
-		
+
 		//create a configSet from template first.
-		ConfigSetAdminRequest.Create confSetCreator = new ConfigSetAdminRequest.Create();
-		confSetCreator.setBaseConfigSetName("ndex-nodes-template");
-		confSetCreator.setConfigSetName(collectionName);
-		
-		ConfigSetAdminResponse cr = confSetCreator.process(client);
-		
-		if ( cr.getStatus() != 0 ) {
-			throw new NdexException("Failed to create Solr ConfigSet " + collectionName);
-		}
-		
-		//CollectionAdminRequest.Create creator = CollectionAdminRequest.createCollection(collectionName,"ndex-nodes",1 , 1); 
-		CoreAdminRequest.Create creator = new CoreAdminRequest.Create(); 
-		creator.setCoreName(collectionName);
-		creator.setConfigSet(
-				collectionName); 
-		creator.setIsLoadOnStartup(Boolean.FALSE);
-		creator.setIsTransient(Boolean.TRUE); 
-		
-	//	"data_driven_schema_configs");
-		CoreAdminResponse foo = creator.process(client);	
-	
-		if ( foo.getStatus() != 0 ) {
-			throw new NdexException ("Failed to create solrIndex for network " + collectionName + ". Error: " + foo.getResponseHeader().toString());
-		}
-		
-		client.setBaseURL(solrUrl + "/" + collectionName);
+		client.createConfigSet(collectionName, NODE_CONFIG_SET_TEMPLATE);
+		client.createCore(collectionName, collectionName);
 
-		//extend the schema
-	/*	if  ( extraIndexFields !=null ) {
-			for (String fieldName: extraIndexFields ) {
-				 Map<String, Object> fieldAttributes = new LinkedHashMap<>();
-				 fieldAttributes.put("name", fieldName);
-				 fieldAttributes.put("type", "text_ws");
-				 fieldAttributes.put("stored", false);
-				 fieldAttributes.put("required", false);
-				 SchemaRequest.AddField addFieldUpdateSchemaRequest = new SchemaRequest.AddField(fieldAttributes);
-				 SchemaResponse.UpdateResponse addFieldResponse = addFieldUpdateSchemaRequest.process(client);
-				 System.out.println(addFieldResponse.getStatus());
-			}
-		}
-		
-		 SchemaRequest.Fields fieldsSchemaRequest = new SchemaRequest.Fields();
-		 SchemaResponse.FieldsResponse currentFieldsResponse = fieldsSchemaRequest.process(client);
-		 List<Map<String, Object>> currentFields = currentFieldsResponse.getFields();
-		 System.out.println(currentFields);
-	*/	
-		counter = 0;
-		docs = new ArrayList<>(batchSize);
-			
-		Map<Long,NodeIndexEntry> tab = createIndexDocsFromCx2(collectionName);
-		for ( NodeIndexEntry e : tab.values()) {
-			addNodeIndex(e.getId(), e.getName(),e.getRepresents() ,e.getAliases(),e.getText());
-		}
-		
-		commit();
+		return populateIndex(expectedNodeCount);
 	}
-	
-	public void createIndexFromCx2 (Set<String> extraIndexFields) throws NdexException, SolrServerException, IOException {
-		if (extraIndexFields !=null) 
+
+	/**
+	 * Creates this network's query core from its CX2 aspect files and populates it.
+	 *
+	 * @param extraIndexFields must be null; extra attribute indexing is not implemented
+	 * @param expectedNodeCount node count the database reports for this network
+	 * @return number of documents committed to Solr
+	 */
+	public int createIndexFromCx2(Set<String> extraIndexFields, int expectedNodeCount)
+			throws NdexException, SolrServerException, IOException {
+
+		if (extraIndexFields != null)
 			throw new NdexException("Additional node attribute indexing is not implmented yet.");
-		
-		createDefaultIndex();
-	} 
-	
-	
-	private void createDefaultIndex() throws SolrServerException, IOException, NdexException {
 
-		createNewCore();
-		
-		Map<Long,NodeIndexEntry> tab =  createIndexDocsFromCx2(collectionName);
-		for ( NodeIndexEntry e : tab.values()) {
-			/*if ( e.isMemberIsToBeIndexed() && e.getMembers().size()>0) {
-				e.getRepresents().addAll(e.getMembers());
-			}*/
-			addNodeIndex(e.getId(), e.getName(),e.getRepresents() ,e.getAliases(),e.getText());
-		}
-		
-		commit();
+		return createDefaultIndex(expectedNodeCount);
 	}
 
-	private void createNewCore() throws SolrServerException, IOException, NdexException {
-		CoreAdminRequest.Create creator = new CoreAdminRequest.Create(); 
-		creator.setCoreName(collectionName);
-		creator.setConfigSet(
-				"ndex-nodes"); 
-		creator.setIsLoadOnStartup(Boolean.FALSE);
-		creator.setIsTransient(Boolean.TRUE); 
-		
-	//	"data_driven_schema_configs");
-		CoreAdminResponse foo = creator.process(client);	
-	
-		if ( foo.getStatus() != 0 ) {
-			throw new NdexException ("Failed to create solrIndex for network " + collectionName + ". Error: " + foo.getResponseHeader().toString());
-		}
-		
-		client.setBaseURL(solrUrl + "/" + collectionName);
+	private int createDefaultIndex(int expectedNodeCount)
+			throws SolrServerException, IOException, NdexException {
+
+		client.createCore(collectionName, NODE_CONFIG_SET);
+
+		return populateIndex(expectedNodeCount);
+	}
+
+	/**
+	 * Loads the node index entries, sends them to Solr in batches, commits, then reports how
+	 * many documents Solr actually holds.
+	 */
+	private int populateIndex(int expectedNodeCount)
+			throws SolrServerException, IOException, NdexException {
 
 		counter = 0;
 		docs = new ArrayList<>(batchSize);
 
-	}
-	
+		Map<Long, NodeIndexEntry> tab = nodeIndexService.loadNodeIndexEntries(collectionName);
+		for (NodeIndexEntry e : tab.values()) {
+			addNodeIndex(e.getId(), e.getName(), e.getRepresents(), e.getAliases(), e.getText());
+		}
 
-	
+		// Commit unconditionally. The trailing batch may be empty - when the entry count is an
+		// exact multiple of batchSize every document has already been flushed - and skipping
+		// the commit in that case would leave the whole index uncommitted and unsearchable.
+		client.commit(collectionName, docs, true);
+		docs.clear();
+
+		int committed = getCommittedDocCount();
+		verifyDocCount(committed, expectedNodeCount);
+		return committed;
+	}
+
+	/**
+	 * Asks Solr how many documents are in the core, rather than trusting the count of documents
+	 * we tried to send. This catches a failed commit as well as a failed build.
+	 */
+	private int getCommittedDocCount() throws SolrServerException, IOException, NdexException {
+		SolrQuery countQuery = new SolrQuery("*:*");
+		countQuery.setRows(0);
+		return (int) client.query(collectionName, countQuery).getResults().getNumFound();
+	}
+
+	private void verifyDocCount(int committed, int expectedNodeCount) throws NdexException {
+
+		if (committed == 0 && expectedNodeCount > 0) {
+			throw new NdexException("Created Solr query index for network " + collectionName
+					+ " but it holds no documents, while the database reports " + expectedNodeCount
+					+ " nodes. Queries on this network would return no results.");
+		}
+
+		if (committed < expectedNodeCount) {
+			// Normal: nodes carrying no name, represents or alias attribute are not indexed.
+			logger.warn("Solr query index for network {} holds {} documents for {} nodes; "
+					+ "nodes without an indexable attribute are not indexed.",
+					collectionName, committed, expectedNodeCount);
+		}
+	}
+
 	public void dropIndex() throws IOException, SolrServerException, NdexException {
-		try {
-			client.setBaseURL(solrUrl);
-		//	CollectionAdminRequest.deleteCollection(collectionName).process(client);
-			
-			CoreAdminRequest.unloadCore(collectionName, true, true, client);
-		} catch (HttpSolrClient.RemoteSolrException e4) {
-			if ( e4.getMessage().indexOf("Cannot unload non-existent core") == -1) {
-				e4.printStackTrace();
-				throw new NdexException("Unexpected Solr Exception: " + e4.getMessage());
-			}	
-		} 
-		
-		/**
-		 * One reference implementation to check if a core exists
-		 * CommonsHttpSolrServer adminServer = new
-			CommonsHttpSolrServer(solrRootUrl);
-			CoreAdminResponse status =
-			CoreAdminRequest.getStatus(coreName, adminServer);
-
-			return status.getCoreStatus(coreName).get("instanceDir") != null;
-		 */
+		client.dropCore(collectionName);
 	}
-	
-	private void addNodeIndex(Long id, String name, Collection<String> represents, Collection<String> alias, Collection<String> txtArray) throws SolrServerException, IOException {
-		
-		SolrInputDocument doc = NodeIndexDocumentBuilder.buildNodeDocument(id, name, represents, alias, txtArray);
+
+	private void addNodeIndex(Long id, String name, Collection<String> represents,
+			Collection<String> alias, Collection<String> txtArray)
+			throws SolrServerException, IOException {
+
+		SolrInputDocument doc = NodeIndexDocumentBuilder.buildNodeDocument(id, name, represents,
+				alias, txtArray);
 		docs.add(doc);
-		counter ++;
-		if ( counter % batchSize == 0 ) {
-			client.add(docs);
-			docs.clear();
-		}
-
-	}
-
-	
-	private void commit() throws SolrServerException, IOException {
-		if ( docs.size()>0 ) {
-			client.add(docs);
-			client.commit(true,true);
+		counter++;
+		if (counter % batchSize == 0) {
+			client.add(collectionName, docs);
 			docs.clear();
 		}
 	}
-	
-	
+
 	@Override
-	public void close () {
-		try {
-			client.close();
-		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-	}
-	
-/*	private static Map<Long,NodeIndexEntry> createIndexDocs(String coreName) throws JsonProcessingException, IOException, NdexException {
-		Map<Long,NodeIndexEntry> result = new TreeMap<> ();
-		
-		String pathPrefix = Configuration.getInstance().getNdexRoot() + "/data/" + coreName + "/aspects/"; 
-	
-		//go through node aspect
-		try (FileInputStream inputStream = new FileInputStream(pathPrefix + "nodes")) {
-
-			Iterator<NodesElement> it = new ObjectMapper().readerFor(NodesElement.class).readValues(inputStream);
-
-			while (it.hasNext()) {
-	        	NodesElement node = it.next();
-	        	
-	        	List<String> represents = getIndexableTerms(node.getNodeRepresents());
-	        	if ( node.getNodeName() != null || represents.size() > 0) {
-	        		NodeIndexEntry e = new NodeIndexEntry(node.getId(), node.getNodeName());
-	        		if ( represents .size() > 0 ) 
-	        			e.setRepresents(represents);	     
-	        		result.put(node.getId(), e);
-	        	}
-			}
-		}
-		
-		// go through Function Term if it exists
-		java.nio.file.Path functionTermAspect = Paths.get(pathPrefix + FunctionTermElement.ASPECT_NAME);
-
-		if ( Files.exists(functionTermAspect)) { 
-			try (FileInputStream inputStream = new FileInputStream(pathPrefix + FunctionTermElement.ASPECT_NAME)) {
-
-				Iterator<FunctionTermElement> it = new ObjectMapper().readerFor(FunctionTermElement.class).readValues(inputStream);
-
-				while (it.hasNext()) {
-		        	FunctionTermElement functionTerm = it.next();
-		        	List<String> terms = NetworkGlobalIndexManager.getIndexableStringsFromFunctionTerm(functionTerm);
-		        	if ( terms.size() > 0 ) {
-			        	NodeIndexEntry e = result.get(functionTerm.getNodeID());
-		        		if ( e == null ) {  // need to add a new entry
-		        			e = new NodeIndexEntry(functionTerm.getNodeID(), null);
-		        			result.put(functionTerm.getNodeID(), e);
-		        		}	        	
-		        		e.setRepresents(terms);
-		        	}	
-				}
-				
-				
-			}	
-		}
-		
-		//go through node attributes to find aliases
-
-		try (AspectIterator<NodeAttributesElement> it = new AspectIterator<>(coreName,NodeAttributesElement.ASPECT_NAME, 
-				   NodeAttributesElement.class, Configuration.getInstance().getNdexRoot() + "/data/")) {
-	//	try (FileInputStream inputStream = new FileInputStream(pathPrefix + NodeAttributesElement.ASPECT_NAME)) {
-
-	//		Iterator<NodeAttributesElement> it = new ObjectMapper().readerFor(NodeAttributesElement.class).readValues(inputStream);
-
-			while (it.hasNext()) {
-	        	NodeAttributesElement attr = it.next();
-	        	String attrName = attr.getName().toLowerCase(); // doing case insensitive check
-	        	if ( attrName.equals("alias")) {
-	        		List<String>  l = getIndexableTerms(attr);
-	        		if ( l.size() > 0 ) {
-	        			NodeIndexEntry e = result.get(attr.getPropertyOf());
-	        			if ( e == null) {
-	        				e = new NodeIndexEntry(attr.getPropertyOf(), null);
-	        				result.put(attr.getPropertyOf(), e);
-	        			}
-	        			e.setAliases(l);
-	        		}
-	        	} else if ( attrName.equals("type")) {
-	        		if ( (attr.getDataType() == null || attr.getDataType() == ATTRIBUTE_DATA_TYPE.STRING) && 
-	        				attr.getValue() != null && attr.getValue().length()>0 ) {
-	        			String typeStr = attr.getValue().trim().toLowerCase();
-	        			if ( typeStr.equals("complex") || typeStr.equals("proteinfamily")) {
-		        			NodeIndexEntry e = result.get(attr.getPropertyOf());
-		        			if ( e != null) {
-		        				e.setMemberIsToBeIndexed(true);
-		        			} else {
-		        				throw new NdexException("Node " + attr.getPropertyOf() + " is not found in node Aspect.");
-		        			}
-	        			}
-	        		}	
-	        	} else if ( attrName.equals("member")) {
-	        		NodeIndexEntry e = result.get(attr.getPropertyOf());
-        			if ( e != null) {
-    	        		List<String>  l = getIndexableTerms(attr);
-    	        		if ( l.size() > 0 ) 
-    	        			e.setMembers(l);
-        			} else {
-        				throw new NdexException("Node " + attr.getPropertyOf() + " is not found in node Aspect.");
-        			}
-	        	}
-			}
-		}
-		
-		return result;
-	}
-	*/
-	
-	private static  Map<Long,NodeIndexEntry> createIndexDocsFromCx2(String coreName) throws JsonProcessingException, IOException {
-		Map<Long,NodeIndexEntry> result = new TreeMap<> ();
-		
-		String pathPrefix = Configuration.getInstance().getNdexRoot() + "/data/" + coreName + "/" + CX2NetworkLoader.cx2AspectDirName + "/"; 
-	
-		ObjectMapper om = new ObjectMapper();
-		
-		//create the attribute name mapping table from attribute declaration
-		File declFile = new File(pathPrefix + CxAttributeDeclaration.ASPECT_NAME);
-		if (!declFile.exists())
-			return result;
-		
-		CxAttributeDeclaration[] declarations = om.readValue(declFile, 
-				CxAttributeDeclaration[].class); 
-		
-		if ( declarations.length == 0 || ! declarations[0].getDeclarations().containsKey(CxNode.ASPECT_NAME))
-			return result;
-		
-		Map<String,DeclarationEntry> nodeAttributeDecls = declarations[0].getAttributesInAspect(CxNode.ASPECT_NAME);
-		if ( nodeAttributeDecls.size() == 0 )
-			return result;
-		
-		//key is lowercased attribute name that we need to index, 
-		//value is the actual attribute name in the node. This is for doing a case-insensitive lookup of attribute value.
-		Map<String, Map.Entry<String,DeclarationEntry>> attributeNameMapping = new HashMap<> ();
-		for ( Map.Entry<String,DeclarationEntry> entry: nodeAttributeDecls.entrySet()) {
-			ATTRIBUTE_DATA_TYPE dType = entry.getValue().getDataType();
-			String attrName = entry.getKey();
-			
-			if ( dType == null || dType == ATTRIBUTE_DATA_TYPE.STRING || dType == ATTRIBUTE_DATA_TYPE.LIST_OF_STRING) {
-				if( attrName.equalsIgnoreCase(ALIAS)) {
-                    attributeNameMapping.put (ALIAS, entry);					
-                } else if ( attrName.equalsIgnoreCase(TYPE)) {
-                    attributeNameMapping.put (TYPE, entry);
-                } else if ( attrName.equalsIgnoreCase(MEMBER)) {
-                    attributeNameMapping.put (MEMBER, entry);
-                } else 
-                    attributeNameMapping.put (attrName, entry);
-			}	 	
-		}
-		
-		//go through node aspect
-		try (FileInputStream inputStream = new FileInputStream(pathPrefix + "nodes")) {
-
-			Iterator<CxNode> it = om.readerFor(CxNode.class).readValues(inputStream);
-
-			while (it.hasNext()) {
-	        	CxNode node = it.next();
-	        	
-	        	node.extendToFullNode(nodeAttributeDecls);
-	        	
-	        	//Map<String, Object> attrs = node.getAttributes();
-	        	NodeIndexEntry e = null;
-	        	String name = getSingleIndexableTermFromNode(CxNode.NAME,node,attributeNameMapping);
-	        	if ( name !=null) {
-	        		e =  new NodeIndexEntry(node.getId(), name);
-	        	}
-	        	List<String> represents = getSplitableTerms(CxNode.REPRESENTS, node, attributeNameMapping);
-	        	if ( represents.size()>0) {
-	        		if ( e ==null)
-	        			e = new NodeIndexEntry(node.getId(),null);
-	        		e.setRepresents(represents);	     
-	        	}
-
-	        	// process alias
-	        	List<String> aliases =  getSplitableTerms(ALIAS, node, attributeNameMapping);
-	        	if ( aliases.size() > 0 ) {
-	        		if ( e==null)
-	        			e= new  NodeIndexEntry(node.getId(),null);
-	        		e.setAliases(aliases);
-	        	}
-	        	
-	        	//process members
-	        	boolean proteinMembersFound = false;
-	        	Map.Entry<String,DeclarationEntry> typeAttrName = attributeNameMapping.get(TYPE);
-	        	if (typeAttrName !=null ) {
-	        		ATTRIBUTE_DATA_TYPE t = typeAttrName.getValue().getDataType();
-	        		if ( t == null || t == ATTRIBUTE_DATA_TYPE.STRING) {
-	        			String nodeType = (String)node.getAttributes().get(typeAttrName.getKey());
-	        			if ( nodeType != null && (nodeType.equalsIgnoreCase(PROTEINFAMILY) || 
-	        					nodeType.equalsIgnoreCase(COMPLEX) )) {
-	        				List<String> memberGenes = getSplitableTerms (MEMBER, node, attributeNameMapping);
-	        				if( e==null)
-	        					e = new NodeIndexEntry ( node.getId(),null);
-	        				e.getRepresents().addAll(memberGenes);
-	        				proteinMembersFound = true;
-	        			}
-	        		}	
-	        	}
-	        	
-	        	//process the rest of the attributes
-	        	for (Map.Entry<String, Map.Entry<String,DeclarationEntry>> attrDecl:  attributeNameMapping.entrySet()) {
-	        		String attrName = attrDecl.getKey();
-	        		if ( attrName.equals(CxNode.NAME) || attrName.equals(CxNode.REPRESENTS) || 
-	        				attrName.equals(ALIAS))
-	        			continue;
-	        		if ( proteinMembersFound && attrName.equals(MEMBER)) 
-	        			continue;
-	        		
-	        		// process the value
-	        		Map.Entry<String,DeclarationEntry> decl = attrDecl.getValue();
-	        		Object  attrValue = node.getAttributes().get(decl.getKey());
-	        		ATTRIBUTE_DATA_TYPE dType = decl.getValue().getDataType();
-	        		if ( dType == null || dType == ATTRIBUTE_DATA_TYPE.STRING) {
-	        			if ( attrValue !=null ) { 
-	        				String s = (String) attrValue;
-	        				if ( s.length() > 1) {
-	        					if( e==null)
-		        					e = new NodeIndexEntry ( node.getId(),null);
-	        					e.addText(s);
-	        				}	
-	        			}	
-	        		} else {  // list of strings
- 	        			List<String> ls = (List<String>)attrValue;
- 	        			if (ls != null ) {
- 	        				for ( String str: ls) {
- 	        					if ( str!=null && str.length()>1) {
- 	        						if( e==null)
- 	   	        					   e = new NodeIndexEntry ( node.getId(),null);
- 	        						e.addText(str);
- 	        					}
- 	        				}
- 	        			}
-	        		}
-	        		
-	        	}
-	        	
-	        	if ( e!=null)
-	        		result.put(node.getId(), e);
-
-			}
-		}
-		
-		// go through Function Term if it exists
-		java.nio.file.Path functionTermAspect = Paths.get(pathPrefix + FunctionTermElement.ASPECT_NAME);
-
-		if ( Files.exists(functionTermAspect)) { 
-			try (FileInputStream inputStream = new FileInputStream(pathPrefix + FunctionTermElement.ASPECT_NAME)) {
-
-				Iterator<FunctionTermElement> it = new ObjectMapper().readerFor(FunctionTermElement.class).readValues(inputStream);
-
-				while (it.hasNext()) {
-		        	FunctionTermElement functionTerm = it.next();
-		        	List<String> terms = NetworkGlobalIndexManager.getIndexableStringsFromFunctionTerm(functionTerm);
-		        	if ( terms.size() > 0 ) {
-			        	NodeIndexEntry e = result.get(functionTerm.getNodeID());
-		        		if ( e == null ) {  // need to add a new entry
-		        			e = new NodeIndexEntry(functionTerm.getNodeID(), null);
-		        			result.put(functionTerm.getNodeID(), e);
-		        		}	        	
-		        		e.setRepresents(terms);
-		        	}	
-				}
-				
-				
-			}	
-		}
-		
-		
-		return result;
+	public void close() {
+		client.close();
 	}
 
-	protected static String getSingleIndexableTermFromNode (String attrName, CxNode node, 
-			Map<String, Map.Entry<String,DeclarationEntry>> attributeNameMapping) {		
-	
-		Map.Entry<String,DeclarationEntry> entry = attributeNameMapping.get(attrName);
-	
-		if ( entry != null) {
-			String actualAttrName = entry.getKey();
-			ATTRIBUTE_DATA_TYPE t = entry.getValue().getDataType();
-			if ( t == null || t== ATTRIBUTE_DATA_TYPE.STRING)  {
-				return (String)node.getAttributes().get(actualAttrName);
-			}
-		
-		}
-	
-		return null;
+	protected String getNetworkId() {
+		return collectionName;
 	}
-	
-	protected static List<String> getSplitableTerms (String attrName, CxNode node, 
-				Map<String, Map.Entry<String,DeclarationEntry>> attributeNameMapping) {		
-	
-		List<String> result = new ArrayList<>();
-
-		Map.Entry<String,DeclarationEntry> entry = attributeNameMapping.get(attrName);
-		
-		if ( entry != null) {
-			String actualAttrName = entry.getKey();
-			ATTRIBUTE_DATA_TYPE t = entry.getValue().getDataType();
-			
-			if ( t == null || t == ATTRIBUTE_DATA_TYPE.STRING) {
-				String v = (String)node.getAttributes().get(actualAttrName);
-				if ( v!= null) {
-					for ( String indexableString : NetworkGlobalIndexManager.getIndexableString(v) ){
-						result.add( indexableString);
-					}
-				}
-			} else if (t == ATTRIBUTE_DATA_TYPE.LIST_OF_STRING) {
-				List<String> vl = (List<String>)node.getAttributes().get(actualAttrName);
-				if(vl !=null) {
-					for ( String v : vl) {
-						for ( String indexableString : NetworkGlobalIndexManager.getIndexableString(v) ){
-							result.add( indexableString);
-						}
-					}
-				}
-			} 
-						
-		}
-		
-		return result;
-
-	}
-	
-	private static List<String> getIndexableTerms (String originalString) {		
-		if (originalString == null) return new ArrayList<>(1);
-		return NetworkGlobalIndexManager.getIndexableString(originalString);
-	}
-	
-	private static List<String> getIndexableTerms (NodeAttributesElement e) {		
-		List<String> result = new ArrayList<>();
-		
-		if ( e.getDataType() == ATTRIBUTE_DATA_TYPE.LIST_OF_STRING 	&& !e.getValues().isEmpty()) {
-			for ( String v : e.getValues()) {
-				for ( String indexableString : NetworkGlobalIndexManager.getIndexableString(v) ){
-					result.add( indexableString);
-				}
-			}
-		} else if ( e.getDataType() == ATTRIBUTE_DATA_TYPE.STRING) {
-			String v = e.getValue();
-			for ( String indexableString : NetworkGlobalIndexManager.getIndexableString(v) ){
-				result.add( indexableString);
-			}
-		}
-		
-		return result;
-	}
-	
-	protected String getNetworkId () {return collectionName;}
-	protected HttpSolrClient getClient() {return this.client;}
 }

--- a/src/main/java/org/ndexbio/common/solr/SolrClientWrapper.java
+++ b/src/main/java/org/ndexbio/common/solr/SolrClientWrapper.java
@@ -18,10 +18,78 @@ public interface SolrClientWrapper extends AutoCloseable {
 	/**
 	 * Creates core in Solr if it does not already exist
 	 * @param coreName Name of core
-	 * @throws NdexException 
+	 * @throws NdexException
 	 */
 	void createCoreIfNeeded(final String coreName) throws SolrServerException, IOException, NdexException;
-	
+
+	/**
+	 * Creates core in Solr if it does not already exist, using a named configSet.
+	 *
+	 * <p>Use this when the configSet is shared rather than named after the core, as the
+	 * per-network node cores are: they all share the {@code ndex-nodes} configSet.
+	 *
+	 * @param coreName      Name of core
+	 * @param configSetName Name of the configSet the core should use
+	 * @throws NdexException
+	 */
+	void createCoreIfNeeded(final String coreName, final String configSetName) throws SolrServerException, IOException, NdexException;
+
+	/**
+	 * Reports whether a core is registered in Solr.
+	 *
+	 * @param coreName Name of core
+	 * @return true when Solr knows about the core
+	 * @throws NdexException
+	 */
+	boolean coreExists(final String coreName) throws SolrServerException, IOException, NdexException;
+
+	/**
+	 * Creates a core, failing if it already exists.
+	 *
+	 * <p>Unlike {@link #createCoreIfNeeded(String, String)} this does not swallow an
+	 * "already exists" response - callers that treat a pre-existing core as a distinct
+	 * outcome rely on seeing that error.
+	 *
+	 * @param coreName      Name of core to create
+	 * @param configSetName configSet the core should use
+	 * @throws NdexException
+	 */
+	void createCore(final String coreName, final String configSetName) throws SolrServerException, IOException, NdexException;
+
+	/**
+	 * Creates a configSet by cloning a template configSet.
+	 *
+	 * @param configSetName     Name of the configSet to create
+	 * @param baseConfigSetName Name of the template to clone from
+	 * @throws NdexException
+	 */
+	void createConfigSet(final String configSetName, final String baseConfigSetName) throws SolrServerException, IOException, NdexException;
+
+	/**
+	 * Adds documents to a core without committing. Use for batching a large document set;
+	 * follow the final batch with a commit.
+	 *
+	 * @param coreName  Name of core
+	 * @param documents Documents to add; null or empty is a no-op
+	 * @throws SolrServerException
+	 * @throws IOException
+	 */
+	void add(final String coreName, Collection<SolrInputDocument> documents) throws SolrServerException, IOException;
+
+	/**
+	 * Commits documents, choosing between a soft and a hard commit.
+	 *
+	 * <p>A hard commit flushes to disk, so it is what index <em>creation</em> should use - a
+	 * soft-committed index is visible but not durable until a later autoCommit fires.
+	 *
+	 * @param coreName    Name of core
+	 * @param documents   Documents to add before committing; null or empty just commits
+	 * @param hardCommit  true for a hard (durable) commit, false for a soft commit
+	 * @throws SolrServerException
+	 * @throws IOException
+	 */
+	void commit(final String coreName, Collection<SolrInputDocument> documents, boolean hardCommit) throws SolrServerException, IOException;
+
 	/**
 	 * Removes core from Solr completely (deletes filesystem data)
 	 * where a core contains one or more indexes

--- a/src/main/java/org/ndexbio/common/solr/SolrClientWrapperImpl.java
+++ b/src/main/java/org/ndexbio/common/solr/SolrClientWrapperImpl.java
@@ -12,7 +12,9 @@ import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.BaseHttpSolrClient;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
+import org.apache.solr.client.solrj.request.ConfigSetAdminRequest;
 import org.apache.solr.client.solrj.request.CoreAdminRequest;
+import org.apache.solr.client.solrj.response.ConfigSetAdminResponse;
 import org.apache.solr.client.solrj.response.CoreAdminResponse;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrInputDocument;
@@ -81,32 +83,108 @@ public class SolrClientWrapperImpl implements SolrClientWrapper {
 	 */
 	@Override
 	public void createCoreIfNeeded(final String coreName) throws SolrServerException, IOException, NdexException {
+		createCoreIfNeeded(coreName, coreName);
+	}
+
+	/**
+	 * Creates core on Solr if needed using the given configSet. If core exists, nothing is done
+	 *
+	 * @param coreName Name of core
+	 * @param configSetName configSet the core should use
+	 * @throws SolrServerException
+	 * @throws IOException
+	 * @throws NdexException
+	 */
+	@Override
+	public void createCoreIfNeeded(final String coreName, final String configSetName) throws SolrServerException, IOException, NdexException {
+
+		if ( coreExists(coreName) ) {
+			logger.debug("Found core "+ coreName + " in Solr.");
+			return;
+		}
+
+		logger.debug("Solr core " + coreName + " doesn't exist. Creating it now ....");
+
+		CoreAdminRequest.Create creator = _factory.getCoreAdminRequestCreate();
+		creator.setCoreName(coreName);
+		creator.setConfigSet(configSetName);
+		CoreAdminResponse foo = creator.process(_baseClient);
+		if ( foo.getStatus() != 0 ) {
+			throw new NdexException ("Failed to create solrIndex for " + coreName + ". Error: " + foo.getResponseHeader().toString());
+		}
+		logger.debug("Done.");
+	}
+
+	/**
+	 * Creates a core, letting an "already exists" error surface to the caller
+	 *
+	 * @param coreName Name of core
+	 * @param configSetName configSet the core should use
+	 * @throws SolrServerException
+	 * @throws IOException
+	 * @throws NdexException
+	 */
+	@Override
+	public void createCore(final String coreName, final String configSetName) throws SolrServerException, IOException, NdexException {
+
+		CoreAdminRequest.Create creator = _factory.getCoreAdminRequestCreate();
+		creator.setCoreName(coreName);
+		creator.setConfigSet(configSetName);
+		creator.setIsLoadOnStartup(Boolean.FALSE);
+		creator.setIsTransient(Boolean.TRUE);
+
+		CoreAdminResponse foo = creator.process(_baseClient);
+		if ( foo.getStatus() != 0 ) {
+			throw new NdexException ("Failed to create solrIndex for network " + coreName + ". Error: " + foo.getResponseHeader().toString());
+		}
+	}
+
+	/**
+	 * Creates a configSet cloned from a template configSet
+	 *
+	 * @param configSetName Name of configSet to create
+	 * @param baseConfigSetName Template to clone
+	 * @throws SolrServerException
+	 * @throws IOException
+	 * @throws NdexException
+	 */
+	@Override
+	public void createConfigSet(final String configSetName, final String baseConfigSetName) throws SolrServerException, IOException, NdexException {
+
+		ConfigSetAdminRequest.Create confSetCreator = _factory.getConfigSetAdminRequestCreate();
+		confSetCreator.setBaseConfigSetName(baseConfigSetName);
+		confSetCreator.setConfigSetName(configSetName);
+
+		ConfigSetAdminResponse cr = confSetCreator.process(_baseClient);
+		if ( cr.getStatus() != 0 ) {
+			throw new NdexException("Failed to create Solr ConfigSet " + configSetName);
+		}
+	}
+
+	/**
+	 * Reports whether Solr has a core registered under coreName
+	 *
+	 * @param coreName Name of core
+	 * @throws SolrServerException
+	 * @throws IOException
+	 * @throws NdexException
+	 */
+	@Override
+	public boolean coreExists(final String coreName) throws SolrServerException, IOException, NdexException {
 
 		CoreAdminResponse foo = _factory.getCoreAdminRequestGetStatus(coreName);
 		if (foo.getStatus() != 0 ) {
 			throw new NdexException ("Failed to get status of solrIndex for " + coreName + ". Error: " + foo.getResponseHeader().toString());
 		}
 		NamedList<Object> bar = foo.getResponse();
-		
+
 		NamedList<Object> st = (NamedList<Object>)bar.get("status");
-		
+		if ( st == null ) {
+			return false;
+		}
+
 		NamedList<Object> core = (NamedList<Object>)st.get(coreName);
-		if ( core.size() == 0 ) {
-			logger.debug("Solr core " + coreName + " doesn't exist. Creating it now ....");
-
-			CoreAdminRequest.Create creator = _factory.getCoreAdminRequestCreate();
-			creator.setCoreName(coreName);
-			creator.setConfigSet(coreName); 
-			foo = creator.process(_baseClient);				
-			if ( foo.getStatus() != 0 ) {
-				throw new NdexException ("Failed to create solrIndex for " + coreName + ". Error: " + foo.getResponseHeader().toString());
-			}
-			logger.debug("Done.");		
-		}
-		else {
-			logger.debug("Found core "+ coreName + " in Solr.");	
-		}
-
+		return core != null && core.size() != 0;
 	}
 
 	/**
@@ -140,18 +218,49 @@ public class SolrClientWrapperImpl implements SolrClientWrapper {
 	 */
 	@Override
 	public void commit(final String coreName, final Collection<SolrInputDocument> documents) throws SolrServerException, IOException {
+		commit(coreName, documents, false);
+	}
+
+	/**
+	 * Adds any documents passed in, then commits. A hard commit flushes to disk
+	 * (waitFlush=true, softCommit=false); a soft commit only makes the documents visible.
+	 *
+	 * @param coreName Core to commit
+	 * @param documents documents to add
+	 * @param hardCommit whether the commit should be durable
+	 * @throws SolrServerException
+	 * @throws IOException
+	 */
+	@Override
+	public void commit(final String coreName, final Collection<SolrInputDocument> documents, final boolean hardCommit) throws SolrServerException, IOException {
 
 		var client = getSolrClient(coreName);
-		if (documents != null && documents.isEmpty() == false){
-			var ur = client.add(documents);
-			if (ur != null && logger.isDebugEnabled()){
-				logger.debug("add: " + ur.toString());
-			}
-		}
-		
-		var ur = client.commit(false, true, true);
+		add(coreName, documents);
+
+		var ur = hardCommit ? client.commit(true, true, false) : client.commit(false, true, true);
 		if (ur != null && logger.isDebugEnabled()){
 			logger.debug("commit response: " + ur.toString());
+		}
+	}
+
+	/**
+	 * Adds documents to a core without committing
+	 *
+	 * @param coreName Core to add to
+	 * @param documents documents to add; null or empty is a no-op
+	 * @throws SolrServerException
+	 * @throws IOException
+	 */
+	@Override
+	public void add(final String coreName, final Collection<SolrInputDocument> documents) throws SolrServerException, IOException {
+
+		if (documents == null || documents.isEmpty()){
+			return;
+		}
+
+		var ur = getSolrClient(coreName).add(documents);
+		if (ur != null && logger.isDebugEnabled()){
+			logger.debug("add: " + ur.toString());
 		}
 	}
 

--- a/src/main/java/org/ndexbio/common/solr/SolrIndexBuilder.java
+++ b/src/main/java/org/ndexbio/common/solr/SolrIndexBuilder.java
@@ -5,6 +5,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -47,11 +48,19 @@ public class SolrIndexBuilder implements AutoCloseable {
 	public SolrIndexBuilder () throws NdexException, SolrServerException, IOException {
 		  globalIdx = new NetworkGlobalIndexManager();
 	      globalIdx.createCoreIfNotExists();
-		
+
+	}
+
+	/**
+	 * Test constructor. The public constructor reaches Solr while building its global index
+	 * manager, so tests supply one instead of having it created for them.
+	 */
+	SolrIndexBuilder (NetworkGlobalIndexManager globalIdx) {
+		this.globalIdx = globalIdx;
 	}
 	
 	
-	private  void rebuildNetworkIndex (UUID networkid, boolean ignoreDeletion ) throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
+	void rebuildNetworkIndex (UUID networkid, boolean ignoreDeletion ) throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO()) {
 		  logger.info("Rebuild solr index of network " + networkid);
 		  NetworkSummary summary = dao.getNetworkSummaryById(networkid);
@@ -59,7 +68,7 @@ public class SolrIndexBuilder implements AutoCloseable {
 			  throw new NdexException ("Network "+ networkid + " not found in the server." );
 		  
 		  dao.lockNetwork(networkid);
-		  try (SingleNetworkSolrIdxManager idx2 = new SingleNetworkSolrIdxManager(networkid.toString())) {
+		  try (SingleNetworkSolrIdxManager idx2 = Configuration.getInstance().getSolrObjectFactory().getSingleNetworkSolrIdxManager(networkid.toString())) {
 		  
 			  if (!ignoreDeletion) {
 				try {
@@ -74,10 +83,11 @@ public class SolrIndexBuilder implements AutoCloseable {
 			  }		
 			  if (summary.getNodeCount() >= SingleNetworkSolrIdxManager.AUTOCREATE_THRESHHOLD ) {
 					
-					idx2.createIndex(null);
+					int committed = idx2.createIndex(null, summary.getNodeCount());
 					idx2.close();
-				
-				    logger.info("Solr index for query created.");
+
+				    logger.info("Solr index for query created for network {} with {} documents.",
+				    		networkid, committed);
 			  } 
 		  
 			  if ( summary.getIndexLevel() != NetworkIndexLevel.NONE) {
@@ -225,15 +235,14 @@ public class SolrIndexBuilder implements AutoCloseable {
 	}
 	
 	
-	private static  void rebuildLocalNetworkIndex (UUID networkid, boolean ignoreDeletion ) throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
+	void rebuildLocalNetworkIndex (UUID networkid, boolean ignoreDeletion ) throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO()) {
 		  logger.info("Rebuild local index of " + networkid);
 		  NetworkSummary summary = dao.getNetworkSummaryById(networkid);
 		  if (summary == null)
 			  throw new NdexException ("Network "+ networkid + " not found in the server." );
 		  
-		  //dao.lockNetwork(networkid);
-		  try (SingleNetworkSolrIdxManager idx2 = new SingleNetworkSolrIdxManager(networkid.toString())) {
+		  try (SingleNetworkSolrIdxManager idx2 = Configuration.getInstance().getSolrObjectFactory().getSingleNetworkSolrIdxManager(networkid.toString())) {
 		  
 			  if (!ignoreDeletion) {
 				try {
@@ -246,10 +255,11 @@ public class SolrIndexBuilder implements AutoCloseable {
 			  }		
 			  if (summary.getNodeCount() >= SingleNetworkSolrIdxManager.AUTOCREATE_THRESHHOLD ) {
 					
-					idx2.createIndex(null);
+					int committed = idx2.createIndex(null, summary.getNodeCount());
 					idx2.close();
-				
-				    logger.info("Solr index for query created.");
+
+				    logger.info("Solr index for query created for network {} with {} documents.",
+				    		networkid, committed);
 			  }   			 	
 			
 		  }	 
@@ -302,12 +312,10 @@ public class SolrIndexBuilder implements AutoCloseable {
 			try (PreparedStatement pst = db.prepareStatement(sqlStr)) {
 				try ( ResultSet rs = pst.executeQuery()) {
 					while (rs.next()) {
-				       //int nodeCount = rs.getInt(2);
 						rebuildNetworkIndexInGlobalIdx((UUID)rs.getObject(1), true);
 					   i ++;
 					   if ( i % 1000 == 0 ) {
 						   System.err.println("Loaded " + i + " records to solr. sleep 2 seconds");
-						//   globalIdx.commit();
 						   try {
 							  Thread.sleep(2000);
 						   } catch (InterruptedException e) {
@@ -319,12 +327,11 @@ public class SolrIndexBuilder implements AutoCloseable {
 				}
 			}
 		}
-	//	globalIdx.commit();
 		logger.info("Indexes of all networks have been rebuilt.");
 	}
 	
 
-	private static  void rebuildAllLocalIdx() throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
+	private  void rebuildAllLocalIdx() throws SQLException, JsonParseException, JsonMappingException, IOException, NdexException, SolrServerException {
 		try (PostgresNetworkDAO dao = new PostgresNetworkDAO ()) {
 			@SuppressWarnings("resource")
 			Connection db = dao.getDBConnection();
@@ -332,27 +339,18 @@ public class SolrIndexBuilder implements AutoCloseable {
 					+ SingleNetworkSolrIdxManager.AUTOCREATE_THRESHHOLD ;
 			
 			int i = 0;
-			int j = 0; 
+			int j = 0;
+			List<String> failedNetworks = new ArrayList<>();
 			try (PreparedStatement pst = db.prepareStatement(sqlStr)) {
 				try ( ResultSet rs = pst.executeQuery()) {
 					while (rs.next()) {
-				       //int nodeCount = rs.getInt(2);
 						UUID netid = (UUID)rs.getObject(1);
-						try {
-							rebuildLocalNetworkIndex(netid, true);
+						if (runLocalIndexStep(netid, failedNetworks)) {
 							j++;
-						} catch (HttpSolrClient.RemoteSolrException e4) {
-							if ( e4.getMessage().indexOf("Core with name '"+
-						             netid.toString() +  "' already exists") == -1) {
-								e4.printStackTrace();
-								throw new NdexException("Unexpected Solr Exception: " + e4.getMessage());
-							}	
-							logger.info("index exists. Ignore creating it.");
-						} 
+						}
 					   i ++;
 					   if ( i % 500 == 0 ) {
 						   System.err.println("Loaded " + i + " records to solr. sleep 2 seconds");
-						//   globalIdx.commit();
 						   try {
 							  Thread.sleep(2000);
 						   } catch (InterruptedException e) {
@@ -364,8 +362,8 @@ public class SolrIndexBuilder implements AutoCloseable {
 				}
 			}
 			logger.info("Local index of " + i + " networks have been checked. " + j + " are created." );
+			logSweepSummary("all-local", j, failedNetworks);
 		}
-	//	globalIdx.commit();
 	}
 
 	
@@ -376,34 +374,96 @@ public class SolrIndexBuilder implements AutoCloseable {
 			String sqlStr = "select \"UUID\" from network n where n.iscomplete and n.is_deleted=false and n.is_validated and n.error is null";
 			
 			int i = 0;
+			int succeeded = 0;
+			List<String> failedNetworks = new ArrayList<>();
 			try (PreparedStatement pst = db.prepareStatement(sqlStr)) {
 				try ( ResultSet rs = pst.executeQuery()) {
 					while (rs.next()) {
-				       //int nodeCount = rs.getInt(2);
 					   UUID networkId = (UUID)rs.getObject(1);
-					   try {
-						   
-						   rebuildNetworkIndex(networkId, false);
-					   } catch(Exception ex){
-						   logger.error("Failed to rebuild index for network: " + networkId.toString());
+					   if (runNetworkIndexStep(networkId, failedNetworks)) {
+						   succeeded++;
 					   }
 					   i ++;
 					   if ( i % 500 == 0 ) {
 						   System.err.println("Loaded " + i + " records to solr. sleep 2 seconds");
-						//   globalIdx.commit();
 						   try {
 							  Thread.sleep(2000);
 						   } catch (InterruptedException e) {
 							  // TODO Auto-generated catch block
 							  e.printStackTrace();
 						   }
-					   }	   
+					   }
 					}
 				}
 			}
+			logSweepSummary("all-networks-online", succeeded, failedNetworks);
 		}
-	//	globalIdx.commit();
 		logger.info("Indexes of all networks have been rebuilt.");
+	}
+
+	/**
+	 * Rebuilds one network's index as part of a sweep.
+	 *
+	 * <p>A failure here concerns only this network: it is logged once at WARN with the reason
+	 * carried by the exception, recorded in {@code failedNetworks}, and never rethrown, so the
+	 * caller's loop continues to the next network.
+	 *
+	 * @return true when the network was indexed
+	 */
+	boolean runNetworkIndexStep(UUID networkId, List<String> failedNetworks) {
+		try {
+			rebuildNetworkIndex(networkId, false);
+			return true;
+		} catch (Exception ex) {
+			failedNetworks.add(networkId.toString());
+			logger.warn("Failed to rebuild index for network {}: {}", networkId, ex.getMessage(), ex);
+			return false;
+		}
+	}
+
+	/**
+	 * Creates one network's local query index as part of a sweep.
+	 *
+	 * <p>A core that already exists is not a failure - this command only fills in missing ones.
+	 * Anything else is this network's problem alone: logged once at WARN and never rethrown.
+	 * This previously rethrew, which aborted the whole sweep on the first bad network.
+	 *
+	 * @return true when an index was created
+	 */
+	boolean runLocalIndexStep(UUID networkId, List<String> failedNetworks) {
+		try {
+			rebuildLocalNetworkIndex(networkId, true);
+			return true;
+		} catch (HttpSolrClient.RemoteSolrException e4) {
+			if (e4.getMessage() != null && e4.getMessage().indexOf("Core with name '"
+					+ networkId.toString() + "' already exists") != -1) {
+				logger.info("index exists. Ignore creating it.");
+				return false;
+			}
+			failedNetworks.add(networkId.toString());
+			logger.warn("Failed to create local index for network {}: {}",
+					networkId, e4.getMessage(), e4);
+			return false;
+		} catch (Exception e) {
+			failedNetworks.add(networkId.toString());
+			logger.warn("Failed to create local index for network {}: {}",
+					networkId, e.getMessage(), e);
+			return false;
+		}
+	}
+
+	/**
+	 * Reports the outcome of a sweep so a run that quietly failed on every network is visible
+	 * without grepping the whole log. Never changes the process exit status - the loops are
+	 * designed to always run to completion.
+	 */
+	private static void logSweepSummary(String command, int succeeded, List<String> failed) {
+		if (failed.isEmpty()) {
+			logger.info("{}: {} networks indexed, 0 failed.", command, succeeded);
+			return;
+		}
+		logger.warn("{}: {} networks indexed, {} failed. Failed network ids: {}",
+				command, succeeded, failed.size(), String.join(", ", failed));
 	}
 
 	
@@ -612,7 +672,7 @@ public class SolrIndexBuilder implements AutoCloseable {
 				builder.rebuildGlobalIdx();
 				break;
 			case "all-local":
-				SolrIndexBuilder.rebuildAllLocalIdx();
+				builder.rebuildAllLocalIdx();
 				break;
 			case "nfs":
 				SolrIndexBuilder.rebuildNFSIdx();

--- a/src/main/java/org/ndexbio/common/solr/SolrObjectFactory.java
+++ b/src/main/java/org/ndexbio/common/solr/SolrObjectFactory.java
@@ -3,6 +3,7 @@ package org.ndexbio.common.solr;
 import java.io.IOException;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.request.ConfigSetAdminRequest;
 import org.apache.solr.client.solrj.request.CoreAdminRequest;
 import org.apache.solr.client.solrj.response.CoreAdminResponse;
 
@@ -32,10 +33,17 @@ public interface SolrObjectFactory {
 	
 	/**
 	 * Creates CoreAdminRequest.Create object
-	 * @return 
+	 * @return
 	 */
 	public CoreAdminRequest.Create getCoreAdminRequestCreate();
-	
+
+	/**
+	 * Creates ConfigSetAdminRequest.Create object, used when a core needs its own
+	 * configSet cloned from a template rather than sharing a static one.
+	 * @return
+	 */
+	public ConfigSetAdminRequest.Create getConfigSetAdminRequestCreate();
+
 	
 	/**
 	 * Removes core from Solr
@@ -51,6 +59,14 @@ public interface SolrObjectFactory {
 	public GlobalNetworkIndexManager getGlobalNetworkIndexManager();
 	public FolderIndexManager getFolderIndexManager();
 	public ShortcutIndexManager getShortcutIndexManager();
+
+	/**
+	 * Gets a manager for one network's node query index, wired with its own Solr client
+	 * and CX2 aspect reader.
+	 *
+	 * @param networkId network UUID, which is also its Solr core name
+	 */
+	public SingleNetworkSolrIdxManager getSingleNetworkSolrIdxManager(final String networkId);
 
 
 }

--- a/src/main/java/org/ndexbio/common/solr/SolrObjectFactoryImpl.java
+++ b/src/main/java/org/ndexbio/common/solr/SolrObjectFactoryImpl.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.Http2SolrClient;
+import org.apache.solr.client.solrj.request.ConfigSetAdminRequest;
 import org.apache.solr.client.solrj.request.CoreAdminRequest;
 import org.apache.solr.client.solrj.response.CoreAdminResponse;
 
@@ -16,15 +17,19 @@ import org.apache.solr.client.solrj.response.CoreAdminResponse;
 public class SolrObjectFactoryImpl implements SolrObjectFactory {
 
 	private final String _baseSolrUrl;
+	private final String _ndexRoot;
 	private static final String SLASH = "/";
-	
+
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @param baseSolrUrl Should be URL to solr service ie http://localhost:8983/solr
+	 * @param ndexRoot NDEx data root, used to locate the CX2 aspect files that node indexes
+	 *                 are built from ie /opt/ndex
 	 */
-	public SolrObjectFactoryImpl(final String baseSolrUrl){
+	public SolrObjectFactoryImpl(final String baseSolrUrl, final String ndexRoot){
 		_baseSolrUrl = baseSolrUrl;
+		_ndexRoot = ndexRoot;
 	}
 	
 	/**
@@ -50,7 +55,11 @@ public class SolrObjectFactoryImpl implements SolrObjectFactory {
 	 */
 	@Override
 	public CoreAdminResponse getCoreAdminRequestGetStatus(final String coreName) throws IOException, SolrServerException {
-		return CoreAdminRequest.getStatus(coreName, getSolrClient(null));
+		// getSolrClient builds a new client per call, and Http2SolrClient owns non-daemon Jetty
+		// threads - leaving it open keeps a CLI process alive after main() returns.
+		try (SolrClient client = getSolrClient(null)) {
+			return CoreAdminRequest.getStatus(coreName, client);
+		}
 	}
 
 	/**
@@ -60,6 +69,15 @@ public class SolrObjectFactoryImpl implements SolrObjectFactory {
 	@Override
 	public CoreAdminRequest.Create getCoreAdminRequestCreate() {
 		return new CoreAdminRequest.Create();
+	}
+
+	/**
+	 * Creates ConfigSetAdminRequest.Create.
+	 * @return
+	 */
+	@Override
+	public ConfigSetAdminRequest.Create getConfigSetAdminRequestCreate() {
+		return new ConfigSetAdminRequest.Create();
 	}
 
 	/**
@@ -73,7 +91,9 @@ public class SolrObjectFactoryImpl implements SolrObjectFactory {
 	 */
 	@Override
 	public CoreAdminResponse getCoreAdminRequestUnloadCore(final String coreName, boolean deleteIndex, boolean deleteInstanceDir) throws IOException, SolrServerException {
-		return CoreAdminRequest.unloadCore(coreName, deleteIndex, deleteInstanceDir, getSolrClient(null));
+		try (SolrClient client = getSolrClient(null)) {
+			return CoreAdminRequest.unloadCore(coreName, deleteIndex, deleteInstanceDir, client);
+		}
 	}
 
 	@Override
@@ -89,6 +109,12 @@ public class SolrObjectFactoryImpl implements SolrObjectFactory {
 	@Override
 	public ShortcutIndexManager getShortcutIndexManager() {
 		return new ShortcutIndexManager(new SolrClientWrapperImpl(this));
+	}
+
+	@Override
+	public SingleNetworkSolrIdxManager getSingleNetworkSolrIdxManager(final String networkId) {
+		return new SingleNetworkSolrIdxManager(networkId, new SolrClientWrapperImpl(this),
+				new Cx2NodeIndexServiceImpl(_ndexRoot));
 	}
 
 

--- a/src/main/java/org/ndexbio/rest/Configuration.java
+++ b/src/main/java/org/ndexbio/rest/Configuration.java
@@ -209,14 +209,18 @@ public class Configuration
             	solrURL = defaultSolrURL;
 			
 			defaultMaxSearchResultRows = getDefaultMaxSearchResultRowsFromConfiguration();
-            solrObjectFactory = new SolrObjectFactoryImpl(solrURL);
+
+            // read before the Solr factory is built: the factory hands the data root to the
+            // CX2 aspect reader that node indexes are built from.
+            this.ndexRoot = getRequiredProperty("NdexRoot");
+
+            solrObjectFactory = new SolrObjectFactoryImpl(solrURL, this.ndexRoot);
 			this.searchFactory = new SearchProviderFactoryImpl(solrObjectFactory, defaultMaxSearchResultRows);
-			
+
             this.ndexSystemUser = getRequiredProperty("NdexSystemUser");
             this.ndexSystemUserPassword = getRequiredProperty("NdexSystemUserPassword");
 			this.migrationPassword = getRequiredProperty("MigrationPassword");
 
-            this.ndexRoot = getRequiredProperty("NdexRoot");
             hostURI = getRequiredProperty("HostURI");
 
             this.networkStorePath = this.ndexRoot + "/data/";

--- a/src/main/java/org/ndexbio/rest/services/NetworkServiceV2.java
+++ b/src/main/java/org/ndexbio/rest/services/NetworkServiceV2.java
@@ -1506,13 +1506,6 @@ public class NetworkServiceV2 extends NdexService {
 			if(networkDao.isAdmin(networkId, userId) ) {
 				if (!networkDao.isReadOnly(networkId) ) {
 					if ( !networkDao.networkIsLocked(networkId)) {
-					/*
-						NetworkGlobalIndexManager globalIdx = new NetworkGlobalIndexManager();
-						globalIdx.deleteNetwork(id);
-						try (SingleNetworkSolrIdxManager idxManager = new SingleNetworkSolrIdxManager(id)) {
-							idxManager.dropIndex();
-						}	
-					*/	
 						networkDao.deleteNetwork(UUID.fromString(id), getLoggedInUser().getExternalId());
 						networkDao.commit();
 

--- a/src/main/java/org/ndexbio/rest/services/SearchServiceV2.java
+++ b/src/main/java/org/ndexbio/rest/services/SearchServiceV2.java
@@ -246,7 +246,8 @@ public class SearchServiceV2 extends NdexService {
 
 		}   
 		
-		try (SingleNetworkSolrIdxManager solr = new SingleNetworkSolrIdxManager(networkId.toString())) {
+		try (SingleNetworkSolrIdxManager solr = Configuration.getInstance().getSolrObjectFactory()
+				.getSingleNetworkSolrIdxManager(networkId.toString())) {
 			SolrDocumentList r = solr.getNodeIdsByQuery(queryParameters.getSearchString(), limit);
 			return r;
 		}
@@ -362,14 +363,12 @@ public class SearchServiceV2 extends NdexService {
 	public static void getSolrIdxReady(UUID networkId, PostgresNetworkDAO dao)
 			throws SQLException, ObjectNotFoundException, SolrServerException, IOException, NdexException {
 		int nodeCount = dao.getNodeCount(networkId);
-		
-		try (SingleNetworkSolrIdxManager solr = new SingleNetworkSolrIdxManager(networkId.toString())) {
-			boolean ready = solr.isReady(nodeCount < SingleNetworkSolrIdxManager.AUTOCREATE_THRESHHOLD);
-			if ( !ready ) {
-				if (nodeCount < SingleNetworkSolrIdxManager.AUTOCREATE_THRESHHOLD) 
-					throw new NdexException ("Failed to create Solr Index on this network.");
-				throw new NdexException("NDEx server hasn't finished creating index on this network yet. Please try again later");
-			}
+
+		try (SingleNetworkSolrIdxManager solr = Configuration.getInstance().getSolrObjectFactory()
+				.getSingleNetworkSolrIdxManager(networkId.toString())) {
+			// Any failure carries its own reason - an unreadable aspect directory names the path
+			// and the OS user - so let it propagate rather than flattening it to a generic message.
+			solr.ensureReady(nodeCount);
 		}
 	}
 	

--- a/src/main/java/org/ndexbio/rest/services/UserService.java
+++ b/src/main/java/org/ndexbio/rest/services/UserService.java
@@ -179,8 +179,9 @@ public class UserService extends NdexService {
 			User user = userdao.createNewUser(newUser, verificationCode);
 			
 			if ( verificationCode == null) {
-				UserIndexManager mgr = new UserIndexManager();
-				mgr.addUser(user.getExternalId().toString(), user.getUserName(), user.getFirstName(), user.getLastName(), user.getDisplayName(), user.getDescription());
+				try (UserIndexManager mgr = new UserIndexManager()) {
+					mgr.addUser(user.getExternalId().toString(), user.getUserName(), user.getFirstName(), user.getLastName(), user.getDisplayName(), user.getDescription());
+				}
 			}
 			
 			userdao.commit();

--- a/src/main/java/org/ndexbio/server/migration/v2/util/CX2NetworkCreationRunner.java
+++ b/src/main/java/org/ndexbio/server/migration/v2/util/CX2NetworkCreationRunner.java
@@ -18,6 +18,7 @@ import org.ndexbio.common.persistence.CXNetworkLoader;
 import org.ndexbio.common.persistence.CXToCX2ServerSideConverter;
 import org.ndexbio.common.solr.NetworkGlobalIndexManager;
 import org.ndexbio.common.solr.SingleNetworkSolrIdxManager;
+import org.ndexbio.rest.Configuration;
 import org.ndexbio.common.util.Util;
 import org.ndexbio.cx2.aspect.element.core.CxMetadata;
 import org.ndexbio.cxio.core.writers.NiceCXCX2Writer;
@@ -122,7 +123,7 @@ public class CX2NetworkCreationRunner implements Callable {
 					_sb.append(" has error. Error message is: ");
 					_sb.append(e.getMessage());
 					_globalIdx.deleteNetwork(_networkUUID.toString());
-					try (SingleNetworkSolrIdxManager networkIdx = new SingleNetworkSolrIdxManager(_networkUUID.toString())) {
+					try (SingleNetworkSolrIdxManager networkIdx = Configuration.getInstance().getSolrObjectFactory().getSingleNetworkSolrIdxManager(_networkUUID.toString())) {
 						networkIdx.dropIndex();
 					}
 				}

--- a/src/main/java/org/ndexbio/server/migration/v3/NFSReIndexer.java
+++ b/src/main/java/org/ndexbio/server/migration/v3/NFSReIndexer.java
@@ -101,14 +101,16 @@ public class NFSReIndexer implements Runnable,AutoCloseable {
 
     public void resetIndexes() throws Exception {
         logger.info("Resetting NFS Solr indexes...");
-        try (FolderIndexManager fim = solrObjectFactory.getFolderIndexManager()) {
+        // Each getSolrClient call builds a new client owning non-daemon Jetty threads, so these
+        // must be closed or a CLI run never exits after main() returns.
+        try (FolderIndexManager fim = solrObjectFactory.getFolderIndexManager();
+             SolrClient publicClient = solrObjectFactory.getSolrClient(NFSIndexManager.publicCoreName);
+             SolrClient privateClient = solrObjectFactory.getSolrClient(NFSIndexManager.privateCoreName)) {
             fim.createCoreIfNeeded();
 
-            SolrClient publicClient = solrObjectFactory.getSolrClient(NFSIndexManager.publicCoreName);
             publicClient.deleteByQuery("*:*");
             publicClient.commit();
 
-            SolrClient privateClient = solrObjectFactory.getSolrClient(NFSIndexManager.privateCoreName);
             privateClient.deleteByQuery("*:*");
             privateClient.commit();
         }
@@ -162,7 +164,7 @@ public class NFSReIndexer implements Runnable,AutoCloseable {
                                 (foldersProcessed * 100) / totalFolders);
                     }
                 } catch (Exception e) {
-                    logger.info("Failed to reindex folder " + folderId, e);
+                    logger.warn("Failed to reindex folder {}: {}", folderId, e.getMessage(), e);
                 }
             }
         }
@@ -216,7 +218,7 @@ public class NFSReIndexer implements Runnable,AutoCloseable {
                                 (shortcutsProcessed * 100) / totalShortcuts);
                     }
                 } catch (Exception e) {
-                    logger.info("Failed to reindex shortcut " + shortcutId, e);
+                    logger.warn("Failed to reindex shortcut {}: {}", shortcutId, e.getMessage(), e);
                 }
             }
         }
@@ -293,7 +295,7 @@ public class NFSReIndexer implements Runnable,AutoCloseable {
                                 (networksProcessed * 100) / totalNetworks);
                     }
                 } catch (Exception e) {
-                    logger.info("Failed to reindex network " + networkId, e);
+                    logger.warn("Failed to reindex network {}: {}", networkId, e.getMessage(), e);
                 }
             }
         }
@@ -338,7 +340,7 @@ public class NFSReIndexer implements Runnable,AutoCloseable {
                     globalNetworkIndexManager.delete(id, visibilityType);
 
                     if ( idxScope == SolrIndexScope.both)
-                        try (SingleNetworkSolrIdxManager idx2 = new SingleNetworkSolrIdxManager(fileId.toString())) {
+                        try (SingleNetworkSolrIdxManager idx2 = solrObjectFactory.getSingleNetworkSolrIdxManager(fileId.toString())) {
                             idx2.dropIndex();
                         }
                 }
@@ -346,11 +348,13 @@ public class NFSReIndexer implements Runnable,AutoCloseable {
                 //build the individual index for queries
                 if (idxScope == SolrIndexScope.both) {
                     long t1 = Calendar.getInstance().getTimeInMillis();
-                    try (SingleNetworkSolrIdxManager idx2 = new SingleNetworkSolrIdxManager(fileId.toString())) {
-                        idx2.createIndexFromCx2(null);
+                    int committedDocs;
+                    try (SingleNetworkSolrIdxManager idx2 = solrObjectFactory.getSingleNetworkSolrIdxManager(fileId.toString())) {
+                        committedDocs = idx2.createIndexFromCx2(null, summary.getNodeCount());
                     }
                     long t = Calendar.getInstance().getTimeInMillis() - t1;
-                    logger.info("Takes {} secs to create index for network {}", t / 1000, fileId);
+                    logger.info("Takes {} secs to create index for network {} with {} documents",
+                            t / 1000, fileId, committedDocs);
                 }
 
 
@@ -498,18 +502,18 @@ public class NFSReIndexer implements Runnable,AutoCloseable {
                 if ( entry.getValue().getDataType() == null ||
                         entry.getValue().getDataType() == ATTRIBUTE_DATA_TYPE.STRING)
                     attributeNameMapping.put (CxNode.REPRESENTS, entry);
-            } else if ( attrName.equalsIgnoreCase(SingleNetworkSolrIdxManager.ALIAS) ) {
+            } else if ( attrName.equalsIgnoreCase(NodeIndexFields.ALIAS) ) {
                 if ( entry.getValue().getDataType() == ATTRIBUTE_DATA_TYPE.LIST_OF_STRING) {
-                    attributeNameMapping.put (SingleNetworkSolrIdxManager.ALIAS, entry);
+                    attributeNameMapping.put (NodeIndexFields.ALIAS, entry);
                 }
-            } else if ( attrName.equalsIgnoreCase(SingleNetworkSolrIdxManager.TYPE)) {
+            } else if ( attrName.equalsIgnoreCase(NodeIndexFields.TYPE)) {
                 if ( entry.getValue().getDataType() == null ||
                         entry.getValue().getDataType() == ATTRIBUTE_DATA_TYPE.STRING)
-                    attributeNameMapping.put (SingleNetworkSolrIdxManager.TYPE, entry);
-            } else if ( attrName.equalsIgnoreCase(SingleNetworkSolrIdxManager.MEMBER)) {
+                    attributeNameMapping.put (NodeIndexFields.TYPE, entry);
+            } else if ( attrName.equalsIgnoreCase(NodeIndexFields.MEMBER)) {
                 if ( entry.getValue().getDataType() == null ||
                         entry.getValue().getDataType() == ATTRIBUTE_DATA_TYPE.STRING)
-                    attributeNameMapping.put (SingleNetworkSolrIdxManager.MEMBER, entry);
+                    attributeNameMapping.put (NodeIndexFields.MEMBER, entry);
             }
 
         }

--- a/src/main/java/org/ndexbio/server/migration/v3/V3Migrator.java
+++ b/src/main/java/org/ndexbio/server/migration/v3/V3Migrator.java
@@ -412,18 +412,18 @@ public class V3Migrator implements AutoCloseable {
 				if ( entry.getValue().getDataType() == null ||
 						entry.getValue().getDataType() == ATTRIBUTE_DATA_TYPE.STRING)
 					attributeNameMapping.put (CxNode.REPRESENTS, entry);
-			} else if ( attrName.equalsIgnoreCase(SingleNetworkSolrIdxManager.ALIAS) ) {
+			} else if ( attrName.equalsIgnoreCase(NodeIndexFields.ALIAS) ) {
 				if ( entry.getValue().getDataType() == ATTRIBUTE_DATA_TYPE.LIST_OF_STRING) {
-					attributeNameMapping.put (SingleNetworkSolrIdxManager.ALIAS, entry);
+					attributeNameMapping.put (NodeIndexFields.ALIAS, entry);
 				}
-			} else if ( attrName.equalsIgnoreCase(SingleNetworkSolrIdxManager.TYPE)) {
+			} else if ( attrName.equalsIgnoreCase(NodeIndexFields.TYPE)) {
 				if ( entry.getValue().getDataType() == null ||
 						entry.getValue().getDataType() == ATTRIBUTE_DATA_TYPE.STRING)
-					attributeNameMapping.put (SingleNetworkSolrIdxManager.TYPE, entry);
-			} else if ( attrName.equalsIgnoreCase(SingleNetworkSolrIdxManager.MEMBER)) {
+					attributeNameMapping.put (NodeIndexFields.TYPE, entry);
+			} else if ( attrName.equalsIgnoreCase(NodeIndexFields.MEMBER)) {
 				if ( entry.getValue().getDataType() == null ||
 						entry.getValue().getDataType() == ATTRIBUTE_DATA_TYPE.STRING)
-					attributeNameMapping.put (SingleNetworkSolrIdxManager.MEMBER, entry);
+					attributeNameMapping.put (NodeIndexFields.MEMBER, entry);
 			}
 
 		}

--- a/src/main/java/org/ndexbio/task/SolrTaskDeleteFile.java
+++ b/src/main/java/org/ndexbio/task/SolrTaskDeleteFile.java
@@ -42,7 +42,7 @@ public class SolrTaskDeleteFile extends NdexSystemTask {
 		try(FolderIndexManager globalIdx = Configuration.getInstance().getSolrObjectFactory().getFolderIndexManager()) {
 			globalIdx.delete(id, visibilityType);
 			if (!globalIdxOnly) {
-				try (SingleNetworkSolrIdxManager idxManager = new SingleNetworkSolrIdxManager(id)) {
+				try (SingleNetworkSolrIdxManager idxManager = Configuration.getInstance().getSolrObjectFactory().getSingleNetworkSolrIdxManager(id)) {
 					idxManager.dropIndex();
 				}
 			}

--- a/src/main/java/org/ndexbio/task/SolrTaskDeleteNetwork.java
+++ b/src/main/java/org/ndexbio/task/SolrTaskDeleteNetwork.java
@@ -42,7 +42,7 @@ public class SolrTaskDeleteNetwork extends NdexSystemTask {
 		try(GlobalNetworkIndexManager globalIdx = Configuration.getInstance().getSolrObjectFactory().getGlobalNetworkIndexManager()) {
 			globalIdx.delete(id, visibilityType);
 			if (!globalIdxOnly) {
-				try (SingleNetworkSolrIdxManager idxManager = new SingleNetworkSolrIdxManager(id)) {
+				try (SingleNetworkSolrIdxManager idxManager = Configuration.getInstance().getSolrObjectFactory().getSingleNetworkSolrIdxManager(id)) {
 					idxManager.dropIndex();
 				}		
 			}

--- a/src/main/java/org/ndexbio/task/SolrTaskRebuildFileIdx.java
+++ b/src/main/java/org/ndexbio/task/SolrTaskRebuildFileIdx.java
@@ -164,18 +164,19 @@ public class SolrTaskRebuildFileIdx extends NdexSystemTask {
 
 				}
 				if (idxScope != SolrIndexScope.global)
-					try (SingleNetworkSolrIdxManager idx2 = new SingleNetworkSolrIdxManager(id)) {
+					try (SingleNetworkSolrIdxManager idx2 = solrObjectFactory.getSingleNetworkSolrIdxManager(id)) {
 						idx2.dropIndex();
 					}
 			}
 
 			if (idxScope != SolrIndexScope.global) {
 				long t1 = Calendar.getInstance().getTimeInMillis();
-				try (SingleNetworkSolrIdxManager idx2 = new SingleNetworkSolrIdxManager(id)) {
-					idx2.createIndexFromCx2(null);
+				int committedDocs;
+				try (SingleNetworkSolrIdxManager idx2 = solrObjectFactory.getSingleNetworkSolrIdxManager(id)) {
+					committedDocs = idx2.createIndexFromCx2(null, summary.getNodeCount());
 				}
 				long t = Calendar.getInstance().getTimeInMillis() - t1;
-                log.info("Takes {} secs to create index", t / 1000);
+                log.info("Takes {} secs to create index with {} documents", t / 1000, committedDocs);
 			}
 
             try (GlobalNetworkIndexManager globalIdx = solrObjectFactory.getGlobalNetworkIndexManager()) {
@@ -312,18 +313,18 @@ public class SolrTaskRebuildFileIdx extends NdexSystemTask {
 				if ( entry.getValue().getDataType() == null ||
 						entry.getValue().getDataType() == ATTRIBUTE_DATA_TYPE.STRING)
 					attributeNameMapping.put (CxNode.REPRESENTS, entry);
-			} else if ( attrName.equalsIgnoreCase(SingleNetworkSolrIdxManager.ALIAS) ) {
+			} else if ( attrName.equalsIgnoreCase(NodeIndexFields.ALIAS) ) {
 				if ( entry.getValue().getDataType() == ATTRIBUTE_DATA_TYPE.LIST_OF_STRING) {
-					attributeNameMapping.put (SingleNetworkSolrIdxManager.ALIAS, entry);
+					attributeNameMapping.put (NodeIndexFields.ALIAS, entry);
 				}
-			} else if ( attrName.equalsIgnoreCase(SingleNetworkSolrIdxManager.TYPE)) {
+			} else if ( attrName.equalsIgnoreCase(NodeIndexFields.TYPE)) {
 				if ( entry.getValue().getDataType() == null ||
 						entry.getValue().getDataType() == ATTRIBUTE_DATA_TYPE.STRING)
-					attributeNameMapping.put (SingleNetworkSolrIdxManager.TYPE, entry);
-			} else if ( attrName.equalsIgnoreCase(SingleNetworkSolrIdxManager.MEMBER)) {
+					attributeNameMapping.put (NodeIndexFields.TYPE, entry);
+			} else if ( attrName.equalsIgnoreCase(NodeIndexFields.MEMBER)) {
 				if ( entry.getValue().getDataType() == null ||
 						entry.getValue().getDataType() == ATTRIBUTE_DATA_TYPE.STRING)
-					attributeNameMapping.put (SingleNetworkSolrIdxManager.MEMBER, entry);
+					attributeNameMapping.put (NodeIndexFields.MEMBER, entry);
 			}
 
 		}

--- a/src/main/java/org/ndexbio/task/SolrTaskRebuildNetworkIdx.java
+++ b/src/main/java/org/ndexbio/task/SolrTaskRebuildNetworkIdx.java
@@ -20,6 +20,8 @@ import org.ndexbio.common.persistence.CX2NetworkLoader;
 import org.ndexbio.common.solr.GlobalNetworkIndexManager;
 import org.ndexbio.common.solr.NetworkGlobalIndexManager;
 import org.ndexbio.common.solr.SingleNetworkSolrIdxManager;
+import org.ndexbio.common.solr.NodeIndexFields;
+import org.ndexbio.common.solr.SolrObjectFactory;
 import org.ndexbio.cx2.aspect.element.core.CxAttributeDeclaration;
 import org.ndexbio.cx2.aspect.element.core.CxNetworkAttribute;
 import org.ndexbio.cx2.aspect.element.core.CxNode;
@@ -59,6 +61,7 @@ public class SolrTaskRebuildNetworkIdx extends NdexSystemTask {
     public static final String FORMCX2FILE = "fromCX2";
     private Set<String> indexedFields;
     private NetworkIndexLevel indexLevel;
+    private final SolrObjectFactory solrObjectFactory;
     
 	
 	public SolrTaskRebuildNetworkIdx (UUID networkUUID, SolrIndexScope scope, boolean createOnly, 
@@ -70,6 +73,7 @@ public class SolrTaskRebuildNetworkIdx extends NdexSystemTask {
 		this.indexedFields =indexedFields;
 		this.indexLevel = NetworkIndexLevel.ALL;
 		this.fromCX2File = fromCX2File;
+		this.solrObjectFactory = Configuration.getInstance().getSolrObjectFactory();
 	}
 	
 	@Override
@@ -91,22 +95,24 @@ public class SolrTaskRebuildNetworkIdx extends NdexSystemTask {
 					}
 				}
 				if (idxScope != SolrIndexScope.global)
-					try (SingleNetworkSolrIdxManager idx2 = new SingleNetworkSolrIdxManager(networkId.toString())) {
+					try (SingleNetworkSolrIdxManager idx2 = solrObjectFactory.getSingleNetworkSolrIdxManager(networkId.toString())) {
 						idx2.dropIndex();
 					}
 			}
 
 			if (this.idxScope != SolrIndexScope.global) {
 				long t1 = Calendar.getInstance().getTimeInMillis();
-				try (SingleNetworkSolrIdxManager idx2 = new SingleNetworkSolrIdxManager(networkId.toString())) {
+				int committedDocs;
+				try (SingleNetworkSolrIdxManager idx2 = solrObjectFactory.getSingleNetworkSolrIdxManager(networkId.toString())) {
 					if (this.fromCX2File)
-						idx2.createIndexFromCx2(indexedFields);
+						committedDocs = idx2.createIndexFromCx2(indexedFields, summary.getNodeCount());
 					else
-						idx2.createIndex(indexedFields);
+						committedDocs = idx2.createIndex(indexedFields, summary.getNodeCount());
 					idx2.close();
 				}
 				long t = Calendar.getInstance().getTimeInMillis() - t1;
-				System.out.println("Takes " + t / 1000 + " secs to create index");
+				System.out.println("Takes " + t / 1000 + " secs to create index with "
+						+ committedDocs + " documents");
 			}
 
 			if (this.idxScope != SolrIndexScope.individual) {
@@ -254,18 +260,18 @@ public class SolrTaskRebuildNetworkIdx extends NdexSystemTask {
 				if ( entry.getValue().getDataType() == null || 
 						entry.getValue().getDataType() == ATTRIBUTE_DATA_TYPE.STRING)
 					attributeNameMapping.put (CxNode.REPRESENTS, entry);
-			} else if ( attrName.equalsIgnoreCase(SingleNetworkSolrIdxManager.ALIAS) ) {
+			} else if ( attrName.equalsIgnoreCase(NodeIndexFields.ALIAS) ) {
 				if ( entry.getValue().getDataType() == ATTRIBUTE_DATA_TYPE.LIST_OF_STRING) {
-					attributeNameMapping.put (SingleNetworkSolrIdxManager.ALIAS, entry);					
+					attributeNameMapping.put (NodeIndexFields.ALIAS, entry);					
 				}
-			} else if ( attrName.equalsIgnoreCase(SingleNetworkSolrIdxManager.TYPE)) {
+			} else if ( attrName.equalsIgnoreCase(NodeIndexFields.TYPE)) {
 				if ( entry.getValue().getDataType() == null || 
 						entry.getValue().getDataType() == ATTRIBUTE_DATA_TYPE.STRING)
-					attributeNameMapping.put (SingleNetworkSolrIdxManager.TYPE, entry);
-			} else if ( attrName.equalsIgnoreCase(SingleNetworkSolrIdxManager.MEMBER)) {
+					attributeNameMapping.put (NodeIndexFields.TYPE, entry);
+			} else if ( attrName.equalsIgnoreCase(NodeIndexFields.MEMBER)) {
 				if ( entry.getValue().getDataType() == null || 
 						entry.getValue().getDataType() == ATTRIBUTE_DATA_TYPE.STRING)
-					attributeNameMapping.put (SingleNetworkSolrIdxManager.MEMBER, entry);
+					attributeNameMapping.put (NodeIndexFields.MEMBER, entry);
 			}
 				
 		}

--- a/src/test/java/org/ndexbio/common/solr/TestCx2NodeIndexServiceImpl.java
+++ b/src/test/java/org/ndexbio/common/solr/TestCx2NodeIndexServiceImpl.java
@@ -1,0 +1,275 @@
+package org.ndexbio.common.solr;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.ndexbio.model.exceptions.NdexException;
+
+/**
+ * Unit tests for {@link Cx2NodeIndexServiceImpl}.
+ *
+ * <p>The reason this class exists: an unreadable aspect directory used to be indistinguishable
+ * from a network with nothing to index, because {@code File.exists()} returns false on permission
+ * denial rather than throwing. A reindex running as the wrong OS user therefore produced empty
+ * Solr cores while reporting success. Every "cannot read" path below must now throw and say which
+ * situation it hit.
+ */
+@RunWith(JUnit4.class)
+public class TestCx2NodeIndexServiceImpl {
+
+	private static final String NETWORK_ID = "ec25aeeb-fb51-11ef-b81d-005056ae3c32";
+
+	/** Declares name via the short alias "n", as CX2 writes it for most networks. */
+	private static final String DECL_ALIAS_FORM =
+			"[{\"nodes\":{\"name\":{\"a\":\"n\",\"d\":\"string\"}}}]";
+
+	/** Declares name with no alias, the shape WikiPathways networks use. */
+	private static final String DECL_PLAIN_FORM =
+			"[{\"nodes\":{\"name\":{\"d\":\"string\"}}}]";
+
+	@Rule
+	public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+	/** Anything we strip permissions from, so teardown can still delete the temp tree. */
+	private final List<File> permissionsToRestore = new ArrayList<>();
+
+	@After
+	public void restorePermissions() {
+		for (File f : permissionsToRestore) {
+			f.setReadable(true);
+			f.setExecutable(true);
+			f.setWritable(true);
+		}
+		permissionsToRestore.clear();
+	}
+
+	// ------------------------------------------------------------------ helpers
+
+	private File aspectDir() throws IOException {
+		File dir = new File(tmpFolder.getRoot(), "data/" + NETWORK_ID + "/aspects_cx2");
+		Files.createDirectories(dir.toPath());
+		return dir;
+	}
+
+	private void write(File dir, String fileName, String content) throws IOException {
+		Files.write(new File(dir, fileName).toPath(), content.getBytes(StandardCharsets.UTF_8));
+	}
+
+	private Cx2NodeIndexService service() {
+		return new Cx2NodeIndexServiceImpl(tmpFolder.getRoot().getAbsolutePath());
+	}
+
+	private void denyAccess(File f) {
+		permissionsToRestore.add(f);
+		// Removing only the read bit on a directory still allows access by exact path; the
+		// traversal bit has to go too, which is what mode drwxr-x--- denies another user.
+		assertTrue("could not clear read permission on " + f, f.setReadable(false));
+		if (f.isDirectory()) {
+			assertTrue("could not clear execute permission on " + f, f.setExecutable(false));
+		}
+	}
+
+	private String expectNdexException(Cx2NodeIndexService svc) throws IOException {
+		try {
+			svc.loadNodeIndexEntries(NETWORK_ID);
+			fail("expected NdexException for an unreadable node index source");
+			return null;
+		} catch (NdexException e) {
+			assertNotNull("exception must carry a message", e.getMessage());
+			return e.getMessage();
+		}
+	}
+
+	/** Permission-based cases are meaningless as root, which bypasses the checks entirely. */
+	private void assumeNotRoot() {
+		Assume.assumeFalse("test requires a non-root user",
+				"root".equals(System.getProperty("user.name")));
+	}
+
+	// ------------------------------------------- unreadable / absent: must throw
+
+	@Test
+	public void unreadableAspectDirectoryThrowsNamingDirAndUser() throws Exception {
+		assumeNotRoot();
+		File dir = aspectDir();
+		write(dir, "attributeDeclarations", DECL_ALIAS_FORM);
+		write(dir, "nodes", "[{\"id\":0,\"v\":{\"n\":\"FBXL13\"}}]");
+		denyAccess(dir);
+
+		String msg = expectNdexException(service());
+		assertTrue("should report the directory is unreadable, got: " + msg,
+				msg.contains("not readable"));
+		assertTrue("should name the aspect directory, got: " + msg,
+				msg.contains(dir.getAbsolutePath()));
+		assertTrue("should name the OS user, got: " + msg,
+				msg.contains(System.getProperty("user.name")));
+		assertTrue("should name the network, got: " + msg, msg.contains(NETWORK_ID));
+	}
+
+	@Test
+	public void missingAspectDirectoryThrowsMissing() throws Exception {
+		// no directory created at all
+		String msg = expectNdexException(service());
+		assertTrue("should report the directory is missing, got: " + msg, msg.contains("missing"));
+		assertTrue("should name the network, got: " + msg, msg.contains(NETWORK_ID));
+	}
+
+	@Test
+	public void unreadableDeclarationFileThrowsNotReadable() throws Exception {
+		assumeNotRoot();
+		File dir = aspectDir();
+		write(dir, "attributeDeclarations", DECL_ALIAS_FORM);
+		write(dir, "nodes", "[{\"id\":0,\"v\":{\"n\":\"FBXL13\"}}]");
+		File declFile = new File(dir, "attributeDeclarations");
+		denyAccess(declFile);
+
+		String msg = expectNdexException(service());
+		assertTrue("should report the file is present but unreadable, got: " + msg,
+				msg.contains("not readable"));
+		assertTrue("should name the declarations file, got: " + msg,
+				msg.contains(declFile.getAbsolutePath()));
+		assertTrue("should name the OS user, got: " + msg,
+				msg.contains(System.getProperty("user.name")));
+	}
+
+	@Test
+	public void missingDeclarationFileThrowsMissing() throws Exception {
+		File dir = aspectDir();
+		write(dir, "nodes", "[{\"id\":0,\"v\":{\"n\":\"FBXL13\"}}]");
+
+		String msg = expectNdexException(service());
+		assertTrue("should report the declarations file is missing, got: " + msg,
+				msg.contains("missing"));
+		assertTrue("should name attributeDeclarations, got: " + msg,
+				msg.contains("attributeDeclarations"));
+	}
+
+	@Test
+	public void missingNodesFilePropagatesRatherThanReturningEmpty() throws Exception {
+		File dir = aspectDir();
+		write(dir, "attributeDeclarations", DECL_ALIAS_FORM);
+		// deliberately no "nodes" file
+
+		try {
+			service().loadNodeIndexEntries(NETWORK_ID);
+			fail("a missing nodes aspect must not be reported as an empty index");
+		} catch (IOException expected) {
+			assertNotNull(expected);
+		}
+	}
+
+	// ------------------------------------- readable but declaration-free: empty, no throw
+
+	@Test
+	public void emptyDeclarationArrayYieldsEmptyMapWithoutThrowing() throws Exception {
+		File dir = aspectDir();
+		write(dir, "attributeDeclarations", "[]");
+		write(dir, "nodes", "[{\"id\":0,\"v\":{\"n\":\"FBXL13\"}}]");
+
+		assertTrue(service().loadNodeIndexEntries(NETWORK_ID).isEmpty());
+	}
+
+	@Test
+	public void declarationsWithoutNodesAspectYieldEmptyMapWithoutThrowing() throws Exception {
+		File dir = aspectDir();
+		write(dir, "attributeDeclarations", "[{\"edges\":{\"interaction\":{\"d\":\"string\"}}}]");
+		write(dir, "nodes", "[{\"id\":0,\"v\":{\"n\":\"FBXL13\"}}]");
+
+		assertTrue(service().loadNodeIndexEntries(NETWORK_ID).isEmpty());
+	}
+
+	@Test
+	public void emptyNodeAttributeDeclarationsYieldEmptyMapWithoutThrowing() throws Exception {
+		File dir = aspectDir();
+		write(dir, "attributeDeclarations", "[{\"nodes\":{}}]");
+		write(dir, "nodes", "[{\"id\":0,\"v\":{\"n\":\"FBXL13\"}}]");
+
+		assertTrue(service().loadNodeIndexEntries(NETWORK_ID).isEmpty());
+	}
+
+	// ------------------------------------------------------------ happy paths
+
+	@Test
+	public void resolvesNodeNameThroughDeclaredAlias() throws Exception {
+		File dir = aspectDir();
+		write(dir, "attributeDeclarations", DECL_ALIAS_FORM);
+		write(dir, "nodes",
+				"[{\"id\":0,\"v\":{\"n\":\"FBXL13\"}},{\"id\":1,\"v\":{\"n\":\"ASB2\"}}]");
+
+		Map<Long, NodeIndexEntry> entries = service().loadNodeIndexEntries(NETWORK_ID);
+
+		assertEquals(2, entries.size());
+		assertEquals("FBXL13", entries.get(0L).getName());
+		assertEquals("ASB2", entries.get(1L).getName());
+	}
+
+	@Test
+	public void resolvesNodeNameFromFullAttributeNameWhenNoAliasDeclared() throws Exception {
+		File dir = aspectDir();
+		write(dir, "attributeDeclarations", DECL_PLAIN_FORM);
+		write(dir, "nodes", "[{\"id\":7,\"v\":{\"name\":\"CDK2\"}}]");
+
+		Map<Long, NodeIndexEntry> entries = service().loadNodeIndexEntries(NETWORK_ID);
+
+		assertEquals(1, entries.size());
+		assertEquals("CDK2", entries.get(7L).getName());
+	}
+
+	@Test
+	public void nodesWithoutAnIndexableAttributeAreSkipped() throws Exception {
+		File dir = aspectDir();
+		write(dir, "attributeDeclarations", DECL_ALIAS_FORM);
+		// second node carries no attributes at all, as layout-only nodes do
+		write(dir, "nodes", "[{\"id\":0,\"v\":{\"n\":\"FBXL13\"}},{\"id\":1}]");
+
+		Map<Long, NodeIndexEntry> entries = service().loadNodeIndexEntries(NETWORK_ID);
+
+		assertEquals("only the named node should be indexed", 1, entries.size());
+		assertEquals("FBXL13", entries.get(0L).getName());
+	}
+
+	@Test
+	public void carriesRepresentsAliasAndProteinFamilyMembers() throws Exception {
+		File dir = aspectDir();
+		write(dir, "attributeDeclarations",
+				"[{\"nodes\":{"
+						+ "\"name\":{\"a\":\"n\",\"d\":\"string\"},"
+						+ "\"represents\":{\"a\":\"r\",\"d\":\"string\"},"
+						+ "\"alias\":{\"d\":\"list_of_string\"},"
+						+ "\"type\":{\"d\":\"string\"},"
+						+ "\"member\":{\"d\":\"list_of_string\"}}}]");
+		write(dir, "nodes",
+				"[{\"id\":0,\"v\":{\"n\":\"FAMILY1\",\"r\":\"PROT1\","
+						+ "\"alias\":[\"ALIAS1\"],\"type\":\"proteinfamily\","
+						+ "\"member\":[\"MEM1\",\"MEM2\"]}}]");
+
+		Map<Long, NodeIndexEntry> entries = service().loadNodeIndexEntries(NETWORK_ID);
+
+		assertEquals(1, entries.size());
+		NodeIndexEntry e = entries.get(0L);
+		assertEquals("FAMILY1", e.getName());
+		assertTrue("represents should carry the declared value: " + e.getRepresents(),
+				e.getRepresents().contains("PROT1"));
+		assertTrue("proteinfamily members fold into represents: " + e.getRepresents(),
+				e.getRepresents().contains("MEM1") && e.getRepresents().contains("MEM2"));
+		assertTrue("alias should be carried: " + e.getAliases(),
+				e.getAliases().contains("ALIAS1"));
+	}
+}

--- a/src/test/java/org/ndexbio/common/solr/TestSingleNetworkSolrIdxManager.java
+++ b/src/test/java/org/ndexbio/common/solr/TestSingleNetworkSolrIdxManager.java
@@ -1,0 +1,559 @@
+package org.ndexbio.common.solr;
+
+import static org.easymock.EasyMock.anyBoolean;
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrDocumentList;
+import org.apache.solr.common.SolrInputDocument;
+import org.easymock.Capture;
+import org.easymock.EasyMock;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.ndexbio.model.exceptions.NdexException;
+
+/**
+ * Unit tests for {@link SingleNetworkSolrIdxManager}.
+ *
+ * <p>The behaviour under test is the reason a fleet-wide outage went unnoticed: a rebuild that
+ * committed zero documents used to be reported as success, leaving an empty core that answered
+ * every query with no results. A zero-document rebuild for a network the database says has nodes
+ * must now fail, and the count reported must be the count Solr actually holds.
+ */
+@RunWith(JUnit4.class)
+public class TestSingleNetworkSolrIdxManager {
+
+	private static final String NETWORK_ID = "ec25aeeb-fb51-11ef-b81d-005056ae3c32";
+
+	// ------------------------------------------------------------------ helpers
+
+	/** A node index entry with a name, which is what makes a node indexable. */
+	private static NodeIndexEntry entry(long id) {
+		return new NodeIndexEntry(id, "NODE" + id);
+	}
+
+	private static Map<Long, NodeIndexEntry> entries(int count) {
+		Map<Long, NodeIndexEntry> map = new LinkedHashMap<>();
+		for (long i = 0; i < count; i++) {
+			map.put(i, entry(i));
+		}
+		return map;
+	}
+
+	/** A QueryResponse whose result list reports numFound, as the doc-count probe reads it. */
+	private static QueryResponse responseWithNumFound(long numFound) {
+		SolrDocumentList docList = new SolrDocumentList();
+		docList.setNumFound(numFound);
+		QueryResponse rsp = createMock(QueryResponse.class);
+		expect(rsp.getResults()).andReturn(docList).anyTimes();
+		replay(rsp);
+		return rsp;
+	}
+
+	private static Cx2NodeIndexService serviceReturning(Map<Long, NodeIndexEntry> toReturn)
+			throws Exception {
+		Cx2NodeIndexService svc = createMock(Cx2NodeIndexService.class);
+		expect(svc.loadNodeIndexEntries(NETWORK_ID)).andReturn(toReturn);
+		replay(svc);
+		return svc;
+	}
+
+	private static Cx2NodeIndexService serviceThrowing(NdexException toThrow) throws Exception {
+		Cx2NodeIndexService svc = createMock(Cx2NodeIndexService.class);
+		expect(svc.loadNodeIndexEntries(NETWORK_ID)).andThrow(toThrow);
+		replay(svc);
+		return svc;
+	}
+
+	/** What a commit call looked like at the moment it happened. */
+	private static final class CommitRecord {
+		private Integer docCount;
+		private Boolean hardCommit;
+		private int calls;
+	}
+
+	/**
+	 * Records the commit arguments as they are received. The manager clears its document buffer
+	 * straight after committing, so a plain {@code Capture} of the collection would be read back
+	 * empty and assert nothing.
+	 */
+	private static CommitRecord expectCommit(SolrClientWrapper wrapper)
+			throws SolrServerException, IOException {
+
+		CommitRecord record = new CommitRecord();
+		wrapper.commit(eq(NETWORK_ID), anyObject(), anyBoolean());
+		expectLastCall().andAnswer(() -> {
+			Object[] args = EasyMock.getCurrentArguments();
+			Collection<?> sent = (Collection<?>) args[1];
+			record.docCount = (sent == null) ? null : Integer.valueOf(sent.size());
+			record.hardCommit = (Boolean) args[2];
+			record.calls++;
+			return null;
+		});
+		return record;
+	}
+
+	// ------------------------------------------------- doc count verification
+
+	@Test
+	public void returnsCountSolrReportsAfterHardCommit() throws Exception {
+		SolrClientWrapper wrapper = createMock(SolrClientWrapper.class);
+		wrapper.createCore(NETWORK_ID, "ndex-nodes");
+		expectLastCall();
+		CommitRecord commit = expectCommit(wrapper);
+		expect(wrapper.query(eq(NETWORK_ID), anyObject(SolrQuery.class)))
+				.andReturn(responseWithNumFound(3));
+		replay(wrapper);
+
+		SingleNetworkSolrIdxManager mgr = new SingleNetworkSolrIdxManager(NETWORK_ID, wrapper,
+				serviceReturning(entries(3)));
+
+		assertEquals(3, mgr.createIndexFromCx2(null, 3));
+		assertTrue("index creation must use a hard commit so the documents are durable",
+				commit.hardCommit);
+		verify(wrapper);
+	}
+
+	@Test
+	public void zeroDocumentsForANetworkWithNodesThrows() throws Exception {
+		SolrClientWrapper wrapper = createMock(SolrClientWrapper.class);
+		wrapper.createCore(NETWORK_ID, "ndex-nodes");
+		expectLastCall();
+		expectCommit(wrapper);
+		expect(wrapper.query(eq(NETWORK_ID), anyObject(SolrQuery.class)))
+				.andReturn(responseWithNumFound(0));
+		replay(wrapper);
+
+		SingleNetworkSolrIdxManager mgr = new SingleNetworkSolrIdxManager(NETWORK_ID, wrapper,
+				serviceReturning(entries(0)));
+
+		try {
+			mgr.createIndexFromCx2(null, 226);
+			fail("a rebuild that commits nothing for a 226 node network must not report success");
+		} catch (NdexException e) {
+			String msg = e.getMessage();
+			assertTrue("should name the network, got: " + msg, msg.contains(NETWORK_ID));
+			assertTrue("should report the expected node count, got: " + msg, msg.contains("226"));
+			assertTrue("should say the index holds no documents, got: " + msg,
+					msg.contains("no documents"));
+		}
+	}
+
+	@Test
+	public void zeroDocumentsForANetworkWithNoNodesIsAccepted() throws Exception {
+		SolrClientWrapper wrapper = createMock(SolrClientWrapper.class);
+		wrapper.createCore(NETWORK_ID, "ndex-nodes");
+		expectLastCall();
+		expectCommit(wrapper);
+		expect(wrapper.query(eq(NETWORK_ID), anyObject(SolrQuery.class)))
+				.andReturn(responseWithNumFound(0));
+		replay(wrapper);
+
+		SingleNetworkSolrIdxManager mgr = new SingleNetworkSolrIdxManager(NETWORK_ID, wrapper,
+				serviceReturning(entries(0)));
+
+		assertEquals(0, mgr.createIndexFromCx2(null, 0));
+	}
+
+	@Test
+	public void partialIndexIsAcceptedBecauseUnnamedNodesAreNotIndexed() throws Exception {
+		SolrClientWrapper wrapper = createMock(SolrClientWrapper.class);
+		wrapper.createCore(NETWORK_ID, "ndex-nodes");
+		expectLastCall();
+		expectCommit(wrapper);
+		expect(wrapper.query(eq(NETWORK_ID), anyObject(SolrQuery.class)))
+				.andReturn(responseWithNumFound(713));
+		replay(wrapper);
+
+		SingleNetworkSolrIdxManager mgr = new SingleNetworkSolrIdxManager(NETWORK_ID, wrapper,
+				serviceReturning(entries(713)));
+
+		// 713 of 867 is the real shape of a WikiPathways network: layout-only nodes carry no name
+		assertEquals(713, mgr.createIndexFromCx2(null, 867));
+	}
+
+	// ------------------------------------------------------- batch boundaries
+
+	@Test
+	public void commitsEvenWhenEntryCountIsAnExactMultipleOfBatchSize() throws Exception {
+		int batchSize = NodeIndexDocumentBuilder.DEFAULT_BATCH_SIZE;
+
+		SolrClientWrapper wrapper = createMock(SolrClientWrapper.class);
+		wrapper.createCore(NETWORK_ID, "ndex-nodes");
+		expectLastCall();
+		// the full batch is flushed by add(), leaving nothing for the final commit to send
+		wrapper.add(eq(NETWORK_ID), anyObject());
+		expectLastCall();
+		CommitRecord commit = expectCommit(wrapper);
+		expect(wrapper.query(eq(NETWORK_ID), anyObject(SolrQuery.class)))
+				.andReturn(responseWithNumFound(batchSize));
+		replay(wrapper);
+
+		SingleNetworkSolrIdxManager mgr = new SingleNetworkSolrIdxManager(NETWORK_ID, wrapper,
+				serviceReturning(entries(batchSize)));
+
+		assertEquals(batchSize, mgr.createIndexFromCx2(null, batchSize));
+		assertEquals("commit must still be issued when the trailing batch is empty",
+				1, commit.calls);
+		assertEquals("the trailing batch really was empty",
+				Integer.valueOf(0), commit.docCount);
+		assertTrue(commit.hardCommit);
+		verify(wrapper);
+	}
+
+	@Test
+	public void flushesEachFullBatchThenCommitsTheRemainder() throws Exception {
+		int batchSize = NodeIndexDocumentBuilder.DEFAULT_BATCH_SIZE;
+		int total = batchSize * 2 + 5;
+
+		SolrClientWrapper wrapper = createMock(SolrClientWrapper.class);
+		wrapper.createCore(NETWORK_ID, "ndex-nodes");
+		expectLastCall();
+		wrapper.add(eq(NETWORK_ID), anyObject());
+		expectLastCall().times(2);
+		CommitRecord commit = expectCommit(wrapper);
+		expect(wrapper.query(eq(NETWORK_ID), anyObject(SolrQuery.class)))
+				.andReturn(responseWithNumFound(total));
+		replay(wrapper);
+
+		SingleNetworkSolrIdxManager mgr = new SingleNetworkSolrIdxManager(NETWORK_ID, wrapper,
+				serviceReturning(entries(total)));
+
+		assertEquals(total, mgr.createIndexFromCx2(null, total));
+		assertEquals("the trailing partial batch goes out with the commit",
+				Integer.valueOf(5), commit.docCount);
+		verify(wrapper);
+	}
+
+	// --------------------------------------------- source failure propagation
+
+	@Test
+	public void aspectReadFailurePropagatesWithItsOwnMessage() throws Exception {
+		SolrClientWrapper wrapper = createMock(SolrClientWrapper.class);
+		wrapper.createCore(NETWORK_ID, "ndex-nodes");
+		expectLastCall();
+		replay(wrapper);
+
+		NdexException cause = new NdexException(
+				"Cannot index network " + NETWORK_ID + ": CX2 aspect directory is not readable "
+						+ "by user 'someoneelse' - /opt/ndex/data/" + NETWORK_ID + "/aspects_cx2");
+
+		SingleNetworkSolrIdxManager mgr = new SingleNetworkSolrIdxManager(NETWORK_ID, wrapper,
+				serviceThrowing(cause));
+
+		try {
+			mgr.createIndexFromCx2(null, 226);
+			fail("an unreadable aspect directory must not be reported as a successful rebuild");
+		} catch (NdexException e) {
+			assertEquals("the diagnostic must survive unchanged", cause.getMessage(), e.getMessage());
+		}
+		// no commit and no doc-count probe should have happened
+		verify(wrapper);
+	}
+
+	// ---------------------------------------------------------- ensureReady
+
+	@Test
+	public void ensureReadyDoesNothingWhenCoreExists() throws Exception {
+		SolrClientWrapper wrapper = createMock(SolrClientWrapper.class);
+		expect(wrapper.coreExists(NETWORK_ID)).andReturn(true);
+		replay(wrapper);
+
+		Cx2NodeIndexService svc = createMock(Cx2NodeIndexService.class);
+		replay(svc); // must not be touched
+
+		new SingleNetworkSolrIdxManager(NETWORK_ID, wrapper, svc).ensureReady(226);
+
+		verify(wrapper);
+		verify(svc);
+	}
+
+	@Test
+	public void ensureReadyBuildsIndexForSmallNetworkWhenCoreAbsent() throws Exception {
+		SolrClientWrapper wrapper = createMock(SolrClientWrapper.class);
+		expect(wrapper.coreExists(NETWORK_ID)).andReturn(false).times(2);
+		wrapper.createCore(NETWORK_ID, "ndex-nodes");
+		expectLastCall();
+		expectCommit(wrapper);
+		expect(wrapper.query(eq(NETWORK_ID), anyObject(SolrQuery.class)))
+				.andReturn(responseWithNumFound(20));
+		replay(wrapper);
+
+		SingleNetworkSolrIdxManager mgr = new SingleNetworkSolrIdxManager(NETWORK_ID, wrapper,
+				serviceReturning(entries(20)));
+
+		mgr.ensureReady(20);
+
+		verify(wrapper);
+	}
+
+	@Test
+	public void ensureReadyRefusesToBuildLargeNetworkOnDemand() throws Exception {
+		SolrClientWrapper wrapper = createMock(SolrClientWrapper.class);
+		expect(wrapper.coreExists(NETWORK_ID)).andReturn(false);
+		replay(wrapper);
+
+		Cx2NodeIndexService svc = createMock(Cx2NodeIndexService.class);
+		replay(svc); // must not attempt a build
+
+		SingleNetworkSolrIdxManager mgr = new SingleNetworkSolrIdxManager(NETWORK_ID, wrapper, svc);
+
+		try {
+			mgr.ensureReady(SingleNetworkSolrIdxManager.AUTOCREATE_THRESHHOLD);
+			fail("a large network should be left to the background indexer");
+		} catch (NdexException e) {
+			assertTrue("got: " + e.getMessage(),
+					e.getMessage().contains("hasn't finished creating index"));
+		}
+		verify(svc);
+	}
+
+	@Test
+	public void ensureReadyPreservesTheAspectReadDiagnostic() throws Exception {
+		SolrClientWrapper wrapper = createMock(SolrClientWrapper.class);
+		expect(wrapper.coreExists(NETWORK_ID)).andReturn(false).times(2);
+		wrapper.createCore(NETWORK_ID, "ndex-nodes");
+		expectLastCall();
+		replay(wrapper);
+
+		NdexException cause = new NdexException("Cannot index network " + NETWORK_ID
+				+ ": CX2 aspect directory is not readable by user 'someoneelse'");
+
+		SingleNetworkSolrIdxManager mgr = new SingleNetworkSolrIdxManager(NETWORK_ID, wrapper,
+				serviceThrowing(cause));
+
+		try {
+			mgr.ensureReady(20);
+			fail("expected the read failure to surface");
+		} catch (NdexException e) {
+			assertEquals("must not be flattened to \"Failed to create Solr Index on this network.\"",
+					cause.getMessage(), e.getMessage());
+			assertTrue(e.getMessage().contains("not readable by user"));
+		}
+	}
+
+	/**
+	 * Two threads racing to make the same network ready must not both create the core.
+	 *
+	 * <p>Hand written stubs rather than EasyMock: EasyMock mocks are not thread safe, so a
+	 * concurrent test built on them fails nondeterministically.
+	 */
+	@Test
+	public void concurrentEnsureReadyCreatesTheCoreOnce() throws Exception {
+		final AtomicInteger createCalls = new AtomicInteger();
+		final CountDownLatch bothArrived = new CountDownLatch(2);
+
+		final CountingWrapper wrapper = new CountingWrapper(createCalls, bothArrived);
+		Cx2NodeIndexService svc = networkId -> entries(5);
+
+		final SingleNetworkSolrIdxManager mgr =
+				new SingleNetworkSolrIdxManager(NETWORK_ID, wrapper, svc);
+
+		Runnable task = () -> {
+			try {
+				mgr.ensureReady(5);
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		};
+
+		Thread t1 = new Thread(task, "ensureReady-1");
+		Thread t2 = new Thread(task, "ensureReady-2");
+		t1.start();
+		t2.start();
+		t1.join(10_000);
+		t2.join(10_000);
+
+		assertEquals("core creation must happen exactly once", 1, createCalls.get());
+	}
+
+	// -------------------------------------------------------- query delegation
+
+	@Test
+	public void getNodeIdsByQueryDelegatesWithEdismaxAndNodeFields() throws Exception {
+		SolrDocumentList results = new SolrDocumentList();
+		SolrDocument doc = new SolrDocument();
+		doc.addField("id", "0");
+		results.add(doc);
+		results.setNumFound(1);
+
+		QueryResponse rsp = createMock(QueryResponse.class);
+		expect(rsp.getResults()).andReturn(results).anyTimes();
+		replay(rsp);
+
+		SolrClientWrapper wrapper = createMock(SolrClientWrapper.class);
+		Capture<SolrQuery> query = Capture.newInstance();
+		expect(wrapper.query(eq(NETWORK_ID), capture(query))).andReturn(rsp);
+		replay(wrapper);
+
+		Cx2NodeIndexService svc = createMock(Cx2NodeIndexService.class);
+		replay(svc);
+
+		SolrDocumentList out = new SingleNetworkSolrIdxManager(NETWORK_ID, wrapper, svc)
+				.getNodeIdsByQuery("fbxl13", 5);
+
+		assertEquals(1, out.size());
+		SolrQuery sent = query.getValue();
+		assertEquals("edismax", sent.get("defType"));
+		assertEquals("nodeName represents alias text", sent.get("qf"));
+		assertEquals(Integer.valueOf(5), sent.getRows());
+		verify(wrapper);
+	}
+
+	@Test
+	public void dropIndexDelegatesToDropCore() throws Exception {
+		SolrClientWrapper wrapper = createMock(SolrClientWrapper.class);
+		wrapper.dropCore(NETWORK_ID);
+		expectLastCall();
+		replay(wrapper);
+
+		Cx2NodeIndexService svc = createMock(Cx2NodeIndexService.class);
+		replay(svc);
+
+		new SingleNetworkSolrIdxManager(NETWORK_ID, wrapper, svc).dropIndex();
+
+		verify(wrapper);
+	}
+
+	@Test
+	public void closeClosesTheWrapperItOwns() throws Exception {
+		SolrClientWrapper wrapper = createMock(SolrClientWrapper.class);
+		wrapper.close();
+		expectLastCall();
+		replay(wrapper);
+
+		Cx2NodeIndexService svc = createMock(Cx2NodeIndexService.class);
+		replay(svc);
+
+		new SingleNetworkSolrIdxManager(NETWORK_ID, wrapper, svc).close();
+
+		verify(wrapper);
+	}
+
+	// ----------------------------------------------------- configSet variant
+
+	@Test
+	public void createIndexWithExtraFieldsClonesAConfigSetFirst() throws Exception {
+		SolrClientWrapper wrapper = createMock(SolrClientWrapper.class);
+		wrapper.createConfigSet(NETWORK_ID, "ndex-nodes-template");
+		expectLastCall();
+		wrapper.createCore(NETWORK_ID, NETWORK_ID);
+		expectLastCall();
+		expectCommit(wrapper);
+		expect(wrapper.query(eq(NETWORK_ID), anyObject(SolrQuery.class)))
+				.andReturn(responseWithNumFound(2));
+		replay(wrapper);
+
+		SingleNetworkSolrIdxManager mgr = new SingleNetworkSolrIdxManager(NETWORK_ID, wrapper,
+				serviceReturning(entries(2)));
+
+		assertEquals(2, mgr.createIndex(Set.of("customField"), 2));
+		verify(wrapper);
+	}
+
+	@Test
+	public void createIndexFromCx2RejectsExtraFields() throws Exception {
+		SolrClientWrapper wrapper = createMock(SolrClientWrapper.class);
+		replay(wrapper);
+		Cx2NodeIndexService svc = createMock(Cx2NodeIndexService.class);
+		replay(svc);
+
+		try {
+			new SingleNetworkSolrIdxManager(NETWORK_ID, wrapper, svc)
+					.createIndexFromCx2(Set.of("customField"), 5);
+			fail("extra attribute indexing is not implemented for the CX2 path");
+		} catch (NdexException e) {
+			assertNotNull(e.getMessage());
+		}
+	}
+
+	/**
+	 * Minimal thread-safe {@link SolrClientWrapper} that counts core creations and makes both
+	 * threads arrive before either proceeds, so the race is real rather than theoretical.
+	 */
+	private static final class CountingWrapper implements SolrClientWrapper {
+
+		private final AtomicInteger createCalls;
+		private final CountDownLatch bothArrived;
+		private volatile boolean created;
+
+		CountingWrapper(AtomicInteger createCalls, CountDownLatch bothArrived) {
+			this.createCalls = createCalls;
+			this.bothArrived = bothArrived;
+		}
+
+		@Override
+		public boolean coreExists(String coreName) {
+			bothArrived.countDown();
+			try {
+				bothArrived.await(5, TimeUnit.SECONDS);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+			return created;
+		}
+
+		@Override
+		public void createCore(String coreName, String configSetName) {
+			createCalls.incrementAndGet();
+			created = true;
+		}
+
+		@Override
+		public QueryResponse query(String coreName, SolrQuery query) {
+			return responseWithNumFound(5);
+		}
+
+		@Override
+		public void createCoreIfNeeded(String coreName) { /* unused */ }
+
+		@Override
+		public void createCoreIfNeeded(String coreName, String configSetName) { /* unused */ }
+
+		@Override
+		public void createConfigSet(String configSetName, String baseConfigSetName) { /* unused */ }
+
+		@Override
+		public void dropCore(String coreName) { /* unused */ }
+
+		@Override
+		public void add(String coreName, Collection<SolrInputDocument> documents) { /* unused */ }
+
+		@Override
+		public void commit(String coreName, Collection<SolrInputDocument> documents) { /* unused */ }
+
+		@Override
+		public void commit(String coreName, Collection<SolrInputDocument> documents,
+				boolean hardCommit) { /* unused */ }
+
+		@Override
+		public void delete(String coreName, String id, boolean commit) { /* unused */ }
+
+		@Override
+		public void close() { /* unused */ }
+	}
+}

--- a/src/test/java/org/ndexbio/common/solr/TestSolrClientWrapperImpl.java
+++ b/src/test/java/org/ndexbio/common/solr/TestSolrClientWrapperImpl.java
@@ -183,7 +183,7 @@ public class TestSolrClientWrapperImpl {
 	 */
 	@Ignore
 	public void testCreateCoreAndPerformSomeIndexes() throws Exception {
-		SolrObjectFactoryImpl factory = new SolrObjectFactoryImpl("http://localhost:8983/solr");
+		SolrObjectFactoryImpl factory = new SolrObjectFactoryImpl("http://localhost:8983/solr", "/opt/ndex");
 		
 		SolrClientWrapperImpl client = new SolrClientWrapperImpl(factory);
 		

--- a/src/test/java/org/ndexbio/common/solr/TestSolrIndexBuilder.java
+++ b/src/test/java/org/ndexbio/common/solr/TestSolrIndexBuilder.java
@@ -1,0 +1,189 @@
+package org.ndexbio.common.solr;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+/**
+ * Tests the per-network failure policy of the index sweeps.
+ *
+ * <p>A rebuild that fails for one network must not stop the sweep, and must say why at WARN.
+ * The migration that emptied every query core across the fleet logged its failures at INFO, and
+ * the all-local sweep rethrew, aborting on the first bad network - both made a total failure look
+ * like a normal run.
+ *
+ * <p>These drive the extracted per-network steps rather than the enclosing loops, because the
+ * loops open a {@code PostgresNetworkDAO} to stream network ids from the database. The steps are
+ * where the policy lives; {@code TestNFSReIndexer} covers loop iteration end to end.
+ */
+@RunWith(JUnit4.class)
+public class TestSolrIndexBuilder {
+
+	private static final UUID NETWORK_A = UUID.fromString("ec25aeeb-fb51-11ef-b81d-005056ae3c32");
+
+	private Logger builderLogger;
+	private ListAppender<ILoggingEvent> logged;
+
+	/** A builder whose rebuild always fails, standing in for an unreadable aspect directory. */
+	private static final class FailingBuilder extends SolrIndexBuilder {
+		private final RuntimeException failure;
+		private int attempts;
+
+		FailingBuilder(RuntimeException failure) {
+			super((NetworkGlobalIndexManager) null);
+			this.failure = failure;
+		}
+
+		@Override
+		void rebuildNetworkIndex(UUID networkId, boolean ignoreDeletion) {
+			attempts++;
+			throw failure;
+		}
+
+		@Override
+		void rebuildLocalNetworkIndex(UUID networkId, boolean ignoreDeletion) {
+			attempts++;
+			throw failure;
+		}
+	}
+
+	@Before
+	public void captureLogs() {
+		builderLogger = (Logger) org.slf4j.LoggerFactory.getLogger(SolrIndexBuilder.class);
+		logged = new ListAppender<>();
+		logged.start();
+		builderLogger.addAppender(logged);
+	}
+
+	@After
+	public void releaseLogs() {
+		builderLogger.detachAppender(logged);
+		logged.stop();
+	}
+
+	private List<ILoggingEvent> failureEvents() {
+		List<ILoggingEvent> events = new ArrayList<>();
+		for (ILoggingEvent e : logged.list) {
+			if (e.getFormattedMessage().startsWith("Failed to")) {
+				events.add(e);
+			}
+		}
+		return events;
+	}
+
+	// ------------------------------------------------------------------------
+
+	@Test
+	public void networkRebuildFailureIsRecordedAtWarnAndDoesNotPropagate() {
+		SolrIndexBuilder builder = new FailingBuilder(
+				new RuntimeException("CX2 aspect directory is not readable by user 'someoneelse'"));
+		List<String> failed = new ArrayList<>();
+
+		boolean ok = builder.runNetworkIndexStep(NETWORK_A, failed);
+
+		assertFalse("a failed network must not count as indexed", ok);
+		assertEquals("the failed network must be recorded for the summary",
+				List.of(NETWORK_A.toString()), failed);
+
+		List<ILoggingEvent> events = failureEvents();
+		assertEquals("exactly one failure line per network", 1, events.size());
+		ILoggingEvent event = events.get(0);
+		assertEquals("reindex failures must be WARN, not INFO or ERROR",
+				Level.WARN, event.getLevel());
+		assertTrue("the message must name the network: " + event.getFormattedMessage(),
+				event.getFormattedMessage().contains(NETWORK_A.toString()));
+		assertTrue("the message must carry the reason: " + event.getFormattedMessage(),
+				event.getFormattedMessage().contains("not readable by user"));
+		assertTrue("the exception itself must be logged so the stack trace survives",
+				event.getThrowableProxy() != null);
+	}
+
+	@Test
+	public void localIndexFailureIsRecordedAtWarnAndDoesNotPropagate() {
+		SolrIndexBuilder builder = new FailingBuilder(new RuntimeException("solr exploded"));
+		List<String> failed = new ArrayList<>();
+
+		// The all-local sweep used to rethrow here, killing the run on the first bad network.
+		boolean created = builder.runLocalIndexStep(NETWORK_A, failed);
+
+		assertFalse(created);
+		assertEquals(List.of(NETWORK_A.toString()), failed);
+
+		List<ILoggingEvent> events = failureEvents();
+		assertEquals(1, events.size());
+		assertEquals(Level.WARN, events.get(0).getLevel());
+		assertTrue(events.get(0).getFormattedMessage().contains("solr exploded"));
+	}
+
+	@Test
+	public void everyNetworkInABatchIsAttemptedEvenWhenAllFail() {
+		FailingBuilder builder = new FailingBuilder(new RuntimeException("boom"));
+		List<String> failed = new ArrayList<>();
+
+		List<UUID> batch = List.of(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+		int succeeded = 0;
+		for (UUID id : batch) {
+			if (builder.runNetworkIndexStep(id, failed)) {
+				succeeded++;
+			}
+		}
+
+		assertEquals("no step may abort the batch", 3, builder.attempts);
+		assertEquals(0, succeeded);
+		assertEquals("all three failures recorded", 3, failed.size());
+		assertEquals("one WARN per network", 3, failureEvents().size());
+		for (ILoggingEvent e : failureEvents()) {
+			assertEquals(Level.WARN, e.getLevel());
+		}
+	}
+
+	@Test
+	public void aPreExistingCoreIsNotCountedAsAFailure() {
+		SolrIndexBuilder builder = new SolrIndexBuilder((NetworkGlobalIndexManager) null) {
+			@Override
+			void rebuildLocalNetworkIndex(UUID networkId, boolean ignoreDeletion) {
+				throw new org.apache.solr.client.solrj.impl.HttpSolrClient.RemoteSolrException(
+						"http://localhost:8983/solr", 400,
+						"Core with name '" + networkId + "' already exists", null);
+			}
+		};
+		List<String> failed = new ArrayList<>();
+
+		boolean created = builder.runLocalIndexStep(NETWORK_A, failed);
+
+		assertFalse("nothing was created", created);
+		assertTrue("an already-present core is not a failure", failed.isEmpty());
+		assertTrue("and must not be logged as one", failureEvents().isEmpty());
+	}
+
+	@Test
+	public void noReindexFailureIsLoggedAtInfoOrError() {
+		SolrIndexBuilder builder = new FailingBuilder(new RuntimeException("boom"));
+		List<String> failed = new ArrayList<>();
+
+		builder.runNetworkIndexStep(NETWORK_A, failed);
+		builder.runLocalIndexStep(NETWORK_A, failed);
+
+		for (ILoggingEvent e : logged.list) {
+			if (e.getFormattedMessage().startsWith("Failed to")) {
+				assertFalse("failures must not be logged at INFO", Level.INFO.equals(e.getLevel()));
+				assertFalse("failures must not be logged at ERROR", Level.ERROR.equals(e.getLevel()));
+			}
+		}
+	}
+}

--- a/src/test/java/org/ndexbio/common/solr/TestSolrObjectFactoryImpl.java
+++ b/src/test/java/org/ndexbio/common/solr/TestSolrObjectFactoryImpl.java
@@ -1,0 +1,56 @@
+package org.ndexbio.common.solr;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+
+import org.apache.solr.client.solrj.request.ConfigSetAdminRequest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Wiring tests for {@link SolrObjectFactoryImpl}.
+ *
+ * <p>The factory is the single place production code obtains a
+ * {@link SingleNetworkSolrIdxManager}, so it is where the manager's Solr client and CX2 aspect
+ * reader get supplied.
+ */
+@RunWith(JUnit4.class)
+public class TestSolrObjectFactoryImpl {
+
+	private static final String SOLR_URL = "http://localhost:8983/solr";
+	private static final String NDEX_ROOT = "/opt/ndex";
+	private static final String NETWORK_ID = "ec25aeeb-fb51-11ef-b81d-005056ae3c32";
+
+	@Test
+	public void buildsAFullyWiredNodeIndexManager() {
+		SolrObjectFactoryImpl factory = new SolrObjectFactoryImpl(SOLR_URL, NDEX_ROOT);
+
+		try (SingleNetworkSolrIdxManager mgr = factory.getSingleNetworkSolrIdxManager(NETWORK_ID)) {
+			assertNotNull(mgr);
+		}
+	}
+
+	@Test
+	public void eachManagerGetsItsOwnClientSoClosingOneDoesNotCloseAnother() {
+		SolrObjectFactoryImpl factory = new SolrObjectFactoryImpl(SOLR_URL, NDEX_ROOT);
+
+		SingleNetworkSolrIdxManager first = factory.getSingleNetworkSolrIdxManager(NETWORK_ID);
+		SingleNetworkSolrIdxManager second = factory.getSingleNetworkSolrIdxManager(NETWORK_ID);
+
+		assertNotSame("callers close managers independently, so they must not share a client",
+				first, second);
+
+		first.close();
+		second.close();
+	}
+
+	@Test
+	public void exposesAConfigSetCreateRequest() {
+		SolrObjectFactoryImpl factory = new SolrObjectFactoryImpl(SOLR_URL, NDEX_ROOT);
+
+		ConfigSetAdminRequest.Create request = factory.getConfigSetAdminRequestCreate();
+
+		assertNotNull("needed so the extra-fields index path can be exercised in tests", request);
+	}
+}

--- a/src/test/java/org/ndexbio/server/migration/v3/TestNFSReIndexer.java
+++ b/src/test/java/org/ndexbio/server/migration/v3/TestNFSReIndexer.java
@@ -3,7 +3,13 @@ package org.ndexbio.server.migration.v3;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.ndexbio.common.NdexClasses;
 import org.ndexbio.common.models.dao.DAOFactory;
@@ -15,6 +21,10 @@ import org.ndexbio.common.solr.GlobalNetworkIndexManager;
 import org.ndexbio.common.solr.SolrObjectFactory;
 
 import static org.easymock.EasyMock.*;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 
 public class TestNFSReIndexer {
 
@@ -69,5 +79,176 @@ public class TestNFSReIndexer {
         org.junit.Assert.assertTrue(NFSReIndexer.REINDEX_COUNT_SQL.contains("error LIKE '" + prefix + "%'"));
         org.junit.Assert.assertTrue(NFSReIndexer.REINDEX_SELECT_SQL.contains("error IS NULL"));
         org.junit.Assert.assertTrue(NFSReIndexer.REINDEX_SELECT_SQL.contains("error LIKE '" + prefix + "%'"));
+    }
+
+    // ------------------------------------------------------------------------
+    // Failure policy: one network's failure must not stop the sweep, and must be
+    // reported at WARN with the reason. This reindexer emptied every per-network
+    // query core across the fleet while logging its failures at INFO, which is why
+    // a total failure looked like a normal run.
+    // ------------------------------------------------------------------------
+
+    /** NFSReIndexer names its logger with getSimpleName(), not the fully qualified class. */
+    private static final String REINDEXER_LOGGER = "NFSReIndexer";
+
+    private ch.qos.logback.classic.Logger reindexerLogger;
+    private ListAppender<ILoggingEvent> logged;
+
+    @Before
+    public void captureLogs() {
+        reindexerLogger = (ch.qos.logback.classic.Logger)
+                org.slf4j.LoggerFactory.getLogger(REINDEXER_LOGGER);
+        logged = new ListAppender<>();
+        logged.start();
+        reindexerLogger.addAppender(logged);
+    }
+
+    @After
+    public void releaseLogs() {
+        if (reindexerLogger != null) {
+            reindexerLogger.detachAppender(logged);
+        }
+        if (logged != null) {
+            logged.stop();
+        }
+    }
+
+    private List<ILoggingEvent> eventsStartingWith(String prefix) {
+        List<ILoggingEvent> matched = new ArrayList<>();
+        for (ILoggingEvent e : logged.list) {
+            if (e.getFormattedMessage().startsWith(prefix)) {
+                matched.add(e);
+            }
+        }
+        return matched;
+    }
+
+    /**
+     * Builds a reindexer whose select query yields the given network ids.
+     *
+     * @param failFor ids whose summary lookup throws, standing in for a network whose aspect
+     *                files cannot be read
+     */
+    private NFSReIndexer reIndexerOver(List<UUID> ids, Set<UUID> failFor,
+            NetworkDAO networkDAO) throws Exception {
+
+        Connection mockConn = createNiceMock(Connection.class);
+
+        PreparedStatement countPst = createNiceMock(PreparedStatement.class);
+        ResultSet countRs = createNiceMock(ResultSet.class);
+        expect(mockConn.prepareStatement(eq(NFSReIndexer.REINDEX_COUNT_SQL))).andReturn(countPst);
+        expect(countPst.executeQuery()).andReturn(countRs);
+        expect(countRs.next()).andReturn(true);
+        expect(countRs.getInt(1)).andReturn(ids.size());
+
+        PreparedStatement selectPst = createNiceMock(PreparedStatement.class);
+        ResultSet selectRs = createNiceMock(ResultSet.class);
+        expect(mockConn.prepareStatement(eq(NFSReIndexer.REINDEX_SELECT_SQL))).andReturn(selectPst);
+        expect(selectPst.executeQuery()).andReturn(selectRs);
+        for (UUID id : ids) {
+            expect(selectRs.next()).andReturn(true);
+            expect(selectRs.getObject(1)).andReturn(id);
+            expect(selectRs.getObject(2)).andReturn(UUID.randomUUID());
+            expect(selectRs.getString(3)).andReturn("owner");
+            expect(selectRs.getString(4)).andReturn("PUBLIC");
+        }
+        expect(selectRs.next()).andReturn(false);
+
+        SolrObjectFactory mockSolrFactory = createNiceMock(SolrObjectFactory.class);
+        GlobalNetworkIndexManager mockGlobalIdx = createNiceMock(GlobalNetworkIndexManager.class);
+        expect(mockSolrFactory.getGlobalNetworkIndexManager()).andReturn(mockGlobalIdx);
+
+        for (UUID id : ids) {
+            if (failFor.contains(id)) {
+                expect(networkDAO.getNetworkSummaryById(id))
+                        .andThrow(new RuntimeException(
+                                "CX2 aspect directory is not readable by user 'someoneelse'"));
+            } else {
+                // returning null makes rebuildNetworkIndex fail its own way; either path is a
+                // per-network failure, which is what this test is about
+                expect(networkDAO.getNetworkSummaryById(id)).andReturn(null);
+            }
+        }
+
+        DAOFactory mockDaoFactory = createNiceMock(DAOFactory.class);
+
+        replay(mockConn, countPst, countRs, selectPst, selectRs, mockSolrFactory, mockGlobalIdx,
+                mockDaoFactory, networkDAO);
+
+        return new NFSReIndexer(mockConn, mockSolrFactory, mockDaoFactory);
+    }
+
+    private static V3Migrator.DaoSet daoSetWith(NetworkDAO networkDAO) {
+        return new V3Migrator.DaoSet(createNiceMock(UserDAO.class), createNiceMock(FolderDAO.class),
+                createNiceMock(ShortcutDAO.class), networkDAO);
+    }
+
+    @Test
+    public void aFailingNetworkDoesNotStopTheSweep() throws Exception {
+        UUID first = UUID.randomUUID();
+        UUID failing = UUID.fromString("ec25aeeb-fb51-11ef-b81d-005056ae3c32");
+        UUID third = UUID.randomUUID();
+        List<UUID> ids = List.of(first, failing, third);
+
+        NetworkDAO networkDAO = createNiceMock(NetworkDAO.class);
+        NFSReIndexer reIndexer = reIndexerOver(ids, Set.of(failing), networkDAO);
+
+        // must not throw
+        reIndexer.reIndexNetworks(daoSetWith(networkDAO));
+
+        // every network was attempted, so the loop advanced past the failure
+        verify(networkDAO);
+
+        List<ILoggingEvent> failures = eventsStartingWith("Failed to reindex network");
+        org.junit.Assert.assertEquals("one failure line per failing network", 3, failures.size());
+
+        boolean sawUnreadable = false;
+        for (ILoggingEvent e : failures) {
+            org.junit.Assert.assertEquals("reindex failures must be WARN, not INFO",
+                    Level.WARN, e.getLevel());
+            org.junit.Assert.assertNotNull("the exception must be logged", e.getThrowableProxy());
+            if (e.getFormattedMessage().contains(failing.toString())) {
+                sawUnreadable = true;
+                org.junit.Assert.assertTrue("the reason must be in the message: "
+                        + e.getFormattedMessage(),
+                        e.getFormattedMessage().contains("not readable by user"));
+            }
+        }
+        org.junit.Assert.assertTrue("the failing network must be named in a WARN", sawUnreadable);
+    }
+
+    @Test
+    public void everyNetworkFailingStillCompletesTheSweep() throws Exception {
+        List<UUID> ids = List.of(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+
+        NetworkDAO networkDAO = createNiceMock(NetworkDAO.class);
+        NFSReIndexer reIndexer = reIndexerOver(ids, Set.copyOf(ids), networkDAO);
+
+        // This is the shape of the incident: every network fails. The run must still finish.
+        reIndexer.reIndexNetworks(daoSetWith(networkDAO));
+
+        verify(networkDAO);
+        org.junit.Assert.assertEquals("all three logged as failures",
+                3, eventsStartingWith("Failed to reindex network").size());
+        for (ILoggingEvent e : eventsStartingWith("Failed to reindex network")) {
+            org.junit.Assert.assertEquals(Level.WARN, e.getLevel());
+        }
+    }
+
+    @Test
+    public void noReindexFailureIsLoggedAtInfo() throws Exception {
+        List<UUID> ids = List.of(UUID.randomUUID());
+
+        NetworkDAO networkDAO = createNiceMock(NetworkDAO.class);
+        NFSReIndexer reIndexer = reIndexerOver(ids, Set.copyOf(ids), networkDAO);
+
+        reIndexer.reIndexNetworks(daoSetWith(networkDAO));
+
+        for (ILoggingEvent e : logged.list) {
+            if (e.getFormattedMessage().startsWith("Failed to reindex")) {
+                org.junit.Assert.assertNotEquals("failures logged at INFO are how this outage hid",
+                        Level.INFO, e.getLevel());
+            }
+        }
     }
 }


### PR DESCRIPTION
Reindexing was muffling errors that occurred during solr reindexing, so was not able to detect when reindexing was actually not working, as it just reports 0 reindexed counts per network, but nothing indicating that is a problem. Now it will log WARN statements per network that fails to correctly rebuild solr index for a given network.