### PR TITLE
search results include viz attribute for folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - network name from /v3/files/folders/{folderid}/list is now swagger doc'd as optional, further details in [ndex-object-model/55](https://github.com/ndexbio/ndex-object-model/pull/55). Resolves - [issue/161](https://github.com/ndexbio/ndex-rest/issues/161).
+- `POST /v3/search/files` now reports `visibility` on FOLDER results. The folder mapper never set it and `FileItemSummary` is `@JsonInclude(NON_NULL)`, so the key was dropped from the response entirely while NETWORK and SHORTCUT items carried it, leaving clients unable to distinguish a public folder from a private one. Resolves - [issue/162](https://github.com/ndexbio/ndex-rest/issues/162).
 
 
 ## [3.0.4] - 2026-07-31

--- a/docker/test/integration-test.sh
+++ b/docker/test/integration-test.sh
@@ -1634,6 +1634,95 @@ echo "  API call ${CALL_NUM}: search files visibility=PRIVATE (shortcut dropped 
 poll_files_until_absent "PRIVATE" "${VM_SHORTCUT_NAME}" "${VM_S_ID}" "shortcut post-move (old core)"
 api_pass "shortcut visibility PRIVATE→PUBLIC fully reindexed: present in public-nfs, absent from private-nfs (no orphan)"
 
+# ── STEP: issue #162 — searchFiles must report visibility on FOLDER results ───
+# NETWORK items in a /v3/search/files response carry "visibility"; FOLDER items omit the key
+# entirely, so clients cannot tell a public folder from a private one (ndexbio/ndex3#52). Cause:
+# NFSSearchProvider.mapFolderToSummary never calls setVisibility, and FileItemSummary is
+# @JsonInclude(NON_NULL), so the unset field is dropped rather than serialized as null. The
+# NETWORK mapper and the shortcut DAO both set it, making FOLDER the lone outlier.
+#
+# Both cores are covered (PUBLIC → public-nfs, PRIVATE → private-nfs) so the fix cannot be
+# satisfied by emitting a hardcoded constant.
+#
+# The folder names MUST stay unique and randomized. `visibility` on this endpoint selects the
+# Solr core, it is not a row filter: PUBLIC and UNLISTED both live in public-nfs, and the public
+# core's permission filter is "exclude UNLISTED OR userAdmin:<me>", so an authenticated owner
+# searching visibility=PUBLIC legitimately gets their own UNLISTED folders back — and TEST_USER
+# owns one by now (the vis-folder flipped to UNLISTED earlier). A broader searchString would
+# match those too and make the assertion below meaningless.
+step "searchFiles reports visibility on FOLDER results (issue #162)"
+
+F162_PUB_NAME="visfolder162pub${RANDOM}${RANDOM}"
+F162_PRIV_NAME="visfolder162priv${RANDOM}${RANDOM}"
+
+# --- PUBLIC folder: must report visibility=PUBLIC in search results ---
+CALL_NUM=$((CALL_NUM+1))
+echo "  API call ${CALL_NUM}: POST /v3/files/folders/ (create PUBLIC folder for issue #162)"
+F162_PUB_RESP=$(curl -s -w "\n%{http_code}" -X POST -u "${TEST_USER}:${TEST_PASS}" \
+  -H "Content-Type: application/json" \
+  -d "{\"name\":\"${F162_PUB_NAME}\",\"visibility\":\"PUBLIC\"}" \
+  "${BASE_URL}/v3/files/folders/")
+F162_PUB_HTTP=$(echo "${F162_PUB_RESP}" | tail -1); F162_PUB_CREATE_BODY=$(echo "${F162_PUB_RESP}" | head -1)
+[[ "${F162_PUB_HTTP}" == "201" ]] || api_fail "create issue-#162 PUBLIC folder → HTTP ${F162_PUB_HTTP}. Body: ${F162_PUB_CREATE_BODY:0:300}"
+F162_PUB_ID=$(echo "${F162_PUB_CREATE_BODY}" | grep -oiE '"uuid"[[:space:]]*:[[:space:]]*"[0-9a-f-]{36}"' | grep -oiE '[0-9a-f-]{36}' | head -1)
+[[ -n "${F162_PUB_ID}" ]] || api_fail "no uuid in issue-#162 PUBLIC folder create body. Body: ${F162_PUB_CREATE_BODY:0:300}"
+
+CALL_NUM=$((CALL_NUM+1))
+echo "  API call ${CALL_NUM}: search files visibility=PUBLIC (folder indexed in public-nfs)"
+poll_files_until_present "PUBLIC" "${F162_PUB_NAME}" "${F162_PUB_ID}" "issue #162 public folder"
+
+# No `type` in the request body — this mirrors the anonymous curl in the ticket, which went
+# through the untyped search path.
+CALL_NUM=$((CALL_NUM+1))
+echo "  API call ${CALL_NUM}: POST /v3/search/files?visibility=PUBLIC (FOLDER item must carry visibility)"
+F162_PUB_SEARCH=$(curl -s -w "\n%{http_code}" -X POST -u "${TEST_USER}:${TEST_PASS}" \
+  -H "Content-Type: application/json" -d "{\"searchString\":\"${F162_PUB_NAME}\"}" \
+  "${BASE_URL}/v3/search/files?visibility=PUBLIC&start=0&size=25")
+F162_PUB_SEARCH_HTTP=$(echo "${F162_PUB_SEARCH}" | tail -1); F162_PUB_BODY=$(echo "${F162_PUB_SEARCH}" | head -1)
+[[ "${F162_PUB_SEARCH_HTTP}" == "200" ]] || api_fail "search visibility=PUBLIC → HTTP ${F162_PUB_SEARCH_HTTP}. Body: ${F162_PUB_BODY:0:300}"
+# Sanity first, so a Solr miss or a stray network cannot masquerade as the visibility bug.
+echo "${F162_PUB_BODY}" | grep -q "${F162_PUB_ID}" \
+  || api_fail "issue #162: folder ${F162_PUB_ID} missing from its own search results. Body: ${F162_PUB_BODY:0:400}"
+echo "${F162_PUB_BODY}" | grep -qE '"type"[[:space:]]*:[[:space:]]*"FOLDER"' \
+  || api_fail "issue #162: no FOLDER item in results for ${F162_PUB_NAME}. Body: ${F162_PUB_BODY:0:400}"
+echo "${F162_PUB_BODY}" | grep -qE '"type"[[:space:]]*:[[:space:]]*"NETWORK"' \
+  && api_fail "issue #162: unexpected NETWORK item matched ${F162_PUB_NAME}; its visibility would mask the folder's. Body: ${F162_PUB_BODY:0:400}"
+echo "${F162_PUB_BODY}" | grep -qE '"visibility"[[:space:]]*:[[:space:]]*"PUBLIC"' \
+  || api_fail "REGRESSION (issue #162): FOLDER item in /v3/search/files results has no visibility field. Body: ${F162_PUB_BODY:0:600}"
+api_pass "search visibility=PUBLIC → FOLDER item reports visibility=PUBLIC"
+
+# --- PRIVATE folder: must report visibility=PRIVATE (not a hardcoded PUBLIC) ---
+CALL_NUM=$((CALL_NUM+1))
+echo "  API call ${CALL_NUM}: POST /v3/files/folders/ (create folder, default visibility=PRIVATE)"
+F162_PRIV_RESP=$(curl -s -w "\n%{http_code}" -X POST -u "${TEST_USER}:${TEST_PASS}" \
+  -H "Content-Type: application/json" -d "{\"name\":\"${F162_PRIV_NAME}\"}" \
+  "${BASE_URL}/v3/files/folders/")
+F162_PRIV_HTTP=$(echo "${F162_PRIV_RESP}" | tail -1); F162_PRIV_CREATE_BODY=$(echo "${F162_PRIV_RESP}" | head -1)
+[[ "${F162_PRIV_HTTP}" == "201" ]] || api_fail "create issue-#162 PRIVATE folder → HTTP ${F162_PRIV_HTTP}. Body: ${F162_PRIV_CREATE_BODY:0:300}"
+F162_PRIV_ID=$(echo "${F162_PRIV_CREATE_BODY}" | grep -oiE '"uuid"[[:space:]]*:[[:space:]]*"[0-9a-f-]{36}"' | grep -oiE '[0-9a-f-]{36}' | head -1)
+[[ -n "${F162_PRIV_ID}" ]] || api_fail "no uuid in issue-#162 PRIVATE folder create body. Body: ${F162_PRIV_CREATE_BODY:0:300}"
+
+CALL_NUM=$((CALL_NUM+1))
+echo "  API call ${CALL_NUM}: search files visibility=PRIVATE (folder indexed in private-nfs)"
+poll_files_until_present "PRIVATE" "${F162_PRIV_NAME}" "${F162_PRIV_ID}" "issue #162 private folder"
+
+CALL_NUM=$((CALL_NUM+1))
+echo "  API call ${CALL_NUM}: POST /v3/search/files?visibility=PRIVATE (FOLDER item must carry visibility)"
+F162_PRIV_SEARCH=$(curl -s -w "\n%{http_code}" -X POST -u "${TEST_USER}:${TEST_PASS}" \
+  -H "Content-Type: application/json" -d "{\"searchString\":\"${F162_PRIV_NAME}\"}" \
+  "${BASE_URL}/v3/search/files?visibility=PRIVATE&start=0&size=25")
+F162_PRIV_SEARCH_HTTP=$(echo "${F162_PRIV_SEARCH}" | tail -1); F162_PRIV_BODY=$(echo "${F162_PRIV_SEARCH}" | head -1)
+[[ "${F162_PRIV_SEARCH_HTTP}" == "200" ]] || api_fail "search visibility=PRIVATE → HTTP ${F162_PRIV_SEARCH_HTTP}. Body: ${F162_PRIV_BODY:0:300}"
+echo "${F162_PRIV_BODY}" | grep -q "${F162_PRIV_ID}" \
+  || api_fail "issue #162: folder ${F162_PRIV_ID} missing from its own search results. Body: ${F162_PRIV_BODY:0:400}"
+echo "${F162_PRIV_BODY}" | grep -qE '"type"[[:space:]]*:[[:space:]]*"FOLDER"' \
+  || api_fail "issue #162: no FOLDER item in results for ${F162_PRIV_NAME}. Body: ${F162_PRIV_BODY:0:400}"
+echo "${F162_PRIV_BODY}" | grep -qE '"type"[[:space:]]*:[[:space:]]*"NETWORK"' \
+  && api_fail "issue #162: unexpected NETWORK item matched ${F162_PRIV_NAME}; its visibility would mask the folder's. Body: ${F162_PRIV_BODY:0:400}"
+echo "${F162_PRIV_BODY}" | grep -qE '"visibility"[[:space:]]*:[[:space:]]*"PRIVATE"' \
+  || api_fail "REGRESSION (issue #162): PRIVATE FOLDER item in /v3/search/files results does not report visibility=PRIVATE. Body: ${F162_PRIV_BODY:0:600}"
+api_pass "search visibility=PRIVATE → FOLDER item reports visibility=PRIVATE"
+
 # ── STEP: /v2/networkset round-trip on the folder-backed compatibility layer ──
 # The network set feature is retired as storage but preserved as an API: a network set id IS a folder
 # id, and every /v2/networkset endpoint performs folder/shortcut operations internally. So this step

--- a/src/main/java/org/ndexbio/common/models/search/NFSSearchProvider.java
+++ b/src/main/java/org/ndexbio/common/models/search/NFSSearchProvider.java
@@ -11,8 +11,6 @@ import org.ndexbio.common.solr.GlobalNetworkIndexManager;
 import org.ndexbio.common.solr.NFSIndexManager;
 import org.ndexbio.common.solr.SolrClientWrapper;
 import org.ndexbio.model.exceptions.NdexException;
-import org.ndexbio.model.exceptions.ObjectNotFoundException;
-import org.ndexbio.model.exceptions.UnauthorizedOperationException;
 import org.ndexbio.model.object.*;
 import org.ndexbio.model.object.network.NetworkSummary;
 import org.ndexbio.model.object.network.VisibilityType;
@@ -20,8 +18,6 @@ import org.ndexbio.rest.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.sql.SQLException;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -119,25 +115,6 @@ public class NFSSearchProvider implements SearchProvider {
         return result;
     }
 
-    private FileItemSummary mapShortcutToSummary(NdexShortcut ndexShortcut) {
-        FileItemSummary fis = new FileItemSummary();
-        fis.setUuid(ndexShortcut.getExternalId());
-        fis.setType(FileType.SHORTCUT);
-        fis.setName(ndexShortcut.getName());
-        fis.setModificationTime(ndexShortcut.getModificationTime());
-
-        Map<String, Object> attr = new HashMap<>();
-        attr.put("parent", ndexShortcut.getParent());
-        attr.put("target", ndexShortcut.getTarget());
-        attr.put("target_type", ndexShortcut.getTargetType() != null ? ndexShortcut.getTargetType().toString() : null);
-        attr.put("creationTime", ndexShortcut.getCreationTime());
-        fis.setAttributes(attr);
-
-        fis.setOwner(ndexShortcut.getOwner());
-        fis.setOwnerId(UUID.fromString(ndexShortcut.getOwner_id()));
-
-        return fis;
-    }
     private FileItemSummary mapFolderToSummary(NdexFolder ndexFolder) {
         FileItemSummary fis = new FileItemSummary();
         fis.setUuid(ndexFolder.getExternalId());
@@ -153,6 +130,7 @@ public class NFSSearchProvider implements SearchProvider {
 
         fis.setOwner(ndexFolder.getOwner());
         fis.setOwnerId(UUID.fromString(ndexFolder.getOwner_id()));
+        fis.setVisibility(ndexFolder.getVisibility() != null ? ndexFolder.getVisibility().toString() : null);
 
         return fis;
     }
@@ -192,17 +170,6 @@ public class NFSSearchProvider implements SearchProvider {
 
         return fis;
     }
-    private FileItemSummary mapSolrDocumentToSummary(SolrDocument solrDocument){
-        String uuid = (String)solrDocument.get(NFSIndexManager.UUID);
-
-        String entityType = (String)solrDocument.get(NFSIndexManager.ENTITY_TYPE);
-
-        FileType fileType = FileType.valueOf(entityType);
-
-        String name = (String)solrDocument.getOrDefault(NFSIndexManager.NAME, "unknown");
-
-        return new FileItemSummary(UUID.fromString(uuid), fileType, name);
-    }
     private List<UUID> getUUIDsFromDocuments(SolrDocumentList solrDocuments){
         return solrDocuments.stream()
                 .map(this::getUUIDFromDocument)
@@ -211,24 +178,6 @@ public class NFSSearchProvider implements SearchProvider {
     private UUID getUUIDFromDocument(SolrDocument solrDocument){
         String uuid = (String)solrDocument.get(NFSIndexManager.UUID);
         return UUID.fromString(uuid);
-    }
-
-    private void addTargetTypeToShortcutSummaryItem(FileItemSummary fileItemSummary, ShortcutDAO shortcutDAO,
-                                                    User accesser){
-        NdexShortcut ndexShortcut;
-        try {
-            ndexShortcut = shortcutDAO.getShortcut(fileItemSummary.getUuid(), accesser.getExternalId());
-        } catch (SQLException | ObjectNotFoundException | UnauthorizedOperationException | IOException e) {
-            ndexShortcut = null;
-        }
-        Map<String, Object> attributes = new HashMap<>();
-        if (ndexShortcut != null){
-            attributes.put(NFSIndexManager.TARGET_TYPE, ndexShortcut.getTargetType());
-        }
-        else attributes.put(NFSIndexManager.TARGET_TYPE, "unknown");
-
-        fileItemSummary.setAttributes(attributes);
-
     }
 
         @Override

--- a/src/test/java/org/ndexbio/common/models/search/TestNFSSearchProvider.java
+++ b/src/test/java/org/ndexbio/common/models/search/TestNFSSearchProvider.java
@@ -8,20 +8,28 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.ndexbio.common.solr.SolrClientWrapper;
+import org.ndexbio.model.object.FileItemSummary;
 import org.ndexbio.model.object.FileSearchResult;
+import org.ndexbio.model.object.NdexFolder;
 import org.ndexbio.model.object.SimpleFileQuery;
 import org.ndexbio.model.object.network.VisibilityType;
 import org.ndexbio.rest.Configuration;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.sql.Timestamp;
+import java.util.UUID;
 
 import static org.easymock.EasyMock.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
- * Unit tests for NFSSearchProvider's Solr query configuration.
+ * Unit tests for NFSSearchProvider's Solr query configuration and result mapping.
  * Verifies the edgeless-network demotion boost (issue #116) is applied to the
- * unified file-search path via the mocked SolrClientWrapper. No live Solr required.
+ * unified file-search path via the mocked SolrClientWrapper, and that each
+ * per-type mapper populates the fields the FileItemSummary contract promises
+ * (issue #162). No live Solr required.
  */
 public class TestNFSSearchProvider {
 
@@ -119,5 +127,62 @@ public class TestNFSSearchProvider {
 
         verify(mockWrapper);
         assertEquals(50L, result.getStart());
+    }
+
+    // ── Issue #162: FOLDER search results must carry visibility ──────────────
+    // searchFiles hydrates Solr hits from Postgres and maps them per type. The
+    // NETWORK mapper sets visibility (mapNetworkToSummary) and the SHORTCUT path
+    // sets it in PostgresShortcutDAO, but mapFolderToSummary omits it — and since
+    // FileItemSummary is @JsonInclude(NON_NULL), the key disappears from the JSON
+    // entirely rather than serializing as null. These tests exercise the mapper
+    // directly: the tests above deliberately use empty Solr result sets so DAO
+    // hydration never runs, because hydration needs a live DAOFactory, so there is
+    // no way to reach the mapper through searchFiles here. Reflection is used
+    // rather than widening the mapper's visibility (this class already reflects on
+    // Configuration.INSTANCE above).
+
+    private static FileItemSummary mapFolder(NdexFolder folder) throws Exception {
+        NFSSearchProvider provider = new NFSSearchProvider(createMock(SolrClientWrapper.class), 100);
+        Method mapper = NFSSearchProvider.class.getDeclaredMethod("mapFolderToSummary", NdexFolder.class);
+        mapper.setAccessible(true);
+        return (FileItemSummary) mapper.invoke(provider, folder);
+    }
+
+    /** owner_id must be a parseable UUID string: the mapper calls UUID.fromString on it unguarded. */
+    private static NdexFolder folderFixture(VisibilityType visibility) {
+        NdexFolder folder = new NdexFolder();
+        folder.setExternalId(UUID.randomUUID());
+        folder.setName("NCI PID");
+        folder.setDescription("curated collection");
+        folder.setOwner("nci-pid");
+        folder.setOwner_id(UUID.randomUUID().toString());
+        folder.setCreationTime(new Timestamp(1_500_000_000_000L));
+        folder.setModificationTime(new Timestamp(1_600_000_000_000L));
+        folder.setVisibility(visibility);
+        return folder;
+    }
+
+    @Test
+    public void testMapFolderToSummary_ReportsPublicVisibility() throws Exception {
+        FileItemSummary summary = mapFolder(folderFixture(VisibilityType.PUBLIC));
+
+        assertEquals("PUBLIC", summary.getVisibility());
+    }
+
+    @Test
+    public void testMapFolderToSummary_ReportsPrivateVisibility() throws Exception {
+        // Pins that the value comes from the folder row rather than a hardcoded constant.
+        FileItemSummary summary = mapFolder(folderFixture(VisibilityType.PRIVATE));
+
+        assertEquals("PRIVATE", summary.getVisibility());
+    }
+
+    @Test
+    public void testMapFolderToSummary_ToleratesNullVisibility() throws Exception {
+        // Legacy rows can have a null visibility column; mapNetworkToSummary already
+        // guards for this, so the folder mapper must not NPE either.
+        FileItemSummary summary = mapFolder(folderFixture(null));
+
+        assertNull(summary.getVisibility());
     }
 }


### PR DESCRIPTION
fixes serarch results to include visibility attribute when object type is network.

Closes #162 